### PR TITLE
Give the model installer a stall-tolerant download session

### DIFF
--- a/Sources/TurboFieldfareRepack/Core/Remote/SupportedModelSource.swift
+++ b/Sources/TurboFieldfareRepack/Core/Remote/SupportedModelSource.swift
@@ -19,6 +19,19 @@ public enum SupportedModelSource {
             outputDir: outputDirectory.path,
             overwrite: overwrite,
             token: token,
-            retainPartialOnFailure: retainPartialOnFailure)
+            retainPartialOnFailure: retainPartialOnFailure,
+            session: Self.downloadSession)
     }
+
+    /// URLSession.shared applies a 60 s per-request timeout that resets only
+    /// when data arrives; a single stalled byte-range on the Hugging Face CDN
+    /// (observed twice at ~3.3 GB into the first shard) then aborts the whole
+    /// ~14.6 GB install. Allow 5 minutes of silence per range request; the
+    /// retry policy still bounds genuinely dead connections.
+    private static let downloadSession: URLSession = {
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 300
+        config.timeoutIntervalForResource = 7 * 24 * 3600
+        return URLSession(configuration: config)
+    }()
 }


### PR DESCRIPTION
## Problem

`URLSession.shared` applies a 60 s per-request timeout that resets only when data arrives. A single stalled byte-range on the Hugging Face CDN aborts the whole ~15 GB install with `NSURLErrorTimedOut` (-1001). Observed twice at ~3.3 GB into the first shard while the network itself was healthy (parallel `curl` pulled the same range at 3.4 MB/s).

## Fix

`SupportedModelSource.installOptions` now passes a dedicated `URLSession` with:

- `timeoutIntervalForRequest = 300` — tolerate 5 minutes of silence per range request instead of 60 s
- `timeoutIntervalForResource = 7 days` — the resource timeout must not bound a ~15 GB multi-hour install on slow connections

Genuinely dead connections are still bounded by the existing `RemoteRetry` policy (4 attempts, 1–16 s backoff).

One-file change, 14 insertions. No behavior change for healthy downloads.