### PR TITLE
Add OpenAI- and Anthropic-compatible HTTP API server

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "fcd8c6c7b3bdc1b2987889f5525974610779e7fe094361a13b5cd2b27afa046b",
+  "originHash" : "3026e6d71a094289ae0e2c1d83c25e285f1976b53bdbfe53c5cdd06f9e7d6e0c",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,24 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "hummingbird",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/hummingbird-project/hummingbird.git",
+      "state" : {
+        "revision" : "277e5db5b6d348270088e6ee8e8fa2539bae603d",
+        "version" : "2.23.0"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
       }
     },
     {
@@ -20,12 +47,30 @@
       }
     },
     {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "89fbc3714264cce8db8e4ec51b64e01c3e28c6c5",
+        "version" : "1.19.3"
       }
     },
     {
@@ -38,12 +83,48 @@
       }
     },
     {
+      "identity" : "swift-configuration",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-configuration.git",
+      "state" : {
+        "revision" : "be76c4ad929eb6c4bcaf3351799f2adf9e6848a9",
+        "version" : "1.2.0"
+      }
+    },
+    {
       "identity" : "swift-crypto",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
         "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
         "version" : "4.5.0"
+      }
+    },
+    {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
       }
     },
     {
@@ -65,12 +146,93 @@
       }
     },
     {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    },
+    {
+      "identity" : "swift-metrics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-metrics.git",
+      "state" : {
+        "revision" : "087e8074afa97040c3b870c8664fe5482fb87cc4",
+        "version" : "2.11.0"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
         "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
         "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -13,9 +13,11 @@ let package = Package(
         .executable(name: "TurboFieldfareCLI", targets: ["TurboFieldfareCLI"]),
         .executable(name: "TurboFieldfareMac", targets: ["TurboFieldfareMac"]),
         .executable(name: "TurboFieldfareDecodeService", targets: ["TurboFieldfareDecodeService"]),
+        .executable(name: "TurboFieldfareServer", targets: ["TurboFieldfareServer"]),
     ],
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0"),
     ],
     targets: [
         .target(
@@ -79,6 +81,19 @@ let package = Package(
             ]
         ),
         .target(
+            name: "TurboFieldfareServerCore",
+            dependencies: [
+                "TurboFieldfare",
+                .product(name: "Hummingbird", package: "hummingbird"),
+            ],
+            path: "Sources/TurboFieldfareServer/Core"
+        ),
+        .executableTarget(
+            name: "TurboFieldfareServer",
+            dependencies: ["TurboFieldfareServerCore"],
+            path: "Sources/TurboFieldfareServer/Command"
+        ),
+        .target(
             name: "TurboFieldfareValidationSupport",
             dependencies: ["TurboFieldfare"],
             path: "Sources/TurboFieldfareValidation/Support"
@@ -102,6 +117,14 @@ let package = Package(
             name: "TurboFieldfareMacPresentationTests",
             dependencies: ["TurboFieldfareMacPresentation"],
             path: "Tests/TurboFieldfareApp/MacPresentation"
+        ),
+        .testTarget(
+            name: "TurboFieldfareServerTests",
+            dependencies: [
+                "TurboFieldfareServerCore",
+                .product(name: "HummingbirdTesting", package: "hummingbird"),
+            ],
+            path: "Tests/TurboFieldfareServer"
         ),
     ]
 )

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ TurboFieldfare provides a native Mac app and a command-line interface. Both
 use the same `.gturbo` model directory. Start with the Mac app; use the CLI for
 scripts, reproducible runs, and direct control over generation settings.
 
-The Swift package exposes five products:
+The Swift package exposes six products:
 
 | Product | Purpose |
 | --- | --- |
@@ -92,6 +92,7 @@ The Swift package exposes five products:
 | `TurboFieldfareDecodeService` | One-shot local model and Metal owner used by the Mac app |
 | `TurboFieldfareCLI` | Command-line instruction chat and raw completion |
 | `TurboFieldfareRepack` | Streaming model installer and install verifier |
+| `TurboFieldfareServer` | LM Studio-style OpenAI-compatible HTTP API server |
 
 ### Requirements
 
@@ -230,6 +231,41 @@ swift run -c release TurboFieldfareCLI --help
 
 Generated text goes to standard output. Timing statistics go to standard error;
 add `--quiet` to suppress that footer in scripts.
+
+### API server
+
+`TurboFieldfareServer` serves an LM Studio-style OpenAI-compatible HTTP API
+over an existing `.gturbo` installation. The model loads once at startup,
+before the port binds; a listening socket always means ready.
+
+```bash
+swift run -c release TurboFieldfareServer \
+  --model scratch/gemma4.gturbo \
+  --port 1234
+```
+
+Endpoints:
+
+| Endpoint | Purpose |
+| --- | --- |
+| `GET /health` | Liveness check |
+| `GET /v1/models` | OpenAI model list with the served model id |
+| `POST /v1/chat/completions` | Chat completion; `stream: true` returns SSE chunks |
+| `POST /v1/completions` | Raw completion without chat formatting |
+
+Point any OpenAI client at `http://127.0.0.1:1234/v1`. Supported request
+fields: `messages`/`prompt`, `temperature`, `top_p`, `max_tokens` (or
+`max_completion_tokens`), `stop`, `seed`, `stream`, and
+`stream_options.include_usage`. Roles are `system`, `user`, and `assistant`;
+tool calling and `n > 1` are rejected. Generation defaults match the CLI
+(temperature `0.2`, Top-P `0.95`, Top-K `64`).
+
+One generation runs at a time — the runtime's single-in-flight contract.
+Concurrent requests queue FIFO and are served in arrival order. Disconnecting
+a streaming client cancels its decode.
+
+Useful flags: `--host` (default `127.0.0.1`), `--port` (default `1234`),
+`--max-context`, `--model-id` (reported by `/v1/models`), `--quiet`.
 
 ## Test and contribute
 

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ Point any OpenAI client at `http://127.0.0.1:1234/v1`. Supported request
 fields: `messages`/`prompt`, `temperature`, `top_p`, `max_tokens` (or
 `max_completion_tokens`), `stop`, `seed`, `stream`, and
 `stream_options.include_usage`. Roles are `system`, `user`, and `assistant`;
-tool calling and `n > 1` are rejected. Generation defaults match the CLI
+tool calling, `response_format`, and any `n` other than `1` are rejected. Generation defaults match the CLI
 (temperature `0.2`, Top-P `0.95`, Top-K `64`).
 
 `POST /v1/messages` speaks the Anthropic Messages API on the same port.
@@ -273,6 +273,11 @@ with a 400. Streaming emits the standard `message_start` →
 One generation runs at a time — the runtime's single-in-flight contract.
 Concurrent requests queue FIFO and are served in arrival order. Disconnecting
 a streaming client cancels its decode.
+
+The server has no authentication and no rate limiting. It binds to
+`127.0.0.1` by default and is meant for local use. Binding it to a routable
+address exposes unauthenticated inference to the network; put it behind an
+authenticating reverse proxy if you need remote access.
 
 Useful flags: `--host` (default `127.0.0.1`), `--port` (default `1234`),
 `--max-context`, `--model-id` (reported by `/v1/models`), `--quiet`.

--- a/README.md
+++ b/README.md
@@ -252,6 +252,7 @@ Endpoints:
 | `GET /v1/models` | OpenAI model list with the served model id |
 | `POST /v1/chat/completions` | Chat completion; `stream: true` returns SSE chunks |
 | `POST /v1/completions` | Raw completion without chat formatting |
+| `POST /v1/messages` | Anthropic Messages API; `stream: true` returns Anthropic SSE events |
 
 Point any OpenAI client at `http://127.0.0.1:1234/v1`. Supported request
 fields: `messages`/`prompt`, `temperature`, `top_p`, `max_tokens` (or
@@ -259,6 +260,15 @@ fields: `messages`/`prompt`, `temperature`, `top_p`, `max_tokens` (or
 `stream_options.include_usage`. Roles are `system`, `user`, and `assistant`;
 tool calling and `n > 1` are rejected. Generation defaults match the CLI
 (temperature `0.2`, Top-P `0.95`, Top-K `64`).
+
+`POST /v1/messages` speaks the Anthropic Messages API on the same port.
+`max_tokens` is required, message roles are limited to `user` and
+`assistant`, and `system` (a string or text blocks) becomes a leading system
+message. Supported fields: `model` (echoed only), `messages`, `system`,
+`max_tokens`, `temperature`, `top_p`, `stop_sequences`, and `stream`.
+`tools`, `tool_choice`, `thinking`, `metadata`, and `n > 1` are rejected
+with a 400. Streaming emits the standard `message_start` →
+`content_block_*` → `message_delta` → `message_stop` event sequence.
 
 One generation runs at a time — the runtime's single-in-flight contract.
 Concurrent requests queue FIFO and are served in arrival order. Disconnecting

--- a/Sources/TurboFieldfareServer/Command/main.swift
+++ b/Sources/TurboFieldfareServer/Command/main.swift
@@ -1,0 +1,29 @@
+import Foundation
+import TurboFieldfareServerCore
+
+private func printError(_ message: String) {
+    FileHandle.standardError.write(Data((message + "\n").utf8))
+}
+
+private func run(_ values: [String]) async -> Int32 {
+    let args: ServerArgs
+    do {
+        args = try ServerArgs.parse(Array(values.dropFirst()))
+    } catch ServerArgsError.helpRequested {
+        print(ServerArgs.usage)
+        return 0
+    } catch {
+        printError("error: \(error)\n\n\(ServerArgs.usage)")
+        return 2
+    }
+
+    do {
+        try await runServer(args: args)
+        return 0
+    } catch {
+        printError("error: \(error)")
+        return 1
+    }
+}
+
+exit(await run(CommandLine.arguments))

--- a/Sources/TurboFieldfareServer/Core/AnthropicTypes.swift
+++ b/Sources/TurboFieldfareServer/Core/AnthropicTypes.swift
@@ -1,0 +1,342 @@
+import Foundation
+
+/// Anthropic Messages API wire types. Unknown request fields are ignored by
+/// the default `Decodable` synthesis, matching the tolerance of the OpenAI
+/// surface; fields we explicitly do not support (tools, thinking, ...) are
+/// detected by key presence and rejected in the route layer.
+
+public struct AnthropicTextBlock: Codable, Sendable, Equatable {
+    public var type: String
+    public var text: String
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case text
+    }
+
+    public init(text: String) {
+        self.type = "text"
+        self.text = text
+    }
+
+    /// Request-side decoding accepts only `text` blocks; anything else
+    /// (image, tool_use, ...) fails the request decode and surfaces as a 400.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        let type = try container.decode(String.self, forKey: .type)
+        guard type == "text" else {
+            throw DecodingError.dataCorruptedError(
+                forKey: .type,
+                in: container,
+                debugDescription: "only text content blocks are supported")
+        }
+        self.type = type
+        self.text = try container.decode(String.self, forKey: .text)
+    }
+}
+
+/// Anthropic `content`/`system` accept either a plain string or an array of
+/// text blocks; both collapse to a single string for the chat template.
+public enum AnthropicContent: Decodable, Sendable, Equatable {
+    case text(String)
+    case blocks([AnthropicTextBlock])
+
+    public var text: String {
+        switch self {
+        case .text(let value): return value
+        case .blocks(let blocks): return blocks.map(\.text).joined()
+        }
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(String.self) {
+            self = .text(value)
+        } else if let blocks = try? container.decode([AnthropicTextBlock].self) {
+            self = .blocks(blocks)
+        } else {
+            throw DecodingError.typeMismatch(
+                AnthropicContent.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "content must be a string or an array of text blocks"))
+        }
+    }
+}
+
+public struct AnthropicMessage: Decodable, Sendable {
+    public var role: String
+    public var content: AnthropicContent
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        role = try container.decode(String.self, forKey: .role)
+        content = try container.decodeIfPresent(AnthropicContent.self, forKey: .content) ?? .text("")
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case role
+        case content
+    }
+}
+
+public struct AnthropicMessagesRequest: Decodable, Sendable {
+    public var model: String?
+    public var maxTokens: Int?
+    public var messages: [AnthropicMessage]
+    public var system: AnthropicContent?
+    public var temperature: Float?
+    public var topP: Float?
+    public var stopSequences: [String]?
+    public var stream: Bool?
+    public var n: Int?
+    /// Key-presence markers for parameters we reject rather than ignore.
+    public var hasTools: Bool
+    public var hasToolChoice: Bool
+    public var hasThinking: Bool
+    public var hasMetadata: Bool
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case system
+        case temperature
+        case stream
+        case n
+        case maxTokens = "max_tokens"
+        case topP = "top_p"
+        case stopSequences = "stop_sequences"
+        case tools
+        case toolChoice = "tool_choice"
+        case thinking
+        case metadata
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        model = try container.decodeIfPresent(String.self, forKey: .model)
+        maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens)
+        messages = try container.decodeIfPresent([AnthropicMessage].self, forKey: .messages) ?? []
+        system = try container.decodeIfPresent(AnthropicContent.self, forKey: .system)
+        temperature = try container.decodeIfPresent(Float.self, forKey: .temperature)
+        topP = try container.decodeIfPresent(Float.self, forKey: .topP)
+        stopSequences = try container.decodeIfPresent([String].self, forKey: .stopSequences)
+        stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
+        n = try container.decodeIfPresent(Int.self, forKey: .n)
+        hasTools = container.contains(.tools)
+        hasToolChoice = container.contains(.toolChoice)
+        hasThinking = container.contains(.thinking)
+        hasMetadata = container.contains(.metadata)
+    }
+}
+
+public struct AnthropicUsage: Encodable, Sendable {
+    public var inputTokens: Int
+    public var outputTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case inputTokens = "input_tokens"
+        case outputTokens = "output_tokens"
+    }
+
+    public init(inputTokens: Int, outputTokens: Int) {
+        self.inputTokens = inputTokens
+        self.outputTokens = outputTokens
+    }
+}
+
+/// Non-streaming response, also embedded (with empty content) in the
+/// streaming `message_start` event.
+public struct AnthropicMessageResponse: Encodable, Sendable {
+    public var id: String
+    public var type: String
+    public var role: String
+    public var content: [AnthropicTextBlock]
+    public var model: String
+    public var stopReason: String?
+    public var stopSequence: String?
+    public var usage: AnthropicUsage
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case type
+        case role
+        case content
+        case model
+        case stopReason = "stop_reason"
+        case stopSequence = "stop_sequence"
+        case usage
+    }
+
+    public init(id: String,
+                model: String,
+                content: [AnthropicTextBlock],
+                stopReason: String?,
+                usage: AnthropicUsage) {
+        self.id = id
+        self.type = "message"
+        self.role = "assistant"
+        self.content = content
+        self.model = model
+        self.stopReason = stopReason
+        self.stopSequence = nil
+        self.usage = usage
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(type, forKey: .type)
+        try container.encode(role, forKey: .role)
+        try container.encode(content, forKey: .content)
+        try container.encode(model, forKey: .model)
+        // Anthropic emits explicit nulls while the turn is in flight; mirror.
+        try container.encode(stopReason, forKey: .stopReason)
+        try container.encode(stopSequence, forKey: .stopSequence)
+        try container.encode(usage, forKey: .usage)
+    }
+}
+
+public struct AnthropicMessageStart: Encodable, Sendable {
+    public var type: String
+    public var message: AnthropicMessageResponse
+
+    public init(message: AnthropicMessageResponse) {
+        self.type = "message_start"
+        self.message = message
+    }
+}
+
+public struct AnthropicContentBlockStart: Encodable, Sendable {
+    public var type: String
+    public var index: Int
+    public var contentBlock: AnthropicTextBlock
+
+    enum CodingKeys: String, CodingKey {
+        case type
+        case index
+        case contentBlock = "content_block"
+    }
+
+    public init(index: Int, contentBlock: AnthropicTextBlock) {
+        self.type = "content_block_start"
+        self.index = index
+        self.contentBlock = contentBlock
+    }
+}
+
+public struct AnthropicTextDelta: Encodable, Sendable {
+    public var type: String
+    public var text: String
+
+    public init(text: String) {
+        self.type = "text_delta"
+        self.text = text
+    }
+}
+
+public struct AnthropicContentBlockDelta: Encodable, Sendable {
+    public var type: String
+    public var index: Int
+    public var delta: AnthropicTextDelta
+
+    public init(index: Int, delta: AnthropicTextDelta) {
+        self.type = "content_block_delta"
+        self.index = index
+        self.delta = delta
+    }
+}
+
+public struct AnthropicContentBlockStop: Encodable, Sendable {
+    public var type: String
+    public var index: Int
+
+    public init(index: Int) {
+        self.type = "content_block_stop"
+        self.index = index
+    }
+}
+
+public struct AnthropicMessageDeltaBody: Encodable, Sendable {
+    public var stopReason: String?
+    public var stopSequence: String?
+
+    enum CodingKeys: String, CodingKey {
+        case stopReason = "stop_reason"
+        case stopSequence = "stop_sequence"
+    }
+
+    public init(stopReason: String?, stopSequence: String? = nil) {
+        self.stopReason = stopReason
+        self.stopSequence = stopSequence
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(stopReason, forKey: .stopReason)
+        try container.encode(stopSequence, forKey: .stopSequence)
+    }
+}
+
+public struct AnthropicOutputUsage: Encodable, Sendable {
+    public var outputTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case outputTokens = "output_tokens"
+    }
+
+    public init(outputTokens: Int) {
+        self.outputTokens = outputTokens
+    }
+}
+
+public struct AnthropicMessageDelta: Encodable, Sendable {
+    public var type: String
+    public var delta: AnthropicMessageDeltaBody
+    public var usage: AnthropicOutputUsage
+
+    public init(delta: AnthropicMessageDeltaBody, usage: AnthropicOutputUsage) {
+        self.type = "message_delta"
+        self.delta = delta
+        self.usage = usage
+    }
+}
+
+public struct AnthropicMessageStop: Encodable, Sendable {
+    public var type: String
+
+    public init() {
+        self.type = "message_stop"
+    }
+}
+
+public struct AnthropicErrorBody: Encodable, Sendable {
+    public var type: String
+    public var message: String
+
+    public init(type: String, message: String) {
+        self.type = type
+        self.message = message
+    }
+}
+
+public struct AnthropicErrorResponse: Encodable, Sendable {
+    public var type: String
+    public var error: AnthropicErrorBody
+
+    public init(type: String = "invalid_request_error", message: String) {
+        self.type = "error"
+        self.error = AnthropicErrorBody(type: type, message: message)
+    }
+}
+
+extension FinishReason {
+    /// Anthropic stop reasons: OpenAI `stop` maps to `end_turn`, `length` to
+    /// `max_tokens`.
+    public var anthropicStopReason: String {
+        switch self {
+        case .stop: return "end_turn"
+        case .length: return "max_tokens"
+        }
+    }
+}

--- a/Sources/TurboFieldfareServer/Core/Generation.swift
+++ b/Sources/TurboFieldfareServer/Core/Generation.swift
@@ -1,0 +1,301 @@
+import Foundation
+
+/// OpenAI-facing finish reasons; mapped from the runtime's `StopReason`.
+public enum FinishReason: String, Sendable, Equatable {
+    case stop
+    case length
+}
+
+/// Per-request sampling knobs after defaults are applied. Defaults mirror the
+/// README/CLI: temperature 0.2, topP 0.95 (topK is a runtime constant, not an
+/// OpenAI field).
+public struct SamplingParams: Sendable, Equatable {
+    public var maxTokens: Int?
+    public var temperature: Float
+    public var topP: Float
+    public var seed: UInt64?
+    public var stop: [String]
+
+    public init(maxTokens: Int? = nil,
+                temperature: Float = 0.2,
+                topP: Float = 0.95,
+                seed: UInt64? = nil,
+                stop: [String] = []) {
+        self.maxTokens = maxTokens
+        self.temperature = temperature
+        self.topP = topP
+        self.seed = seed
+        self.stop = stop
+    }
+
+    public init(maxTokens: Int?,
+                temperature: Float?,
+                topP: Float?,
+                seed: Int?,
+                stop: StopValue?) {
+        self.init(maxTokens: maxTokens,
+                  temperature: temperature ?? 0.2,
+                  topP: topP ?? 0.95,
+                  seed: seed.map { UInt64(bitPattern: Int64($0)) },
+                  stop: stop?.values ?? [])
+    }
+}
+
+/// Final, Metal-free result of one generation.
+public struct GenerationOutcome: Sendable, Equatable {
+    public var text: String
+    public var promptTokens: Int
+    public var completionTokens: Int
+    public var finishReason: FinishReason
+
+    public init(text: String, promptTokens: Int, completionTokens: Int, finishReason: FinishReason) {
+        self.text = text
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+        self.finishReason = finishReason
+    }
+
+    public var usage: Usage {
+        Usage(promptTokens: promptTokens, completionTokens: completionTokens)
+    }
+}
+
+/// A validated, encode-ready prompt source.
+public enum GenerationInput: Sendable, Equatable {
+    /// Chat messages with roles already restricted to system/user/assistant;
+    /// the tokenizer's chat template renders `assistant` as `model`.
+    case chat([ChatMessage])
+    /// Raw completion prompt; encoded verbatim with BOS.
+    case raw(String)
+}
+
+/// One generation that passed validation and is ready to run.
+public struct PreparedGeneration: Sendable, Equatable {
+    public var input: GenerationInput
+    public var sampling: SamplingParams
+    public var effectiveMaxTokens: Int
+    public var promptTokens: Int
+
+    public init(input: GenerationInput,
+                sampling: SamplingParams,
+                effectiveMaxTokens: Int,
+                promptTokens: Int) {
+        self.input = input
+        self.sampling = sampling
+        self.effectiveMaxTokens = effectiveMaxTokens
+        self.promptTokens = promptTokens
+    }
+}
+
+/// Errors surfaced to the HTTP layer as OpenAI-style 400s.
+public enum GenerationRequestError: Error, Equatable, CustomStringConvertible {
+    case emptyMessages
+    case emptyPrompt
+    case unsupportedRole(String)
+    case unsupportedParameter(String)
+    case contextOverflow(prompt: Int, maxTokens: Int, maxContext: Int)
+
+    public var description: String {
+        switch self {
+        case .emptyMessages:
+            return "messages must contain at least one message"
+        case .emptyPrompt:
+            return "prompt produced no tokens"
+        case .unsupportedRole(let role):
+            return "unsupported role '\(role)'; supported roles are system, user, assistant"
+        case .unsupportedParameter(let detail):
+            return detail
+        case .contextOverflow(let prompt, let maxTokens, let maxContext):
+            return "context overflow: prompt (\(prompt) tokens) + max_tokens (\(maxTokens)) exceeds max context (\(maxContext))"
+        }
+    }
+}
+
+/// Seam between the HTTP-facing session and the runtime. The real
+/// implementation wraps `runRawCompletion`; tests substitute a fake that
+/// emits canned tokens. Kept free of Metal/runtime types so the whole
+/// route/SSE stack is testable without a GPU.
+public protocol TokenGenerating: Sendable {
+    /// Token count the input encodes to (BOS included where applicable).
+    func tokenCount(for input: GenerationInput) throws -> Int
+    /// Run one generation. `onDelta` fires per streamed text piece; the
+    /// returned outcome carries the full text and stop metadata.
+    func generate(_ input: GenerationInput,
+                  sampling: SamplingParams,
+                  effectiveMaxTokens: Int,
+                  onDelta: (@Sendable (String) -> Void)?) async throws -> GenerationOutcome
+}
+
+/// Owns the single-in-flight runtime. All generation funnels through this
+/// actor, so requests execute serially in FIFO order — the contract the
+/// underlying `RawCompletionScratch` requires.
+public actor GenerationSession {
+    public let modelID: String
+    public let maxContext: Int
+    /// Unix timestamp reported in `/v1/models`.
+    public let created: Int
+    private let generator: any TokenGenerating
+
+    public init(modelID: String,
+                maxContext: Int,
+                created: Int = Int(Date().timeIntervalSince1970),
+                generator: any TokenGenerating) {
+        self.modelID = modelID
+        self.maxContext = maxContext
+        self.created = created
+        self.generator = generator
+    }
+
+    /// Validate + budget a chat request. Split from `generate` so streaming
+    /// handlers can fail with a 400 before the response head is written.
+    public func prepareChat(messages: [ChatMessage],
+                            sampling: SamplingParams) throws -> PreparedGeneration {
+        try prepare(input: .chat(Self.validateMessages(messages)), sampling: sampling)
+    }
+
+    /// Validate + budget a raw-completion request.
+    public func prepareCompletion(prompt: String,
+                                  sampling: SamplingParams) throws -> PreparedGeneration {
+        try prepare(input: .raw(prompt), sampling: sampling)
+    }
+
+    /// Run a prepared generation. Actor isolation alone does NOT serialize
+    /// this: the method suspends on the external `generator.generate` await,
+    /// which would let a second request enter. An explicit FIFO slot closes
+    /// that reentrancy hole — at most one generation holds the slot, queued
+    /// waiters are resumed in arrival order, and a cancelled waiter is
+    /// removed from the queue instead of running.
+    public func generate(_ prepared: PreparedGeneration,
+                         onDelta: (@Sendable (String) -> Void)? = nil) async throws -> GenerationOutcome {
+        try await acquireSlot()
+        // A waiter cancelled in the same instant the slot was handed over must
+        // not start a generation; check before touching the runtime.
+        try Task.checkCancellation()
+        defer { releaseSlot() }
+        return try await generator.generate(prepared.input,
+                                            sampling: prepared.sampling,
+                                            effectiveMaxTokens: prepared.effectiveMaxTokens,
+                                            onDelta: onDelta)
+    }
+
+    // MARK: - Single-in-flight slot
+
+    // s5d:debt(ceiling="disconnect while parked here is detected only when the generation's first SSE write fails — Hummingbird 2 does not cancel the responder task on socket close", trigger="hummingbird exposes channel-close cancellation, or a watchdog is added")
+    // s5d:debt(ceiling="waiter queue is unbounded — a flood parks one connection+continuation each", trigger="server is exposed beyond localhost or a queue cap (503) is requested")
+    private var slotBusy = false
+    private var waiterOrder: [UUID] = []
+    private var waiters: [UUID: CheckedContinuation<Void, any Error>] = [:]
+
+    private func acquireSlot() async throws {
+        if !slotBusy {
+            slotBusy = true
+            return
+        }
+        let id = UUID()
+        try await withTaskCancellationHandler {
+            try await withCheckedThrowingContinuation { (cont: CheckedContinuation<Void, any Error>) in
+                waiters[id] = cont
+                waiterOrder.append(id)
+            }
+        } onCancel: {
+            Task { await self.cancelWaiter(id) }
+        }
+        // Resumed by releaseSlot: the slot is handed over, slotBusy stays true.
+    }
+
+    private func cancelWaiter(_ id: UUID) {
+        guard let cont = waiters.removeValue(forKey: id) else { return }
+        waiterOrder.removeAll { $0 == id }
+        cont.resume(throwing: CancellationError())
+    }
+
+    private func releaseSlot() {
+        while let nextID = waiterOrder.first {
+            waiterOrder.removeFirst()
+            if let cont = waiters.removeValue(forKey: nextID) {
+                cont.resume()
+                return
+            }
+        }
+        slotBusy = false
+    }
+
+    /// Convenience for non-streaming callers: prepare + generate in one call.
+    public func chat(messages: [ChatMessage],
+                     sampling: SamplingParams,
+                     onDelta: (@Sendable (String) -> Void)? = nil) async throws -> GenerationOutcome {
+        try await generate(prepareChat(messages: messages, sampling: sampling), onDelta: onDelta)
+    }
+
+    public func complete(prompt: String,
+                         sampling: SamplingParams,
+                         onDelta: (@Sendable (String) -> Void)? = nil) async throws -> GenerationOutcome {
+        try await generate(prepareCompletion(prompt: prompt, sampling: sampling), onDelta: onDelta)
+    }
+
+    private func prepare(input: GenerationInput,
+                         sampling: SamplingParams) throws -> PreparedGeneration {
+        try Self.validateSampling(sampling)
+        let promptTokens = try generator.tokenCount(for: input)
+        let effectiveMax = try Self.effectiveMaxTokens(requested: sampling.maxTokens,
+                                                       promptTokens: promptTokens,
+                                                       maxContext: maxContext)
+        return PreparedGeneration(input: input,
+                                  sampling: sampling,
+                                  effectiveMaxTokens: effectiveMax,
+                                  promptTokens: promptTokens)
+    }
+
+    /// Numeric field validation; failures surface as OpenAI-style 400s instead
+    /// of undefined runtime behavior (e.g. maxNewTokens: -5 reaching Metal).
+    public static func validateSampling(_ sampling: SamplingParams) throws {
+        if let maxTokens = sampling.maxTokens, maxTokens <= 0 {
+            throw GenerationRequestError.unsupportedParameter("max_tokens must be a positive integer")
+        }
+        guard sampling.temperature >= 0 else {
+            throw GenerationRequestError.unsupportedParameter("temperature must be >= 0")
+        }
+        guard sampling.topP > 0, sampling.topP <= 1 else {
+            throw GenerationRequestError.unsupportedParameter("top_p must be in (0, 1]")
+        }
+    }
+
+    /// Restricts roles to the chat template's supported set. OpenAI
+    /// `assistant` needs no remapping: the template renders it as `model`.
+    public static func validateMessages(_ messages: [ChatMessage]) throws -> [ChatMessage] {
+        guard !messages.isEmpty else { throw GenerationRequestError.emptyMessages }
+        for message in messages {
+            switch message.role {
+            case "system", "user", "assistant":
+                break
+            default:
+                throw GenerationRequestError.unsupportedRole(message.role)
+            }
+        }
+        return messages
+    }
+
+    /// Picks the decode budget. An explicit `max_tokens` that would overflow
+    /// the context is a client error (400); an absent one clamps to whatever
+    /// the context has left, mirroring the CLI.
+    public static func effectiveMaxTokens(requested: Int?,
+                                          promptTokens: Int,
+                                          maxContext: Int) throws -> Int {
+        guard promptTokens > 0 else { throw GenerationRequestError.emptyPrompt }
+        if let requested {
+            guard promptTokens + requested <= maxContext else {
+                throw GenerationRequestError.contextOverflow(prompt: promptTokens,
+                                                             maxTokens: requested,
+                                                             maxContext: maxContext)
+            }
+            return requested
+        }
+        let remaining = maxContext - promptTokens
+        guard remaining > 0 else {
+            throw GenerationRequestError.contextOverflow(prompt: promptTokens,
+                                                         maxTokens: 0,
+                                                         maxContext: maxContext)
+        }
+        return remaining
+    }
+}

--- a/Sources/TurboFieldfareServer/Core/Generation.swift
+++ b/Sources/TurboFieldfareServer/Core/Generation.swift
@@ -168,10 +168,12 @@ public actor GenerationSession {
     public func generate(_ prepared: PreparedGeneration,
                          onDelta: (@Sendable (String) -> Void)? = nil) async throws -> GenerationOutcome {
         try await acquireSlot()
-        // A waiter cancelled in the same instant the slot was handed over must
-        // not start a generation; check before touching the runtime.
-        try Task.checkCancellation()
+        // Installed before any further throwing call: a task cancelled exactly
+        // when the slot is handed over (cancelWaiter no-ops once the
+        // continuation was resumed) would otherwise throw below and leave
+        // slotBusy stuck, deadlocking every later request.
         defer { releaseSlot() }
+        try Task.checkCancellation()
         return try await generator.generate(prepared.input,
                                             sampling: prepared.sampling,
                                             effectiveMaxTokens: prepared.effectiveMaxTokens,
@@ -252,10 +254,12 @@ public actor GenerationSession {
         if let maxTokens = sampling.maxTokens, maxTokens <= 0 {
             throw GenerationRequestError.unsupportedParameter("max_tokens must be a positive integer")
         }
-        guard sampling.temperature >= 0 else {
+        // NaN fails `>= 0` and is rejected implicitly; +Inf passes it and
+        // would blow up later as a runtime error instead of a 400.
+        guard sampling.temperature.isFinite, sampling.temperature >= 0 else {
             throw GenerationRequestError.unsupportedParameter("temperature must be >= 0")
         }
-        guard sampling.topP > 0, sampling.topP <= 1 else {
+        guard sampling.topP.isFinite, sampling.topP > 0, sampling.topP <= 1 else {
             throw GenerationRequestError.unsupportedParameter("top_p must be in (0, 1]")
         }
     }
@@ -283,7 +287,9 @@ public actor GenerationSession {
                                           maxContext: Int) throws -> Int {
         guard promptTokens > 0 else { throw GenerationRequestError.emptyPrompt }
         if let requested {
-            guard promptTokens + requested <= maxContext else {
+            // Written overflow-safe: `promptTokens + requested` would trap on
+            // `max_tokens` near Int.max, killing the server instead of a 400.
+            guard requested <= maxContext, promptTokens <= maxContext - requested else {
                 throw GenerationRequestError.contextOverflow(prompt: promptTokens,
                                                              maxTokens: requested,
                                                              maxContext: maxContext)

--- a/Sources/TurboFieldfareServer/Core/OpenAITypes.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAITypes.swift
@@ -73,6 +73,12 @@ public struct ChatCompletionRequest: Decodable, Sendable {
     public var stream: Bool?
     public var streamOptions: StreamOptions?
     public var n: Int?
+    /// Key-presence markers for unsupported semantic fields: the runtime
+    /// cannot honor them, so the route layer rejects the request instead of
+    /// silently generating unrestricted text.
+    public var hasTools = false
+    public var hasToolChoice = false
+    public var hasResponseFormat = false
 
     enum CodingKeys: String, CodingKey {
         case model
@@ -86,6 +92,9 @@ public struct ChatCompletionRequest: Decodable, Sendable {
         case stream
         case streamOptions = "stream_options"
         case n
+        case tools
+        case toolChoice = "tool_choice"
+        case responseFormat = "response_format"
     }
 
     public init(from decoder: any Decoder) throws {
@@ -103,6 +112,9 @@ public struct ChatCompletionRequest: Decodable, Sendable {
         stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
         streamOptions = try container.decodeIfPresent(StreamOptions.self, forKey: .streamOptions)
         n = try container.decodeIfPresent(Int.self, forKey: .n)
+        hasTools = container.contains(.tools)
+        hasToolChoice = container.contains(.toolChoice)
+        hasResponseFormat = container.contains(.responseFormat)
     }
 
     public init(model: String? = nil,

--- a/Sources/TurboFieldfareServer/Core/OpenAITypes.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAITypes.swift
@@ -1,0 +1,459 @@
+import Foundation
+
+/// OpenAI-compatible wire types for the LM Studio-style HTTP API. Unknown
+/// request fields are ignored by the default `Decodable` synthesis, which
+/// keeps the server tolerant of clients that send extra knobs.
+
+public struct ChatMessage: Codable, Sendable, Equatable {
+    public var role: String
+    public var content: String
+
+    public init(role: String, content: String) {
+        self.role = role
+        self.content = content
+    }
+}
+
+public struct StreamOptions: Codable, Sendable, Equatable {
+    public var includeUsage: Bool?
+
+    enum CodingKeys: String, CodingKey {
+        case includeUsage = "include_usage"
+    }
+
+    public init(includeUsage: Bool? = nil) {
+        self.includeUsage = includeUsage
+    }
+}
+
+/// OpenAI `stop` accepts either a single string or an array of strings.
+public enum StopValue: Codable, Sendable, Equatable {
+    case single(String)
+    case multiple([String])
+
+    public var values: [String] {
+        switch self {
+        case .single(let value): return [value]
+        case .multiple(let values): return values
+        }
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        if let value = try? container.decode(String.self) {
+            self = .single(value)
+        } else if let values = try? container.decode([String].self) {
+            self = .multiple(values)
+        } else {
+            throw DecodingError.typeMismatch(
+                StopValue.self,
+                DecodingError.Context(
+                    codingPath: decoder.codingPath,
+                    debugDescription: "stop must be a string or an array of strings"))
+        }
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.singleValueContainer()
+        switch self {
+        case .single(let value): try container.encode(value)
+        case .multiple(let values): try container.encode(values)
+        }
+    }
+}
+
+public struct ChatCompletionRequest: Decodable, Sendable {
+    public var model: String?
+    public var messages: [ChatMessage]
+    public var temperature: Float?
+    public var topP: Float?
+    public var maxTokens: Int?
+    public var stop: StopValue?
+    public var seed: Int?
+    public var stream: Bool?
+    public var streamOptions: StreamOptions?
+    public var n: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case messages
+        case temperature
+        case topP = "top_p"
+        case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+        case stop
+        case seed
+        case stream
+        case streamOptions = "stream_options"
+        case n
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        model = try container.decodeIfPresent(String.self, forKey: .model)
+        messages = try container.decodeIfPresent([ChatMessage].self, forKey: .messages) ?? []
+        temperature = try container.decodeIfPresent(Float.self, forKey: .temperature)
+        topP = try container.decodeIfPresent(Float.self, forKey: .topP)
+        // `max_completion_tokens` is the newer alias; `max_tokens` wins when
+        // both are present.
+        maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens)
+            ?? container.decodeIfPresent(Int.self, forKey: .maxCompletionTokens)
+        stop = try container.decodeIfPresent(StopValue.self, forKey: .stop)
+        seed = try container.decodeIfPresent(Int.self, forKey: .seed)
+        stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
+        streamOptions = try container.decodeIfPresent(StreamOptions.self, forKey: .streamOptions)
+        n = try container.decodeIfPresent(Int.self, forKey: .n)
+    }
+
+    public init(model: String? = nil,
+                messages: [ChatMessage],
+                temperature: Float? = nil,
+                topP: Float? = nil,
+                maxTokens: Int? = nil,
+                stop: StopValue? = nil,
+                seed: Int? = nil,
+                stream: Bool? = nil,
+                streamOptions: StreamOptions? = nil,
+                n: Int? = nil) {
+        self.model = model
+        self.messages = messages
+        self.temperature = temperature
+        self.topP = topP
+        self.maxTokens = maxTokens
+        self.stop = stop
+        self.seed = seed
+        self.stream = stream
+        self.streamOptions = streamOptions
+        self.n = n
+    }
+}
+
+public struct CompletionRequest: Decodable, Sendable {
+    public var model: String?
+    public var prompt: String
+    public var temperature: Float?
+    public var topP: Float?
+    public var maxTokens: Int?
+    public var stop: StopValue?
+    public var seed: Int?
+    public var stream: Bool?
+    public var streamOptions: StreamOptions?
+    public var n: Int?
+
+    enum CodingKeys: String, CodingKey {
+        case model
+        case prompt
+        case temperature
+        case topP = "top_p"
+        case maxTokens = "max_tokens"
+        case maxCompletionTokens = "max_completion_tokens"
+        case stop
+        case seed
+        case stream
+        case streamOptions = "stream_options"
+        case n
+    }
+
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        model = try container.decodeIfPresent(String.self, forKey: .model)
+        prompt = try container.decodeIfPresent(String.self, forKey: .prompt) ?? ""
+        temperature = try container.decodeIfPresent(Float.self, forKey: .temperature)
+        topP = try container.decodeIfPresent(Float.self, forKey: .topP)
+        maxTokens = try container.decodeIfPresent(Int.self, forKey: .maxTokens)
+            ?? container.decodeIfPresent(Int.self, forKey: .maxCompletionTokens)
+        stop = try container.decodeIfPresent(StopValue.self, forKey: .stop)
+        seed = try container.decodeIfPresent(Int.self, forKey: .seed)
+        stream = try container.decodeIfPresent(Bool.self, forKey: .stream)
+        streamOptions = try container.decodeIfPresent(StreamOptions.self, forKey: .streamOptions)
+        n = try container.decodeIfPresent(Int.self, forKey: .n)
+    }
+
+    public init(model: String? = nil,
+                prompt: String,
+                temperature: Float? = nil,
+                topP: Float? = nil,
+                maxTokens: Int? = nil,
+                stop: StopValue? = nil,
+                seed: Int? = nil,
+                stream: Bool? = nil,
+                streamOptions: StreamOptions? = nil,
+                n: Int? = nil) {
+        self.model = model
+        self.prompt = prompt
+        self.temperature = temperature
+        self.topP = topP
+        self.maxTokens = maxTokens
+        self.stop = stop
+        self.seed = seed
+        self.stream = stream
+        self.streamOptions = streamOptions
+        self.n = n
+    }
+}
+
+public struct Usage: Codable, Sendable, Equatable {
+    public var promptTokens: Int
+    public var completionTokens: Int
+    public var totalTokens: Int
+
+    enum CodingKeys: String, CodingKey {
+        case promptTokens = "prompt_tokens"
+        case completionTokens = "completion_tokens"
+        case totalTokens = "total_tokens"
+    }
+
+    public init(promptTokens: Int, completionTokens: Int) {
+        self.promptTokens = promptTokens
+        self.completionTokens = completionTokens
+        self.totalTokens = promptTokens + completionTokens
+    }
+}
+
+public struct HealthResponse: Encodable, Sendable {
+    public var status: String
+
+    public init(status: String = "ok") {
+        self.status = status
+    }
+}
+
+public struct ModelObject: Encodable, Sendable {
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var ownedBy: String
+
+    enum CodingKeys: String, CodingKey {
+        case id
+        case object
+        case created
+        case ownedBy = "owned_by"
+    }
+
+    public init(id: String, created: Int, ownedBy: String = "local") {
+        self.id = id
+        self.object = "model"
+        self.created = created
+        self.ownedBy = ownedBy
+    }
+}
+
+public struct ModelList: Encodable, Sendable {
+    public var object: String
+    public var data: [ModelObject]
+
+    public init(models: [ModelObject]) {
+        self.object = "list"
+        self.data = models
+    }
+}
+
+public struct ChatChoiceMessage: Encodable, Sendable {
+    public var role: String
+    public var content: String
+
+    public init(content: String) {
+        self.role = "assistant"
+        self.content = content
+    }
+}
+
+public struct ChatChoice: Encodable, Sendable {
+    public var index: Int
+    public var message: ChatChoiceMessage
+    public var finishReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case index
+        case message
+        case finishReason = "finish_reason"
+    }
+
+    public init(index: Int, message: ChatChoiceMessage, finishReason: String?) {
+        self.index = index
+        self.message = message
+        self.finishReason = finishReason
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(index, forKey: .index)
+        try container.encode(message, forKey: .message)
+        // OpenAI emits an explicit null for in-flight choices; mirror that.
+        try container.encode(finishReason, forKey: .finishReason)
+    }
+}
+
+public struct ChatCompletionResponse: Encodable, Sendable {
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var model: String
+    public var choices: [ChatChoice]
+    public var usage: Usage
+
+    public init(id: String, created: Int, model: String, choices: [ChatChoice], usage: Usage) {
+        self.id = id
+        self.object = "chat.completion"
+        self.created = created
+        self.model = model
+        self.choices = choices
+        self.usage = usage
+    }
+}
+
+public struct ChatChunkDelta: Encodable, Sendable {
+    public var role: String?
+    public var content: String?
+
+    public init(role: String? = nil, content: String? = nil) {
+        self.role = role
+        self.content = content
+    }
+}
+
+public struct ChatChunkChoice: Encodable, Sendable {
+    public var index: Int
+    public var delta: ChatChunkDelta
+    public var finishReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case index
+        case delta
+        case finishReason = "finish_reason"
+    }
+
+    public init(index: Int, delta: ChatChunkDelta, finishReason: String?) {
+        self.index = index
+        self.delta = delta
+        self.finishReason = finishReason
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(index, forKey: .index)
+        try container.encode(delta, forKey: .delta)
+        try container.encode(finishReason, forKey: .finishReason)
+    }
+}
+
+public struct ChatCompletionChunk: Encodable, Sendable {
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var model: String
+    public var choices: [ChatChunkChoice]
+    public var usage: Usage?
+
+    public init(id: String,
+                created: Int,
+                model: String,
+                choices: [ChatChunkChoice],
+                usage: Usage? = nil) {
+        self.id = id
+        self.object = "chat.completion.chunk"
+        self.created = created
+        self.model = model
+        self.choices = choices
+        self.usage = usage
+    }
+}
+
+public struct CompletionChoice: Encodable, Sendable {
+    public var index: Int
+    public var text: String
+    public var finishReason: String?
+
+    enum CodingKeys: String, CodingKey {
+        case index
+        case text
+        case finishReason = "finish_reason"
+    }
+
+    public init(index: Int, text: String, finishReason: String?) {
+        self.index = index
+        self.text = text
+        self.finishReason = finishReason
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(index, forKey: .index)
+        try container.encode(text, forKey: .text)
+        try container.encode(finishReason, forKey: .finishReason)
+    }
+}
+
+public struct CompletionResponse: Encodable, Sendable {
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var model: String
+    public var choices: [CompletionChoice]
+    public var usage: Usage
+
+    public init(id: String, created: Int, model: String, choices: [CompletionChoice], usage: Usage) {
+        self.id = id
+        self.object = "text_completion"
+        self.created = created
+        self.model = model
+        self.choices = choices
+        self.usage = usage
+    }
+}
+
+public struct CompletionChunk: Encodable, Sendable {
+    public var id: String
+    public var object: String
+    public var created: Int
+    public var model: String
+    public var choices: [CompletionChoice]
+    public var usage: Usage?
+
+    public init(id: String,
+                created: Int,
+                model: String,
+                choices: [CompletionChoice],
+                usage: Usage? = nil) {
+        self.id = id
+        self.object = "text_completion"
+        self.created = created
+        self.model = model
+        self.choices = choices
+        self.usage = usage
+    }
+}
+
+public struct OpenAIErrorBody: Encodable, Sendable {
+    public var message: String
+    public var type: String
+    public var code: String?
+
+    public init(message: String, type: String = "invalid_request_error", code: String? = nil) {
+        self.message = message
+        self.type = type
+        self.code = code
+    }
+
+    public func encode(to encoder: any Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(message, forKey: .message)
+        try container.encode(type, forKey: .type)
+        try container.encode(code, forKey: .code)
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case message
+        case type
+        case code
+    }
+}
+
+public struct OpenAIErrorResponse: Encodable, Sendable {
+    public var error: OpenAIErrorBody
+
+    public init(message: String, type: String = "invalid_request_error", code: String? = nil) {
+        self.error = OpenAIErrorBody(message: message, type: type, code: code)
+    }
+}

--- a/Sources/TurboFieldfareServer/Core/RealTokenGenerator.swift
+++ b/Sources/TurboFieldfareServer/Core/RealTokenGenerator.swift
@@ -1,0 +1,129 @@
+import Foundation
+import TurboFieldfare
+
+/// Bridges the Metal runtime to the Metal-free `TokenGenerating` seam.
+///
+/// One instance per server, owned by the `GenerationSession` actor which
+/// serializes every call — the single-in-flight contract
+/// `RawCompletionScratch` requires. The runner is built once with
+/// `forceLogitsHead: true`: an API server mostly serves sampling configs, and
+/// the logits head also serves pure-greedy configs, so one runner covers all
+/// requests.
+final class RealTokenGenerator: TokenGenerating, @unchecked Sendable {
+    private let tokenizer: GFTokenizer
+    private let runner: RealForwardRunner
+    private let context: MetalContext
+    private let scratch: RawCompletionScratch
+    private let runtime: RuntimeConfiguration
+
+    init(tokenizer: GFTokenizer,
+         runner: RealForwardRunner,
+         context: MetalContext,
+         scratch: RawCompletionScratch,
+         runtime: RuntimeConfiguration) {
+        self.tokenizer = tokenizer
+        self.runner = runner
+        self.context = context
+        self.scratch = scratch
+        self.runtime = runtime
+    }
+
+    /// Load sequence mirrors the CLI (`Sources/TurboFieldfareCLI/Run.swift`).
+    static func load(modelPath: String, maxContext: Int) async throws -> RealTokenGenerator {
+        let modelURL = URL(fileURLWithPath: modelPath)
+        let tokenizer = try await GFTokenizer.load(forModelDirectory: modelURL)
+        let runtime = RuntimeConfiguration(forceLogitsHead: true)
+        let context = try MetalContext()
+        let model = try Model.load(
+            directoryURL: modelURL,
+            device: context.device,
+            streamingMode: .pread(slotCount: runtime.expertCacheSlots),
+            expertCachePolicy: runtime.modelExpertCachePolicy,
+            integrityPolicy: .fullSha256)
+        let runner = try RealForwardRunner(
+            model: model,
+            context: context,
+            maxContext: maxContext,
+            runtimeConfiguration: runtime)
+        let scratch = try RawCompletionScratch(context: context,
+                                               vocab: model.config.vocabSize)
+        return RealTokenGenerator(tokenizer: tokenizer,
+                                  runner: runner,
+                                  context: context,
+                                  scratch: scratch,
+                                  runtime: runtime)
+    }
+
+    func tokenCount(for input: GenerationInput) throws -> Int {
+        try encode(input).count
+    }
+
+    func generate(_ input: GenerationInput,
+                  sampling: SamplingParams,
+                  effectiveMaxTokens: Int,
+                  onDelta: (@Sendable (String) -> Void)?) async throws -> GenerationOutcome {
+        let promptIds = try encode(input)
+        let config = GenerationConfig(
+            maxNewTokens: effectiveMaxTokens,
+            temperature: sampling.temperature,
+            topK: 64,
+            topP: sampling.topP,
+            repetitionPenalty: 1.0,
+            seed: sampling.seed,
+            stopStrings: sampling.stop,
+            extraStopTokens: [])
+        var text = ""
+        let result = try await runRawCompletion(
+            producer: runner,
+            tokenizer: tokenizer,
+            promptIds: promptIds,
+            config: config,
+            context: context,
+            scratch: scratch,
+            prefillConfig: runtime.prefillConfig) { progress in
+                switch progress {
+                case .prefill:
+                    break
+                case .token(_, _, let delta):
+                    if !delta.isEmpty {
+                        text += delta
+                        onDelta?(delta)
+                    }
+                case .tail(let tail):
+                    if !tail.isEmpty {
+                        text += tail
+                        onDelta?(tail)
+                    }
+                }
+            }
+        return GenerationOutcome(text: text,
+                                 promptTokens: result.prefillTokens,
+                                 completionTokens: result.newTokens,
+                                 finishReason: Self.finishReason(for: result.reason))
+    }
+
+    private func encode(_ input: GenerationInput) throws -> [Int32] {
+        switch input {
+        case .chat(let messages):
+            let templated = try messages.map { message -> GFTokenizer.Message in
+                guard let role = GFTokenizer.Role(rawValue: message.role) else {
+                    throw GenerationRequestError.unsupportedRole(message.role)
+                }
+                return GFTokenizer.Message(role: role, content: message.content)
+            }
+            let rendered = try tokenizer.applyChatTemplate(templated)
+            return tokenizer.encode(rendered, addBOS: false)
+        case .raw(let prompt):
+            return tokenizer.encode(prompt, addBOS: true)
+        }
+    }
+
+    static func finishReason(for reason: StopReason) -> FinishReason {
+        switch reason {
+        case .endOfTurn, .eos, .stopString:
+            return .stop
+        case .maxTokens:
+            return .length
+        }
+    }
+}

--- a/Sources/TurboFieldfareServer/Core/RealTokenGenerator.swift
+++ b/Sources/TurboFieldfareServer/Core/RealTokenGenerator.swift
@@ -3,12 +3,16 @@ import TurboFieldfare
 
 /// Bridges the Metal runtime to the Metal-free `TokenGenerating` seam.
 ///
-/// One instance per server, owned by the `GenerationSession` actor which
-/// serializes every call — the single-in-flight contract
-/// `RawCompletionScratch` requires. The runner is built once with
-/// `forceLogitsHead: true`: an API server mostly serves sampling configs, and
-/// the logits head also serves pure-greedy configs, so one runner covers all
-/// requests.
+/// One instance per server, owned by the `GenerationSession` actor. Metal
+/// state (`runner` / `scratch` / `context`) is touched only from `generate`,
+/// which the session's single-in-flight slot serializes. `tokenCount` runs
+/// outside the slot so bad requests fail fast with a 400; it only encodes via
+/// `GFTokenizer`, whose underlying `Tokenizer` protocol is `Sendable` with
+/// immutable post-load state, so concurrent encode/detokenize is safe.
+///
+/// The runner is built once with `forceLogitsHead: true`: an API server
+/// mostly serves sampling configs, and the logits head also serves
+/// pure-greedy configs, so one runner covers all requests.
 final class RealTokenGenerator: TokenGenerating, @unchecked Sendable {
     private let tokenizer: GFTokenizer
     private let runner: RealForwardRunner

--- a/Sources/TurboFieldfareServer/Core/Routes.swift
+++ b/Sources/TurboFieldfareServer/Core/Routes.swift
@@ -1,0 +1,274 @@
+import Foundation
+import Hummingbird
+import NIOCore
+
+/// Builds the OpenAI-compatible API surface. All runtime access goes through
+/// the `GenerationSession` actor, so this layer stays Metal-free.
+public func buildServerRouter(session: GenerationSession) -> Router<BasicRequestContext> {
+    let router = Router(context: BasicRequestContext.self)
+
+    router.get("health") { _, _ -> Response in
+        jsonResponse(.ok, HealthResponse())
+    }
+
+    router.get("v1/models") { _, _ -> Response in
+        let model = ModelObject(id: await session.modelID, created: await session.created)
+        return jsonResponse(.ok, ModelList(models: [model]))
+    }
+
+    router.post("v1/chat/completions") { request, context -> Response in
+        await handleChatCompletions(request: request, context: context, session: session)
+    }
+
+    router.post("v1/completions") { request, context -> Response in
+        await handleCompletions(request: request, context: context, session: session)
+    }
+
+    return router
+}
+
+private func handleChatCompletions(request: Request,
+                                   context: some RequestContext,
+                                   session: GenerationSession) async -> Response {
+    do {
+        let body = try await request.decode(as: ChatCompletionRequest.self, context: context)
+        if let n = body.n, n > 1 {
+            throw GenerationRequestError.unsupportedParameter("n > 1 is not supported")
+        }
+        let sampling = SamplingParams(maxTokens: body.maxTokens,
+                                      temperature: body.temperature,
+                                      topP: body.topP,
+                                      seed: body.seed,
+                                      stop: body.stop)
+        let prepared = try await session.prepareChat(messages: body.messages, sampling: sampling)
+        let includeUsage = body.streamOptions?.includeUsage ?? false
+        let modelID = await session.modelID
+        if body.stream == true {
+            return streamingResponse(kind: .chat,
+                                     session: session,
+                                     prepared: prepared,
+                                     modelID: modelID,
+                                     includeUsage: includeUsage)
+        }
+        let outcome = try await session.generate(prepared)
+        let response = ChatCompletionResponse(
+            id: openAIID(prefix: "chatcmpl"),
+            created: unixNow(),
+            model: modelID,
+            choices: [ChatChoice(index: 0,
+                                 message: ChatChoiceMessage(content: outcome.text),
+                                 finishReason: outcome.finishReason.rawValue)],
+            usage: outcome.usage)
+        return jsonResponse(.ok, response)
+    } catch let error as HTTPError {
+        return errorResponse(status: error.status,
+                             message: error.body ?? "invalid request body")
+    } catch let error as GenerationRequestError {
+        return errorResponse(status: .badRequest, message: error.description)
+    } catch {
+        // Deliberately generic: runtime errors carry internal paths/Metal
+        // details that must not leak into HTTP responses.
+        return errorResponse(status: .internalServerError,
+                             message: "generation failed",
+                             type: "server_error")
+    }
+}
+
+private func handleCompletions(request: Request,
+                               context: some RequestContext,
+                               session: GenerationSession) async -> Response {
+    do {
+        let body = try await request.decode(as: CompletionRequest.self, context: context)
+        if let n = body.n, n > 1 {
+            throw GenerationRequestError.unsupportedParameter("n > 1 is not supported")
+        }
+        let sampling = SamplingParams(maxTokens: body.maxTokens,
+                                      temperature: body.temperature,
+                                      topP: body.topP,
+                                      seed: body.seed,
+                                      stop: body.stop)
+        let prepared = try await session.prepareCompletion(prompt: body.prompt, sampling: sampling)
+        let includeUsage = body.streamOptions?.includeUsage ?? false
+        let modelID = await session.modelID
+        if body.stream == true {
+            return streamingResponse(kind: .raw,
+                                     session: session,
+                                     prepared: prepared,
+                                     modelID: modelID,
+                                     includeUsage: includeUsage)
+        }
+        let outcome = try await session.generate(prepared)
+        let response = CompletionResponse(
+            id: openAIID(prefix: "cmpl"),
+            created: unixNow(),
+            model: modelID,
+            choices: [CompletionChoice(index: 0,
+                                       text: outcome.text,
+                                       finishReason: outcome.finishReason.rawValue)],
+            usage: outcome.usage)
+        return jsonResponse(.ok, response)
+    } catch let error as HTTPError {
+        return errorResponse(status: error.status,
+                             message: error.body ?? "invalid request body")
+    } catch let error as GenerationRequestError {
+        return errorResponse(status: .badRequest, message: error.description)
+    } catch {
+        // Deliberately generic: runtime errors carry internal paths/Metal
+        // details that must not leak into HTTP responses.
+        return errorResponse(status: .internalServerError,
+                             message: "generation failed",
+                             type: "server_error")
+    }
+}
+
+private enum StreamKind {
+    case chat
+    case raw
+}
+
+/// Events bridged from the generation task to the SSE body writer.
+private enum StreamEvent {
+    case delta(String)
+    case finished(GenerationOutcome)
+}
+
+/// SSE response. The generation runs in a child task bridged through an
+/// AsyncThrowingStream; each chunk is written (and flushed) as it is
+/// produced. If the client disconnects, the write throws, the loop exits and
+/// `defer` cancels the generation task — `runRawCompletion` observes that via
+/// `Task.checkCancellation()`.
+// s5d:debt(ceiling="disconnect during prefill is detected only at the first decode write — prefill yields no deltas, so a dead client still pays the full prefill", trigger="prefill progress is surfaced through TokenGenerating or the runtime checks cancellation mid-prefill")
+private func streamingResponse(kind: StreamKind,
+                               session: GenerationSession,
+                               prepared: PreparedGeneration,
+                               modelID: String,
+                               includeUsage: Bool) -> Response {
+    let id = openAIID(prefix: kind == .chat ? "chatcmpl" : "cmpl")
+    let created = unixNow()
+    let body = ResponseBody { writer in
+        let (stream, continuation) = AsyncThrowingStream<StreamEvent, Error>.makeStream()
+        let generation = Task {
+            do {
+                let outcome = try await session.generate(prepared) { delta in
+                    continuation.yield(.delta(delta))
+                }
+                continuation.yield(.finished(outcome))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        defer { generation.cancel() }
+        if kind == .chat {
+            let roleChunk = ChatCompletionChunk(
+                id: id, created: created, model: modelID,
+                choices: [ChatChunkChoice(index: 0,
+                                          delta: ChatChunkDelta(role: "assistant"),
+                                          finishReason: nil)])
+            try await writer.write(ByteBuffer(data: SSEFramer.frame(roleChunk)))
+        }
+        for try await event in stream {
+            switch event {
+            case .delta(let text):
+                try await writer.write(ByteBuffer(data: SSEFramer.frame(deltaChunk(
+                    kind: kind, id: id, created: created, modelID: modelID, text: text))))
+            case .finished(let outcome):
+                try await writer.write(ByteBuffer(data: SSEFramer.frame(finalChunk(
+                    kind: kind, id: id, created: created, modelID: modelID, outcome: outcome))))
+                if includeUsage {
+                    try await writer.write(ByteBuffer(data: SSEFramer.frame(usageChunk(
+                        kind: kind, id: id, created: created, modelID: modelID, outcome: outcome))))
+                }
+            }
+        }
+        try await writer.write(ByteBuffer(data: SSEFramer.doneFrame))
+        try await writer.finish(nil)
+    }
+    return Response(status: .ok,
+                    headers: [.contentType: "text/event-stream", .cacheControl: "no-cache"],
+                    body: body)
+}
+
+private func deltaChunk(kind: StreamKind,
+                        id: String,
+                        created: Int,
+                        modelID: String,
+                        text: String) -> any Encodable {
+    switch kind {
+    case .chat:
+        return ChatCompletionChunk(
+            id: id, created: created, model: modelID,
+            choices: [ChatChunkChoice(index: 0,
+                                      delta: ChatChunkDelta(content: text),
+                                      finishReason: nil)])
+    case .raw:
+        return CompletionChunk(
+            id: id, created: created, model: modelID,
+            choices: [CompletionChoice(index: 0, text: text, finishReason: nil)])
+    }
+}
+
+private func finalChunk(kind: StreamKind,
+                        id: String,
+                        created: Int,
+                        modelID: String,
+                        outcome: GenerationOutcome) -> any Encodable {
+    switch kind {
+    case .chat:
+        return ChatCompletionChunk(
+            id: id, created: created, model: modelID,
+            choices: [ChatChunkChoice(index: 0,
+                                      delta: ChatChunkDelta(),
+                                      finishReason: outcome.finishReason.rawValue)])
+    case .raw:
+        return CompletionChunk(
+            id: id, created: created, model: modelID,
+            choices: [CompletionChoice(index: 0,
+                                       text: "",
+                                       finishReason: outcome.finishReason.rawValue)])
+    }
+}
+
+private func usageChunk(kind: StreamKind,
+                        id: String,
+                        created: Int,
+                        modelID: String,
+                        outcome: GenerationOutcome) -> any Encodable {
+    switch kind {
+    case .chat:
+        return ChatCompletionChunk(id: id, created: created, model: modelID,
+                                   choices: [], usage: outcome.usage)
+    case .raw:
+        return CompletionChunk(id: id, created: created, model: modelID,
+                               choices: [], usage: outcome.usage)
+    }
+}
+
+func jsonResponse<T: Encodable>(_ status: HTTPResponse.Status, _ value: T) -> Response {
+    do {
+        let data = try JSONEncoder().encode(value)
+        return Response(status: status,
+                        headers: [.contentType: "application/json"],
+                        body: .init(byteBuffer: ByteBuffer(data: data)))
+    } catch {
+        return Response(status: .internalServerError,
+                        headers: [.contentType: "application/json"],
+                        body: .init(byteBuffer: ByteBuffer(
+                            string: #"{"error":{"message":"response encoding failed","type":"server_error","code":null}}"#)))
+    }
+}
+
+func errorResponse(status: HTTPResponse.Status,
+                   message: String,
+                   type: String = "invalid_request_error") -> Response {
+    jsonResponse(status, OpenAIErrorResponse(message: message, type: type))
+}
+
+func unixNow() -> Int {
+    Int(Date().timeIntervalSince1970)
+}
+
+func openAIID(prefix: String) -> String {
+    let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased().prefix(24)
+    return "\(prefix)-\(suffix)"
+}

--- a/Sources/TurboFieldfareServer/Core/Routes.swift
+++ b/Sources/TurboFieldfareServer/Core/Routes.swift
@@ -2,8 +2,9 @@ import Foundation
 import Hummingbird
 import NIOCore
 
-/// Builds the OpenAI-compatible API surface. All runtime access goes through
-/// the `GenerationSession` actor, so this layer stays Metal-free.
+/// Builds the HTTP API surface: the OpenAI-compatible endpoints plus the
+/// Anthropic Messages endpoint. All runtime access goes through the
+/// `GenerationSession` actor, so this layer stays Metal-free.
 public func buildServerRouter(session: GenerationSession) -> Router<BasicRequestContext> {
     let router = Router(context: BasicRequestContext.self)
 
@@ -22,6 +23,10 @@ public func buildServerRouter(session: GenerationSession) -> Router<BasicRequest
 
     router.post("v1/completions") { request, context -> Response in
         await handleCompletions(request: request, context: context, session: session)
+    }
+
+    router.post("v1/messages") { request, context -> Response in
+        await handleMessages(request: request, context: context, session: session)
     }
 
     return router
@@ -121,11 +126,77 @@ private func handleCompletions(request: Request,
     }
 }
 
+private func handleMessages(request: Request,
+                            context: some RequestContext,
+                            session: GenerationSession) async -> Response {
+    do {
+        let body = try await request.decode(as: AnthropicMessagesRequest.self, context: context)
+        guard let maxTokens = body.maxTokens else {
+            throw GenerationRequestError.unsupportedParameter("max_tokens is required")
+        }
+        if body.hasTools {
+            throw GenerationRequestError.unsupportedParameter("tools is not supported")
+        }
+        if body.hasToolChoice {
+            throw GenerationRequestError.unsupportedParameter("tool_choice is not supported")
+        }
+        if body.hasThinking {
+            throw GenerationRequestError.unsupportedParameter("thinking is not supported")
+        }
+        if body.hasMetadata {
+            throw GenerationRequestError.unsupportedParameter("metadata is not supported")
+        }
+        if let n = body.n, n > 1 {
+            throw GenerationRequestError.unsupportedParameter("n > 1 is not supported")
+        }
+        var messages: [ChatMessage] = []
+        if let system = body.system {
+            messages.append(ChatMessage(role: "system", content: system.text))
+        }
+        for message in body.messages {
+            guard message.role == "user" || message.role == "assistant" else {
+                throw GenerationRequestError.unsupportedRole(message.role)
+            }
+            messages.append(ChatMessage(role: message.role, content: message.content.text))
+        }
+        let sampling = SamplingParams(maxTokens: maxTokens,
+                                      temperature: body.temperature,
+                                      topP: body.topP,
+                                      seed: nil,
+                                      stop: body.stopSequences.map { .multiple($0) })
+        let prepared = try await session.prepareChat(messages: messages, sampling: sampling)
+        // `modelID` is a nonisolated `let` on the actor; no await needed.
+        let modelID = session.modelID
+        if body.stream == true {
+            return anthropicStreamingResponse(session: session, prepared: prepared, modelID: modelID)
+        }
+        let outcome = try await session.generate(prepared)
+        let response = AnthropicMessageResponse(
+            id: anthropicMessageID(),
+            model: modelID,
+            content: [AnthropicTextBlock(text: outcome.text)],
+            stopReason: outcome.finishReason.anthropicStopReason,
+            usage: AnthropicUsage(inputTokens: outcome.promptTokens,
+                                  outputTokens: outcome.completionTokens))
+        return jsonResponse(.ok, response)
+    } catch let error as HTTPError {
+        return anthropicErrorResponse(status: error.status,
+                                      message: error.body ?? "invalid request body")
+    } catch let error as GenerationRequestError {
+        return anthropicErrorResponse(status: .badRequest, message: error.description)
+    } catch {
+        // Deliberately generic: runtime errors carry internal paths/Metal
+        // details that must not leak into HTTP responses.
+        return anthropicErrorResponse(status: .internalServerError,
+                                      message: "generation failed",
+                                      type: "api_error")
+    }
+}
+
 private enum StreamKind {
     case chat
     case raw
 }
-
 /// Events bridged from the generation task to the SSE body writer.
 private enum StreamEvent {
     case delta(String)
@@ -182,6 +253,69 @@ private func streamingResponse(kind: StreamKind,
             }
         }
         try await writer.write(ByteBuffer(data: SSEFramer.doneFrame))
+        try await writer.finish(nil)
+    }
+    return Response(status: .ok,
+                    headers: [.contentType: "text/event-stream", .cacheControl: "no-cache"],
+                    body: body)
+}
+
+/// Anthropic Messages SSE stream. Same bridge/disconnect semantics as
+/// `streamingResponse`, but every frame carries an `event:` line, the event
+/// order is message_start → content_block_start → deltas →
+/// content_block_stop → message_delta → message_stop, and there is no
+/// `[DONE]` sentinel.
+// s5d:debt(ceiling="disconnect during prefill is detected only at the first decode write — prefill yields no deltas, so a dead client still pays the full prefill", trigger="prefill progress is surfaced through TokenGenerating or the runtime checks cancellation mid-prefill")
+private func anthropicStreamingResponse(session: GenerationSession,
+                                        prepared: PreparedGeneration,
+                                        modelID: String) -> Response {
+    let id = anthropicMessageID()
+    let body = ResponseBody { writer in
+        let (stream, continuation) = AsyncThrowingStream<StreamEvent, Error>.makeStream()
+        let generation = Task {
+            do {
+                let outcome = try await session.generate(prepared) { delta in
+                    continuation.yield(.delta(delta))
+                }
+                continuation.yield(.finished(outcome))
+                continuation.finish()
+            } catch {
+                continuation.finish(throwing: error)
+            }
+        }
+        defer { generation.cancel() }
+        try await writer.write(ByteBuffer(data: SSEFramer.frame(
+            event: "message_start",
+            AnthropicMessageStart(message: AnthropicMessageResponse(
+                id: id,
+                model: modelID,
+                content: [],
+                stopReason: nil,
+                usage: AnthropicUsage(inputTokens: prepared.promptTokens, outputTokens: 1))))))
+        try await writer.write(ByteBuffer(data: SSEFramer.frame(
+            event: "content_block_start",
+            AnthropicContentBlockStart(index: 0, contentBlock: AnthropicTextBlock(text: "")))))
+        for try await event in stream {
+            switch event {
+            case .delta(let text):
+                try await writer.write(ByteBuffer(data: SSEFramer.frame(
+                    event: "content_block_delta",
+                    AnthropicContentBlockDelta(index: 0, delta: AnthropicTextDelta(text: text)))))
+            case .finished(let outcome):
+                try await writer.write(ByteBuffer(data: SSEFramer.frame(
+                    event: "content_block_stop",
+                    AnthropicContentBlockStop(index: 0))))
+                try await writer.write(ByteBuffer(data: SSEFramer.frame(
+                    event: "message_delta",
+                    AnthropicMessageDelta(
+                        delta: AnthropicMessageDeltaBody(
+                            stopReason: outcome.finishReason.anthropicStopReason),
+                        usage: AnthropicOutputUsage(outputTokens: outcome.completionTokens)))))
+            }
+        }
+        try await writer.write(ByteBuffer(data: SSEFramer.frame(
+            event: "message_stop",
+            AnthropicMessageStop())))
         try await writer.finish(nil)
     }
     return Response(status: .ok,
@@ -271,4 +405,17 @@ func unixNow() -> Int {
 func openAIID(prefix: String) -> String {
     let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased().prefix(24)
     return "\(prefix)-\(suffix)"
+}
+
+func anthropicErrorResponse(status: HTTPResponse.Status,
+                            message: String,
+                            type: String = "invalid_request_error") -> Response {
+    jsonResponse(status, AnthropicErrorResponse(type: type, message: message))
+}
+
+/// Anthropic ids use an underscore separator (`msg_...`), unlike the OpenAI
+/// `prefix-...` form above.
+func anthropicMessageID() -> String {
+    let suffix = UUID().uuidString.replacingOccurrences(of: "-", with: "").lowercased().prefix(24)
+    return "msg_\(suffix)"
 }

--- a/Sources/TurboFieldfareServer/Core/Routes.swift
+++ b/Sources/TurboFieldfareServer/Core/Routes.swift
@@ -37,8 +37,17 @@ private func handleChatCompletions(request: Request,
                                    session: GenerationSession) async -> Response {
     do {
         let body = try await request.decode(as: ChatCompletionRequest.self, context: context)
-        if let n = body.n, n > 1 {
-            throw GenerationRequestError.unsupportedParameter("n > 1 is not supported")
+        if body.hasTools {
+            throw GenerationRequestError.unsupportedParameter("tools is not supported")
+        }
+        if body.hasToolChoice {
+            throw GenerationRequestError.unsupportedParameter("tool_choice is not supported")
+        }
+        if body.hasResponseFormat {
+            throw GenerationRequestError.unsupportedParameter("response_format is not supported")
+        }
+        if let n = body.n, n != 1 {
+            throw GenerationRequestError.unsupportedParameter("n must be 1")
         }
         let sampling = SamplingParams(maxTokens: body.maxTokens,
                                       temperature: body.temperature,
@@ -84,8 +93,8 @@ private func handleCompletions(request: Request,
                                session: GenerationSession) async -> Response {
     do {
         let body = try await request.decode(as: CompletionRequest.self, context: context)
-        if let n = body.n, n > 1 {
-            throw GenerationRequestError.unsupportedParameter("n > 1 is not supported")
+        if let n = body.n, n != 1 {
+            throw GenerationRequestError.unsupportedParameter("n must be 1")
         }
         let sampling = SamplingParams(maxTokens: body.maxTokens,
                                       temperature: body.temperature,
@@ -146,8 +155,8 @@ private func handleMessages(request: Request,
         if body.hasMetadata {
             throw GenerationRequestError.unsupportedParameter("metadata is not supported")
         }
-        if let n = body.n, n > 1 {
-            throw GenerationRequestError.unsupportedParameter("n > 1 is not supported")
+        if let n = body.n, n != 1 {
+            throw GenerationRequestError.unsupportedParameter("n must be 1")
         }
         var messages: [ChatMessage] = []
         if let system = body.system {

--- a/Sources/TurboFieldfareServer/Core/SSE.swift
+++ b/Sources/TurboFieldfareServer/Core/SSE.swift
@@ -1,13 +1,23 @@
 import Foundation
 
-/// Server-Sent Events framing. One OpenAI JSON object per `data:` frame,
-/// terminated by the literal `[DONE]` sentinel.
+/// Server-Sent Events framing. The OpenAI surface emits one JSON object per
+/// `data:` frame terminated by the literal `[DONE]` sentinel; the Anthropic
+/// surface adds an `event:` line per frame and has no sentinel.
 public enum SSEFramer {
     /// Shared encoder; JSONEncoder is documented as thread-safe for reuse.
     private static let encoder = JSONEncoder()
 
     public static func frame<T: Encodable>(_ value: T) throws -> Data {
         var data = Data("data: ".utf8)
+        data.append(try encoder.encode(value))
+        data.append(Data("\n\n".utf8))
+        return data
+    }
+
+    /// Named-event variant for the Anthropic Messages API, whose SSE streams
+    /// tag every frame with an `event:` line.
+    public static func frame<T: Encodable>(event: String, _ value: T) throws -> Data {
+        var data = Data("event: \(event)\ndata: ".utf8)
         data.append(try encoder.encode(value))
         data.append(Data("\n\n".utf8))
         return data

--- a/Sources/TurboFieldfareServer/Core/SSE.swift
+++ b/Sources/TurboFieldfareServer/Core/SSE.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+/// Server-Sent Events framing. One OpenAI JSON object per `data:` frame,
+/// terminated by the literal `[DONE]` sentinel.
+public enum SSEFramer {
+    /// Shared encoder; JSONEncoder is documented as thread-safe for reuse.
+    private static let encoder = JSONEncoder()
+
+    public static func frame<T: Encodable>(_ value: T) throws -> Data {
+        var data = Data("data: ".utf8)
+        data.append(try encoder.encode(value))
+        data.append(Data("\n\n".utf8))
+        return data
+    }
+
+    public static var doneFrame: Data {
+        Data("data: [DONE]\n\n".utf8)
+    }
+}

--- a/Sources/TurboFieldfareServer/Core/Server.swift
+++ b/Sources/TurboFieldfareServer/Core/Server.swift
@@ -1,0 +1,23 @@
+import Foundation
+import Hummingbird
+
+/// Loads the model, builds the router and runs the HTTP server. The model is
+/// fully loaded before the port is bound, so a listening socket always means
+/// ready.
+public func runServer(args: ServerArgs) async throws {
+    let generator = try await RealTokenGenerator.load(modelPath: args.model,
+                                                      maxContext: args.maxContext)
+    let session = GenerationSession(modelID: args.modelID,
+                                    maxContext: args.maxContext,
+                                    generator: generator)
+    let router = buildServerRouter(session: session)
+    let app = Application(
+        router: router,
+        configuration: ApplicationConfiguration(
+            address: .hostname(args.host, port: args.port),
+            serverName: "TurboFieldfareServer"))
+    if !args.quiet {
+        print("TurboFieldfareServer listening on http://\(args.host):\(args.port) (model: \(args.modelID))")
+    }
+    try await app.runService()
+}

--- a/Sources/TurboFieldfareServer/Core/ServerArgs.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerArgs.swift
@@ -1,0 +1,113 @@
+import Foundation
+
+/// Hand-rolled flag parsing, matching the style of the CLI and repack tools.
+public struct ServerArgs: Equatable, Sendable {
+    public var model: String
+    public var host: String
+    public var port: Int
+    public var maxContext: Int
+    public var modelID: String
+    public var quiet: Bool
+
+    public init(model: String,
+                host: String = "127.0.0.1",
+                port: Int = 1234,
+                maxContext: Int = 4096,
+                modelID: String = "gemma-4-26b-a4b-it-4bit",
+                quiet: Bool = false) {
+        self.model = model
+        self.host = host
+        self.port = port
+        self.maxContext = maxContext
+        self.modelID = modelID
+        self.quiet = quiet
+    }
+}
+
+public enum ServerArgsError: Error, Equatable, CustomStringConvertible {
+    case helpRequested
+    case unknownFlag(String)
+    case missingValue(flag: String)
+    case invalidValue(flag: String, value: String)
+    case requiredMissing(String)
+
+    public var description: String {
+        switch self {
+        case .helpRequested: return "help requested"
+        case .unknownFlag(let flag): return "unknown flag: \(flag)"
+        case .missingValue(let flag): return "missing value for \(flag)"
+        case .invalidValue(let flag, let value): return "invalid value for \(flag): \(value)"
+        case .requiredMissing(let flag): return "required flag missing: \(flag)"
+        }
+    }
+}
+
+extension ServerArgs {
+    public static let usage = """
+    TurboFieldfareServer — OpenAI-compatible HTTP API for Gemma 4 26B-A4B
+
+    usage: TurboFieldfareServer --model <dir> [options]
+
+    required:
+      --model <dir>             Path to a .gturbo model directory.
+
+    options:
+      --host <string>           Bind address (default 127.0.0.1).
+      --port <int>              Bind port (default 1234).
+      --max-context <int>       Context limit in tokens (default 4096).
+      --model-id <string>       Model id reported by /v1/models
+                                (default gemma-4-26b-a4b-it-4bit).
+      --quiet                   Suppress the startup banner.
+      --help                    Show this message.
+    """
+
+    public static func parse(_ argv: [String]) throws -> ServerArgs {
+        var parsed = ServerArgs(model: "")
+        var model: String?
+
+        var index = 0
+        while index < argv.count {
+            let flag = argv[index]
+            switch flag {
+            case "--help":
+                throw ServerArgsError.helpRequested
+            case "--quiet":
+                parsed.quiet = true
+                index += 1
+            case "--model":
+                model = try takeValue(argv, &index, flag: flag)
+            case "--host":
+                parsed.host = try takeValue(argv, &index, flag: flag)
+            case "--port":
+                let value = try takeValue(argv, &index, flag: flag)
+                guard let port = Int(value), (1...65535).contains(port) else {
+                    throw ServerArgsError.invalidValue(flag: flag, value: value)
+                }
+                parsed.port = port
+            case "--max-context":
+                let value = try takeValue(argv, &index, flag: flag)
+                guard let maxContext = Int(value), maxContext > 0 else {
+                    throw ServerArgsError.invalidValue(flag: flag, value: value)
+                }
+                parsed.maxContext = maxContext
+            case "--model-id":
+                parsed.modelID = try takeValue(argv, &index, flag: flag)
+            default:
+                throw ServerArgsError.unknownFlag(flag)
+            }
+        }
+
+        guard let model else { throw ServerArgsError.requiredMissing("--model") }
+        parsed.model = model
+        return parsed
+    }
+
+    private static func takeValue(_ argv: [String],
+                                  _ index: inout Int,
+                                  flag: String) throws -> String {
+        guard index + 1 < argv.count else { throw ServerArgsError.missingValue(flag: flag) }
+        let value = argv[index + 1]
+        index += 2
+        return value
+    }
+}

--- a/Tests/TurboFieldfareServer/AnthropicRoutesTests.swift
+++ b/Tests/TurboFieldfareServer/AnthropicRoutesTests.swift
@@ -1,0 +1,341 @@
+import Foundation
+import Hummingbird
+import HummingbirdTesting
+import NIOCore
+import Testing
+@testable import TurboFieldfareServerCore
+
+/// End-to-end tests for the Anthropic Messages endpoint, backed by the fake
+/// generator. No Metal, no model files.
+@Suite("Anthropic messages route")
+struct AnthropicRoutesTests {
+    private func makeApp(generator: FakeTokenGenerator = FakeTokenGenerator(),
+                         maxContext: Int = 64) -> some ApplicationProtocol {
+        let session = GenerationSession(modelID: "test-model",
+                                        maxContext: maxContext,
+                                        created: 1_700_000_000,
+                                        generator: generator)
+        return Application(router: buildServerRouter(session: session))
+    }
+
+    private func jsonBody(_ json: String) -> ByteBuffer {
+        ByteBuffer(string: json)
+    }
+
+    private func jsonObject(_ buffer: ByteBuffer) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: buffer) as? [String: Any])
+    }
+
+    @Test func nonStreamingHappyPath() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"model": "claude-x", "max_tokens": 10,
+                 "messages": [{"role": "user", "content": "hi"}]}
+                """#)
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(response.head.headerFields[.contentType] == "application/json")
+                let object = try jsonObject(response.body)
+                #expect(object["type"] as? String == "message")
+                #expect(object["role"] as? String == "assistant")
+                #expect(object["model"] as? String == "test-model")
+                #expect((object["id"] as? String)?.hasPrefix("msg_") == true)
+                let content = try #require(object["content"] as? [[String: Any]])
+                #expect(content.count == 1)
+                #expect(content[0]["type"] as? String == "text")
+                #expect(content[0]["text"] as? String == "Hello, world")
+                #expect(object["stop_reason"] as? String == "end_turn")
+                #expect(object["stop_sequence"] is NSNull)
+                let usage = try #require(object["usage"] as? [String: Any])
+                #expect(usage["input_tokens"] as? Int == 8)
+                #expect(usage["output_tokens"] as? Int == 2)
+            }
+        }
+    }
+
+    @Test func finishReasonLengthMapsToMaxTokens() async throws {
+        let generator = FakeTokenGenerator()
+        generator.finishReason = .length
+        try await makeApp(generator: generator).test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"max_tokens": 10, "messages": [{"role": "user", "content": "hi"}]}
+                """#)
+            ) { response in
+                #expect(response.status == .ok)
+                let object = try jsonObject(response.body)
+                #expect(object["stop_reason"] as? String == "max_tokens")
+            }
+        }
+    }
+
+    @Test func systemStringAndBlocksBecomeLeadingSystemMessage() async throws {
+        let generator = FakeTokenGenerator()
+        try await makeApp(generator: generator).test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"max_tokens": 10, "system": "be terse",
+                 "messages": [{"role": "user", "content": "hi"}]}
+                """#)
+            ) { response in
+                #expect(response.status == .ok)
+            }
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"max_tokens": 10,
+                 "system": [{"type": "text", "text": "be "}, {"type": "text", "text": "terse"}],
+                 "messages": [{"role": "user", "content": "hi"}]}
+                """#)
+            ) { response in
+                #expect(response.status == .ok)
+            }
+        }
+        let calls = await generator.calls
+        #expect(calls.count == 2)
+        for call in calls {
+            guard case .chat(let messages) = call.input else {
+                Issue.record("expected chat input")
+                continue
+            }
+            #expect(messages.first?.role == "system")
+            #expect(messages.first?.content == "be terse")
+            #expect(messages.count == 2)
+            #expect(messages[1].role == "user")
+        }
+    }
+
+    @Test func contentBlocksConcatenated() async throws {
+        let generator = FakeTokenGenerator()
+        try await makeApp(generator: generator).test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"max_tokens": 10,
+                 "messages": [{"role": "user",
+                               "content": [{"type": "text", "text": "Hello"},
+                                           {"type": "text", "text": " world"}]}]}
+                """#)
+            ) { response in
+                #expect(response.status == .ok)
+            }
+        }
+        let calls = await generator.calls
+        guard case .chat(let messages) = calls.first?.input else {
+            Issue.record("expected chat input")
+            return
+        }
+        #expect(messages.first?.role == "user")
+        #expect(messages.first?.content == "Hello world")
+    }
+
+    @Test func missingMaxTokensRejected() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"{"messages": [{"role": "user", "content": "hi"}]}"#)
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                #expect(object["type"] as? String == "error")
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "invalid_request_error")
+                #expect((error["message"] as? String)?.contains("max_tokens") == true)
+            }
+        }
+    }
+
+    @Test func zeroMaxTokensRejected() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"max_tokens": 0, "messages": [{"role": "user", "content": "hi"}]}
+                """#)
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "invalid_request_error")
+                #expect((error["message"] as? String)?.contains("max_tokens") == true)
+            }
+        }
+    }
+
+    @Test func toolRoleRejected() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"max_tokens": 10, "messages": [{"role": "tool", "content": "x"}]}
+                """#)
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "invalid_request_error")
+                #expect((error["message"] as? String)?.contains("tool") == true)
+            }
+        }
+    }
+
+    @Test func unsupportedParametersRejected() async throws {
+        try await makeApp().test(.router) { client in
+            for field in [#""tools": []"#, #""tool_choice": {"type": "auto"}"#,
+                          #""thinking": {"type": "enabled"}"#, #""metadata": {}"#] {
+                try await client.execute(
+                    uri: "/v1/messages",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: jsonBody(#"{"max_tokens": 10, "messages": [{"role": "user", "content": "hi"}], \#(field)}"#)
+                ) { response in
+                    #expect(response.status == .badRequest)
+                    let object = try jsonObject(response.body)
+                    let error = try #require(object["error"] as? [String: Any])
+                    #expect(error["type"] as? String == "invalid_request_error")
+                }
+            }
+        }
+    }
+
+    @Test func streamingEventOrder() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"max_tokens": 10, "stream": true,
+                 "messages": [{"role": "user", "content": "hi"}]}
+                """#)
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(response.head.headerFields[.contentType] == "text/event-stream")
+                let body = String(buffer: response.body)
+                #expect(!body.contains("[DONE]"))
+
+                let frames = body.components(separatedBy: "\n\n").filter { !$0.isEmpty }
+                // message_start, content_block_start, 2 deltas,
+                // content_block_stop, message_delta, message_stop
+                #expect(frames.count == 7)
+
+                let events = frames.map { frame -> String in
+                    #expect(frame.hasPrefix("event: "))
+                    return String(frame.dropFirst("event: ".count).prefix { $0 != "\n" })
+                }
+                #expect(events == ["message_start", "content_block_start",
+                                 "content_block_delta", "content_block_delta",
+                                 "content_block_stop", "message_delta", "message_stop"])
+
+                func frameData(_ index: Int) throws -> [String: Any] {
+                    let frame = frames[index]
+                    let dataStart = try #require(frame.range(of: "\ndata: "))
+                    return try jsonObject(ByteBuffer(string: String(frame[dataStart.upperBound...])))
+                }
+
+                let messageStart = try frameData(0)
+                #expect(messageStart["type"] as? String == "message_start")
+                let message = try #require(messageStart["message"] as? [String: Any])
+                #expect((message["id"] as? String)?.hasPrefix("msg_") == true)
+                #expect(message["type"] as? String == "message")
+                #expect(message["role"] as? String == "assistant")
+                #expect(message["model"] as? String == "test-model")
+                #expect((message["content"] as? [[String: Any]])?.isEmpty == true)
+                #expect(message["stop_reason"] is NSNull)
+                #expect(message["stop_sequence"] is NSNull)
+                let startUsage = try #require(message["usage"] as? [String: Any])
+                #expect(startUsage["input_tokens"] as? Int == 8)
+                #expect(startUsage["output_tokens"] as? Int == 1)
+
+                let blockStart = try frameData(1)
+                #expect(blockStart["type"] as? String == "content_block_start")
+                #expect(blockStart["index"] as? Int == 0)
+                let block = try #require(blockStart["content_block"] as? [String: Any])
+                #expect(block["type"] as? String == "text")
+                #expect(block["text"] as? String == "")
+
+                let firstDelta = try frameData(2)
+                #expect(firstDelta["type"] as? String == "content_block_delta")
+                let delta = try #require(firstDelta["delta"] as? [String: Any])
+                #expect(delta["type"] as? String == "text_delta")
+                #expect(delta["text"] as? String == "Hello")
+
+                let blockStop = try frameData(4)
+                #expect(blockStop["type"] as? String == "content_block_stop")
+                #expect(blockStop["index"] as? Int == 0)
+
+                let messageDelta = try frameData(5)
+                #expect(messageDelta["type"] as? String == "message_delta")
+                let stopDelta = try #require(messageDelta["delta"] as? [String: Any])
+                #expect(stopDelta["stop_reason"] as? String == "end_turn")
+                #expect(stopDelta["stop_sequence"] is NSNull)
+                let deltaUsage = try #require(messageDelta["usage"] as? [String: Any])
+                #expect(deltaUsage["output_tokens"] as? Int == 2)
+
+                let messageStop = try frameData(6)
+                #expect(messageStop["type"] as? String == "message_stop")
+            }
+        }
+    }
+
+    @Test func generationFailureReturnsSanitizedAPIError() async throws {
+        struct Boom: Error {}
+        let generator = FakeTokenGenerator()
+        generator.thrownError = Boom()
+        try await makeApp(generator: generator).test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {"max_tokens": 10, "messages": [{"role": "user", "content": "hi"}]}
+                """#)
+            ) { response in
+                #expect(response.status == .internalServerError)
+                let object = try jsonObject(response.body)
+                #expect(object["type"] as? String == "error")
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "api_error")
+                #expect(error["message"] as? String == "generation failed")
+            }
+        }
+    }
+
+    @Test func malformedJSONReturnsAnthropicError() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/messages",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody("{not json")
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                #expect(object["type"] as? String == "error")
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "invalid_request_error")
+                #expect(error["message"] != nil)
+            }
+        }
+    }
+}

--- a/Tests/TurboFieldfareServer/GenerationSessionTests.swift
+++ b/Tests/TurboFieldfareServer/GenerationSessionTests.swift
@@ -299,6 +299,63 @@ struct GenerationSessionTests {
                                              sampling: SamplingParams())
         #expect(outcome.text == "Hello, world")
     }
+
+    /// max_tokens near Int.max must produce a 400-class error, not trap on
+    /// checked `promptTokens + requested` overflow and kill the process.
+    @Test func hugeMaxTokensRejectedWithoutOverflow() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(
+            throws: GenerationRequestError.contextOverflow(prompt: 8, maxTokens: Int.max, maxContext: 64)
+        ) {
+            try await session.chat(
+                messages: [ChatMessage(role: "user", content: "hi")],
+                sampling: SamplingParams(maxTokens: Int.max))
+        }
+    }
+
+    /// +Inf passes `temperature >= 0` and would otherwise fail deep in the
+    /// runtime; reject it at the boundary like any other invalid value.
+    @Test func infiniteTemperatureRejected() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(throws: GenerationRequestError.unsupportedParameter("temperature must be >= 0")) {
+            try await session.chat(messages: [ChatMessage(role: "user", content: "hi")],
+                                   sampling: SamplingParams(temperature: .infinity))
+        }
+    }
+
+    /// A task cancelled exactly when the free slot is handed to it must not
+    /// wedge the slot: releaseSlot is installed before the cancellation
+    /// check, so the next request still runs.
+    @Test func slotReleasedWhenCancelledAtHandoff() async throws {
+        struct Timeout: Error {}
+        let generator = FakeTokenGenerator()
+        let session = makeSession(generator)
+
+        let cancelled = Task {
+            try await session.chat(messages: [ChatMessage(role: "user", content: "hi")],
+                                   sampling: SamplingParams())
+        }
+        cancelled.cancel()
+        _ = try? await cancelled.value
+
+        // If the slot stayed wedged this hangs; bound the wait so the
+        // regression fails instead of stalling the suite.
+        try await withThrowingTaskGroup(of: String.self) { group in
+            group.addTask {
+                let outcome = try await session.chat(
+                    messages: [ChatMessage(role: "user", content: "next")],
+                    sampling: SamplingParams())
+                return outcome.text
+            }
+            group.addTask {
+                try await Task.sleep(nanoseconds: 5_000_000_000)
+                throw Timeout()
+            }
+            let text = try await group.next()
+            group.cancelAll()
+            #expect(text == "Hello, world")
+        }
+    }
 }
 
 @Suite("StopReason to finish_reason mapping")

--- a/Tests/TurboFieldfareServer/GenerationSessionTests.swift
+++ b/Tests/TurboFieldfareServer/GenerationSessionTests.swift
@@ -1,0 +1,312 @@
+import Foundation
+import Synchronization
+import Testing
+@testable import TurboFieldfareServerCore
+
+/// Metal-free fake for the runtime seam. Emits canned deltas and lets tests
+/// script outcomes and observe concurrency.
+final class FakeTokenGenerator: TokenGenerating, @unchecked Sendable {
+    struct Call: Sendable {
+        var input: GenerationInput
+        var effectiveMaxTokens: Int
+    }
+
+    /// Records actor-style entry/exit so tests can assert serialization.
+    actor OverlapTracker {
+        private(set) var active = 0
+        private(set) var maxActive = 0
+        private(set) var events: [String] = []
+        private(set) var calls: [Call] = []
+
+        func record(_ call: Call) {
+            calls.append(call)
+        }
+
+        func enter(_ tag: String) {
+            active += 1
+            maxActive = max(maxActive, active)
+            events.append("+\(tag)")
+        }
+
+        func exit(_ tag: String) {
+            active -= 1
+            events.append("-\(tag)")
+        }
+    }
+
+    let tracker = OverlapTracker()
+    /// Canned deltas emitted via onDelta, in order.
+    var deltas: [String] = ["Hello", ", world"]
+    var finishReason: FinishReason = .stop
+    var promptTokenCount = 8
+    /// Artificial decode time so overlapping calls would be observable.
+    var latencyNanoseconds: UInt64 = 20_000_000
+
+    var calls: [Call] {
+        get async { await tracker.calls }
+    }
+
+    /// When set, generate throws this after entering (simulates a mid-flight
+    /// runtime failure).
+    var thrownError: (any Error)?
+
+    /// Tag derived from the input, used in overlap events.
+    private func tag(for input: GenerationInput) -> String {
+        switch input {
+        case .chat(let messages): return messages.last?.content ?? "chat"
+        case .raw(let prompt): return prompt
+        }
+    }
+
+    func tokenCount(for input: GenerationInput) throws -> Int {
+        promptTokenCount
+    }
+
+    func generate(_ input: GenerationInput,
+                  sampling: SamplingParams,
+                  effectiveMaxTokens: Int,
+                  onDelta: (@Sendable (String) -> Void)?) async throws -> GenerationOutcome {
+        let tag = tag(for: input)
+        await tracker.record(Call(input: input, effectiveMaxTokens: effectiveMaxTokens))
+        await tracker.enter(tag)
+        if let thrownError {
+            await tracker.exit(tag)
+            throw thrownError
+        }
+        try? await Task.sleep(nanoseconds: latencyNanoseconds)
+        var text = ""
+        for delta in deltas {
+            text += delta
+            onDelta?(delta)
+        }
+        await tracker.exit(tag)
+        return GenerationOutcome(text: text,
+                                 promptTokens: promptTokenCount,
+                                 completionTokens: deltas.count,
+                                 finishReason: finishReason)
+    }
+}
+
+@Suite("GenerationSession")
+struct GenerationSessionTests {
+    private func makeSession(_ generator: FakeTokenGenerator,
+                             maxContext: Int = 64) -> GenerationSession {
+        GenerationSession(modelID: "test-model", maxContext: maxContext, generator: generator)
+    }
+
+    @Test func assistantRoleAccepted() async throws {
+        let generator = FakeTokenGenerator()
+        let session = makeSession(generator)
+        let outcome = try await session.chat(
+            messages: [ChatMessage(role: "user", content: "hi"),
+                       ChatMessage(role: "assistant", content: "hello"),
+                       ChatMessage(role: "user", content: "again")],
+            sampling: SamplingParams())
+        #expect(outcome.text == "Hello, world")
+        // assistant maps to the template's model turn; the input passed down
+        // keeps the OpenAI role for the tokenizer to render.
+        let calls = await generator.calls
+        guard case .chat(let forwarded) = calls.first?.input else {
+            Issue.record("expected chat input")
+            return
+        }
+        #expect(forwarded[1].role == "assistant")
+    }
+
+    @Test func toolRoleRejected() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(throws: GenerationRequestError.unsupportedRole("tool")) {
+            try await session.chat(
+                messages: [ChatMessage(role: "tool", content: "result")],
+                sampling: SamplingParams())
+        }
+    }
+
+    @Test func functionRoleRejected() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(throws: GenerationRequestError.unsupportedRole("function")) {
+            try await session.chat(
+                messages: [ChatMessage(role: "function", content: "result")],
+                sampling: SamplingParams())
+        }
+    }
+
+    @Test func emptyMessagesRejected() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(throws: GenerationRequestError.emptyMessages) {
+            try await session.chat(messages: [], sampling: SamplingParams())
+        }
+    }
+
+    @Test func deltasStreamedAndUsageComputed() async throws {
+        let generator = FakeTokenGenerator()
+        let session = makeSession(generator)
+        let streamed = Mutex<[String]>([])
+        let outcome = try await session.chat(
+            messages: [ChatMessage(role: "user", content: "hi")],
+            sampling: SamplingParams()) { delta in
+                streamed.withLock { $0.append(delta) }
+            }
+        #expect(streamed.withLock { $0 } == ["Hello", ", world"])
+        #expect(outcome.text == "Hello, world")
+        #expect(outcome.promptTokens == 8)
+        #expect(outcome.completionTokens == 2)
+        #expect(outcome.usage.totalTokens == 10)
+    }
+
+    @Test func explicitMaxTokensOverflowRejected() async {
+        let session = makeSession(FakeTokenGenerator(), maxContext: 10)
+        await #expect(
+            throws: GenerationRequestError.contextOverflow(prompt: 8, maxTokens: 3, maxContext: 10)
+        ) {
+            try await session.chat(
+                messages: [ChatMessage(role: "user", content: "hi")],
+                sampling: SamplingParams(maxTokens: 3))
+        }
+    }
+
+    @Test func absentMaxTokensClampsToRemainingContext() async throws {
+        let generator = FakeTokenGenerator()
+        let session = makeSession(generator, maxContext: 100)
+        _ = try await session.chat(
+            messages: [ChatMessage(role: "user", content: "hi")],
+            sampling: SamplingParams())
+        let calls = await generator.calls
+        #expect(calls.first?.effectiveMaxTokens == 92)
+    }
+
+    @Test func concurrentGenerationsSerializeInOrder() async throws {
+        let generator = FakeTokenGenerator()
+        let session = makeSession(generator)
+
+        async let first = session.chat(
+            messages: [ChatMessage(role: "user", content: "one")],
+            sampling: SamplingParams())
+        // Give the first call a head start so FIFO order is deterministic.
+        try await Task.sleep(nanoseconds: 5_000_000)
+        async let second = session.chat(
+            messages: [ChatMessage(role: "user", content: "two")],
+            sampling: SamplingParams())
+
+        let outcomes = try await [first, second]
+        #expect(outcomes.count == 2)
+
+        let maxActive = await generator.tracker.maxActive
+        let events = await generator.tracker.events
+        #expect(maxActive == 1)
+        #expect(events == ["+one", "-one", "+two", "-two"])
+    }
+
+    @Test func finishReasonStop() async throws {
+        let generator = FakeTokenGenerator()
+        generator.finishReason = .stop
+        let outcome = try await makeSession(generator).complete(prompt: "p", sampling: SamplingParams())
+        #expect(outcome.finishReason == .stop)
+    }
+
+    @Test func finishReasonLength() async throws {
+        let generator = FakeTokenGenerator()
+        generator.finishReason = .length
+        let outcome = try await makeSession(generator).complete(prompt: "p", sampling: SamplingParams())
+        #expect(outcome.finishReason == .length)
+    }
+
+    @Test func zeroMaxTokensRejected() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(throws: GenerationRequestError.unsupportedParameter("max_tokens must be a positive integer")) {
+            try await session.chat(messages: [ChatMessage(role: "user", content: "hi")],
+                                   sampling: SamplingParams(maxTokens: 0))
+        }
+    }
+
+    @Test func negativeMaxTokensRejected() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(throws: GenerationRequestError.unsupportedParameter("max_tokens must be a positive integer")) {
+            try await session.chat(messages: [ChatMessage(role: "user", content: "hi")],
+                                   sampling: SamplingParams(maxTokens: -5))
+        }
+    }
+
+    @Test func negativeTemperatureRejected() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(throws: GenerationRequestError.unsupportedParameter("temperature must be >= 0")) {
+            try await session.chat(messages: [ChatMessage(role: "user", content: "hi")],
+                                   sampling: SamplingParams(temperature: -0.1))
+        }
+    }
+
+    @Test func outOfRangeTopPRejected() async {
+        let session = makeSession(FakeTokenGenerator())
+        await #expect(throws: GenerationRequestError.unsupportedParameter("top_p must be in (0, 1]")) {
+            try await session.chat(messages: [ChatMessage(role: "user", content: "hi")],
+                                   sampling: SamplingParams(topP: 0))
+        }
+        await #expect(throws: GenerationRequestError.unsupportedParameter("top_p must be in (0, 1]")) {
+            try await session.chat(messages: [ChatMessage(role: "user", content: "hi")],
+                                   sampling: SamplingParams(topP: 1.5))
+        }
+    }
+
+    /// A waiter cancelled while parked in the slot queue must be removed and
+    /// never run; the queued-behind request still gets served.
+    @Test func cancelledWaiterNeverRuns() async throws {
+        let generator = FakeTokenGenerator()
+        generator.latencyNanoseconds = 50_000_000
+        let session = makeSession(generator)
+
+        async let first = session.chat(
+            messages: [ChatMessage(role: "user", content: "one")],
+            sampling: SamplingParams())
+        try await Task.sleep(nanoseconds: 5_000_000)
+
+        let parked = Task {
+            try await session.chat(
+                messages: [ChatMessage(role: "user", content: "parked")],
+                sampling: SamplingParams())
+        }
+        try await Task.sleep(nanoseconds: 5_000_000)
+        parked.cancel()
+
+        await #expect(throws: CancellationError.self) { try await parked.value }
+        _ = try await first
+
+        let calls = await generator.calls
+        #expect(calls.count == 1)
+        let events = await generator.tracker.events
+        #expect(events == ["+one", "-one"])
+
+        // Slot was released: a fresh request runs to completion.
+        _ = try await session.chat(messages: [ChatMessage(role: "user", content: "three")],
+                                   sampling: SamplingParams())
+        let finalCalls = await generator.calls
+        #expect(finalCalls.count == 2)
+    }
+
+    /// A generator failure must free the slot; the next request is served.
+    @Test func slotReleasedOnGenerationError() async throws {
+        struct Boom: Error {}
+        let generator = FakeTokenGenerator()
+        let session = makeSession(generator)
+
+        generator.thrownError = Boom()
+        await #expect(throws: Boom.self) {
+            try await session.chat(messages: [ChatMessage(role: "user", content: "one")],
+                                   sampling: SamplingParams())
+        }
+
+        generator.thrownError = nil
+        let outcome = try await session.chat(messages: [ChatMessage(role: "user", content: "two")],
+                                             sampling: SamplingParams())
+        #expect(outcome.text == "Hello, world")
+    }
+}
+
+@Suite("StopReason to finish_reason mapping")
+struct StopReasonMappingTests {
+    @Test func mapping() {
+        // The mapping itself lives in the Metal-backed generator; these pin
+        // the contract it implements against the runtime's StopReason cases.
+        #expect(FinishReason.stop.rawValue == "stop")
+        #expect(FinishReason.length.rawValue == "length")
+    }
+}

--- a/Tests/TurboFieldfareServer/OpenAITypesTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAITypesTests.swift
@@ -76,12 +76,29 @@ struct ChatCompletionRequestDecodingTests {
         {
           "messages": [{"role": "user", "content": "hi"}],
           "frequency_penalty": 0.5,
-          "logit_bias": {"1": 2},
-          "tools": [{"type": "function"}],
-          "response_format": {"type": "json_object"}
+          "logit_bias": {"1": 2}
         }
         """#)
         #expect(request.messages.count == 1)
+        #expect(!request.hasTools)
+        #expect(!request.hasToolChoice)
+        #expect(!request.hasResponseFormat)
+    }
+
+    @Test func unsupportedSemanticFieldsTracked() throws {
+        let request = try decode(#"""
+        {
+          "messages": [{"role": "user", "content": "hi"}],
+          "tools": [{"type": "function"}],
+          "tool_choice": "auto",
+          "response_format": {"type": "json_object"}
+        }
+        """#)
+        // Presence is tracked so the route layer can reject these with a 400
+        // instead of silently ignoring semantics the runtime cannot honor.
+        #expect(request.hasTools)
+        #expect(request.hasToolChoice)
+        #expect(request.hasResponseFormat)
     }
 
     @Test func nIsDecoded() throws {

--- a/Tests/TurboFieldfareServer/OpenAITypesTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAITypesTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareServerCore
+
+@Suite("ChatCompletionRequest decoding")
+struct ChatCompletionRequestDecodingTests {
+    private func decode(_ json: String) throws -> ChatCompletionRequest {
+        try JSONDecoder().decode(ChatCompletionRequest.self, from: Data(json.utf8))
+    }
+
+    @Test func fullBody() throws {
+        let request = try decode(#"""
+        {
+          "model": "gemma",
+          "messages": [
+            {"role": "system", "content": "be brief"},
+            {"role": "user", "content": "hi"}
+          ],
+          "temperature": 0.7,
+          "top_p": 0.9,
+          "max_tokens": 128,
+          "stop": ["</s>", "END"],
+          "seed": 42,
+          "stream": true,
+          "stream_options": {"include_usage": true},
+          "n": 1
+        }
+        """#)
+        #expect(request.model == "gemma")
+        #expect(request.messages.count == 2)
+        #expect(request.messages[0] == ChatMessage(role: "system", content: "be brief"))
+        #expect(request.temperature == 0.7)
+        #expect(request.topP == 0.9)
+        #expect(request.maxTokens == 128)
+        #expect(request.stop == .multiple(["</s>", "END"]))
+        #expect(request.seed == 42)
+        #expect(request.stream == true)
+        #expect(request.streamOptions?.includeUsage == true)
+        #expect(request.n == 1)
+    }
+
+    @Test func minimalBody() throws {
+        let request = try decode(#"{"messages": [{"role": "user", "content": "hi"}]}"#)
+        #expect(request.messages.count == 1)
+        #expect(request.model == nil)
+        #expect(request.temperature == nil)
+        #expect(request.maxTokens == nil)
+        #expect(request.stop == nil)
+        #expect(request.stream == nil)
+        #expect(request.n == nil)
+    }
+
+    @Test func stopAsString() throws {
+        let request = try decode(#"{"messages": [], "stop": "halt"}"#)
+        #expect(request.stop == .single("halt"))
+        #expect(request.stop?.values == ["halt"])
+    }
+
+    @Test func stopAsArray() throws {
+        let request = try decode(#"{"messages": [], "stop": ["a", "b"]}"#)
+        #expect(request.stop?.values == ["a", "b"])
+    }
+
+    @Test func maxCompletionTokensAlias() throws {
+        let request = try decode(#"{"messages": [], "max_completion_tokens": 64}"#)
+        #expect(request.maxTokens == 64)
+    }
+
+    @Test func maxTokensWinsOverAlias() throws {
+        let request = try decode(#"{"messages": [], "max_tokens": 32, "max_completion_tokens": 64}"#)
+        #expect(request.maxTokens == 32)
+    }
+
+    @Test func unknownFieldsIgnored() throws {
+        let request = try decode(#"""
+        {
+          "messages": [{"role": "user", "content": "hi"}],
+          "frequency_penalty": 0.5,
+          "logit_bias": {"1": 2},
+          "tools": [{"type": "function"}],
+          "response_format": {"type": "json_object"}
+        }
+        """#)
+        #expect(request.messages.count == 1)
+    }
+
+    @Test func nIsDecoded() throws {
+        let request = try decode(#"{"messages": [], "n": 2}"#)
+        #expect(request.n == 2)
+    }
+}
+
+@Suite("CompletionRequest decoding")
+struct CompletionRequestDecodingTests {
+    @Test func promptAndOptions() throws {
+        let request = try JSONDecoder().decode(
+            CompletionRequest.self,
+            from: Data(#"{"prompt": "once upon a time", "max_tokens": 10, "stream": true}"#.utf8))
+        #expect(request.prompt == "once upon a time")
+        #expect(request.maxTokens == 10)
+        #expect(request.stream == true)
+    }
+}

--- a/Tests/TurboFieldfareServer/RoutesTests.swift
+++ b/Tests/TurboFieldfareServer/RoutesTests.swift
@@ -1,0 +1,246 @@
+import Foundation
+import Hummingbird
+import HummingbirdTesting
+import NIOCore
+import Testing
+@testable import TurboFieldfareServerCore
+
+/// End-to-end route tests against the router, backed by the fake generator.
+/// No Metal, no model files.
+@Suite("HTTP routes")
+struct RoutesTests {
+    private func makeApp(generator: FakeTokenGenerator = FakeTokenGenerator(),
+                         maxContext: Int = 64) -> some ApplicationProtocol {
+        let session = GenerationSession(modelID: "test-model",
+                                        maxContext: maxContext,
+                                        created: 1_700_000_000,
+                                        generator: generator)
+        return Application(router: buildServerRouter(session: session))
+    }
+
+    private func jsonBody(_ json: String) -> ByteBuffer {
+        ByteBuffer(string: json)
+    }
+
+    private func jsonObject(_ buffer: ByteBuffer) throws -> [String: Any] {
+        try #require(JSONSerialization.jsonObject(with: buffer) as? [String: Any])
+    }
+
+    @Test func health() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(uri: "/health", method: .get) { response in
+                #expect(response.status == .ok)
+                let object = try jsonObject(response.body)
+                #expect(object["status"] as? String == "ok")
+            }
+        }
+    }
+
+    @Test func models() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(uri: "/v1/models", method: .get) { response in
+                #expect(response.status == .ok)
+                let object = try jsonObject(response.body)
+                #expect(object["object"] as? String == "list")
+                let data = try #require(object["data"] as? [[String: Any]])
+                #expect(data.count == 1)
+                #expect(data[0]["id"] as? String == "test-model")
+                #expect(data[0]["object"] as? String == "model")
+                #expect(data[0]["created"] as? Int == 1_700_000_000)
+                #expect(data[0]["owned_by"] as? String == "local")
+            }
+        }
+    }
+
+    @Test func chatCompletionNonStreaming() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"{"messages": [{"role": "user", "content": "hi"}]}"#)
+            ) { response in
+                #expect(response.status == .ok)
+                let object = try jsonObject(response.body)
+                #expect(object["object"] as? String == "chat.completion")
+                #expect(object["model"] as? String == "test-model")
+                #expect((object["id"] as? String)?.hasPrefix("chatcmpl-") == true)
+                let choices = try #require(object["choices"] as? [[String: Any]])
+                #expect(choices.count == 1)
+                let message = try #require(choices[0]["message"] as? [String: Any])
+                #expect(message["role"] as? String == "assistant")
+                #expect(message["content"] as? String == "Hello, world")
+                #expect(choices[0]["finish_reason"] as? String == "stop")
+                let usage = try #require(object["usage"] as? [String: Any])
+                #expect(usage["prompt_tokens"] as? Int == 8)
+                #expect(usage["completion_tokens"] as? Int == 2)
+                #expect(usage["total_tokens"] as? Int == 10)
+            }
+        }
+    }
+
+    @Test func chatCompletionRejectsNGreaterThanOne() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"{"messages": [{"role": "user", "content": "hi"}], "n": 2}"#)
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "invalid_request_error")
+                #expect(error["message"] != nil)
+            }
+        }
+    }
+
+    @Test func chatCompletionRejectsToolRole() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"{"messages": [{"role": "tool", "content": "x"}]}"#)
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "invalid_request_error")
+                #expect((error["message"] as? String)?.contains("tool") == true)
+            }
+        }
+    }
+
+    @Test func chatCompletionRejectsContextOverflow() async throws {
+        try await makeApp(maxContext: 10).test(.router) { client in
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"{"messages": [{"role": "user", "content": "hi"}], "max_tokens": 5}"#)
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                let error = try #require(object["error"] as? [String: Any])
+                #expect((error["message"] as? String)?.contains("context overflow") == true)
+            }
+        }
+    }
+
+    @Test func chatCompletionStreaming() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"""
+                {
+                  "messages": [{"role": "user", "content": "hi"}],
+                  "stream": true,
+                  "stream_options": {"include_usage": true}
+                }
+                """#)
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(response.head.headerFields[.contentType] == "text/event-stream")
+                let body = String(buffer: response.body)
+                #expect(body.hasSuffix("data: [DONE]\n\n"))
+
+                let frames = body.components(separatedBy: "\n\n").filter { !$0.isEmpty }
+                // role chunk + 2 content chunks + final chunk + usage chunk + [DONE]
+                #expect(frames.count == 6)
+                for frame in frames.dropLast() {
+                    #expect(frame.hasPrefix("data: "))
+                }
+                #expect(frames.last == "data: [DONE]")
+
+                let roleChunk = try jsonObject(
+                    ByteBuffer(string: String(frames[0].dropFirst("data: ".count))))
+                #expect(roleChunk["object"] as? String == "chat.completion.chunk")
+                let roleChoices = try #require(roleChunk["choices"] as? [[String: Any]])
+                #expect((roleChoices[0]["delta"] as? [String: Any])?["role"] as? String == "assistant")
+
+                let firstDelta = try jsonObject(
+                    ByteBuffer(string: String(frames[1].dropFirst("data: ".count))))
+                let deltaChoices = try #require(firstDelta["choices"] as? [[String: Any]])
+                #expect((deltaChoices[0]["delta"] as? [String: Any])?["content"] as? String == "Hello")
+
+                let finalChunk = try jsonObject(
+                    ByteBuffer(string: String(frames[3].dropFirst("data: ".count))))
+                let finalChoices = try #require(finalChunk["choices"] as? [[String: Any]])
+                #expect(finalChoices[0]["finish_reason"] as? String == "stop")
+
+                let usageChunk = try jsonObject(
+                    ByteBuffer(string: String(frames[4].dropFirst("data: ".count))))
+                let usage = try #require(usageChunk["usage"] as? [String: Any])
+                #expect(usage["total_tokens"] as? Int == 10)
+                #expect((usageChunk["choices"] as? [[String: Any]])?.isEmpty == true)
+            }
+        }
+    }
+
+    @Test func completionNonStreaming() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"{"prompt": "once upon a time", "max_tokens": 10}"#)
+            ) { response in
+                #expect(response.status == .ok)
+                let object = try jsonObject(response.body)
+                #expect(object["object"] as? String == "text_completion")
+                #expect((object["id"] as? String)?.hasPrefix("cmpl-") == true)
+                let choices = try #require(object["choices"] as? [[String: Any]])
+                #expect(choices[0]["text"] as? String == "Hello, world")
+                #expect(choices[0]["finish_reason"] as? String == "stop")
+                let usage = try #require(object["usage"] as? [String: Any])
+                #expect(usage["total_tokens"] as? Int == 10)
+            }
+        }
+    }
+
+    @Test func completionStreamingFinishReasonLength() async throws {
+        let generator = FakeTokenGenerator()
+        generator.finishReason = .length
+        try await makeApp(generator: generator).test(.router) { client in
+            try await client.execute(
+                uri: "/v1/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"{"prompt": "p", "stream": true}"#)
+            ) { response in
+                #expect(response.status == .ok)
+                #expect(response.head.headerFields[.contentType] == "text/event-stream")
+                let body = String(buffer: response.body)
+                #expect(body.hasSuffix("data: [DONE]\n\n"))
+                let frames = body.components(separatedBy: "\n\n").filter { !$0.isEmpty }
+                // 2 content chunks + final chunk + [DONE]
+                #expect(frames.count == 4)
+                let finalChunk = try jsonObject(
+                    ByteBuffer(string: String(frames[2].dropFirst("data: ".count))))
+                #expect(finalChunk["object"] as? String == "text_completion")
+                let choices = try #require(finalChunk["choices"] as? [[String: Any]])
+                #expect(choices[0]["finish_reason"] as? String == "length")
+            }
+        }
+    }
+
+    @Test func malformedJSONReturnsOpenAIError() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody("{not json")
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "invalid_request_error")
+            }
+        }
+    }
+}

--- a/Tests/TurboFieldfareServer/RoutesTests.swift
+++ b/Tests/TurboFieldfareServer/RoutesTests.swift
@@ -96,6 +96,59 @@ struct RoutesTests {
         }
     }
 
+    @Test func chatCompletionRejectsNZero() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                body: jsonBody(#"{"messages": [{"role": "user", "content": "hi"}], "n": 0}"#)
+            ) { response in
+                #expect(response.status == .badRequest)
+            }
+        }
+    }
+
+    @Test func chatCompletionRejectsUnsupportedSemanticFields() async throws {
+        let bodies = [
+            #"{"messages": [{"role": "user", "content": "hi"}], "tools": [{"type": "function"}]}"#,
+            #"{"messages": [{"role": "user", "content": "hi"}], "tool_choice": "auto"}"#,
+            #"{"messages": [{"role": "user", "content": "hi"}], "response_format": {"type": "json_object"}}"#,
+        ]
+        for body in bodies {
+            try await makeApp().test(.router) { client in
+                try await client.execute(
+                    uri: "/v1/chat/completions",
+                    method: .post,
+                    headers: [.contentType: "application/json"],
+                    body: jsonBody(body)
+                ) { response in
+                    #expect(response.status == .badRequest)
+                    let object = try jsonObject(response.body)
+                    let error = try #require(object["error"] as? [String: Any])
+                    #expect(error["type"] as? String == "invalid_request_error")
+                }
+            }
+        }
+    }
+
+    @Test func chatCompletionRejectsHugeMaxTokens() async throws {
+        try await makeApp().test(.router) { client in
+            try await client.execute(
+                uri: "/v1/chat/completions",
+                method: .post,
+                headers: [.contentType: "application/json"],
+                // Int.max must yield a 400, not an integer-overflow trap.
+                body: jsonBody(#"{"messages": [{"role": "user", "content": "hi"}], "max_tokens": 9223372036854775807}"#)
+            ) { response in
+                #expect(response.status == .badRequest)
+                let object = try jsonObject(response.body)
+                let error = try #require(object["error"] as? [String: Any])
+                #expect(error["type"] as? String == "invalid_request_error")
+            }
+        }
+    }
+
     @Test func chatCompletionRejectsToolRole() async throws {
         try await makeApp().test(.router) { client in
             try await client.execute(

--- a/Tests/TurboFieldfareServer/SSEFramerTests.swift
+++ b/Tests/TurboFieldfareServer/SSEFramerTests.swift
@@ -1,0 +1,86 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareServerCore
+
+@Suite("SSE framing")
+struct SSEFramerTests {
+    @Test func frameWrapsJSONWithDataPrefixAndBlankLine() throws {
+        struct Probe: Encodable { var value: Int }
+        let frame = try SSEFramer.frame(Probe(value: 7))
+        let text = String(decoding: frame, as: UTF8.self)
+        #expect(text.hasPrefix("data: "))
+        #expect(text.hasSuffix("\n\n"))
+        #expect(text == "data: {\"value\":7}\n\n")
+    }
+
+    @Test func doneSentinel() {
+        #expect(String(decoding: SSEFramer.doneFrame, as: UTF8.self) == "data: [DONE]\n\n")
+    }
+
+    @Test func chatChunkSerializesOpenAIShape() throws {
+        let chunk = ChatCompletionChunk(
+            id: "chatcmpl-x",
+            created: 123,
+            model: "m",
+            choices: [ChatChunkChoice(index: 0,
+                                      delta: ChatChunkDelta(content: "hi"),
+                                      finishReason: nil)])
+        let frame = try SSEFramer.frame(chunk)
+        let text = String(decoding: frame, as: UTF8.self)
+        #expect(text.hasPrefix("data: "))
+        #expect(text.hasSuffix("\n\n"))
+
+        let jsonText = String(text.dropFirst("data: ".count).dropLast(2))
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: Data(jsonText.utf8)) as? [String: Any])
+        #expect(object["object"] as? String == "chat.completion.chunk")
+        #expect(object["id"] as? String == "chatcmpl-x")
+        #expect(object["created"] as? Int == 123)
+        #expect(object["model"] as? String == "m")
+        let choices = try #require(object["choices"] as? [[String: Any]])
+        #expect(choices.count == 1)
+        #expect(choices[0]["index"] as? Int == 0)
+        // finish_reason must be present as explicit null in in-flight chunks.
+        #expect(choices[0].keys.contains("finish_reason"))
+        #expect(choices[0]["finish_reason"] is NSNull)
+        let delta = try #require(choices[0]["delta"] as? [String: Any])
+        #expect(delta["content"] as? String == "hi")
+        // usage omitted unless requested
+        #expect(object["usage"] == nil)
+    }
+
+    @Test func completionChunkUsesTextCompletionObject() throws {
+        let chunk = CompletionChunk(
+            id: "cmpl-x",
+            created: 1,
+            model: "m",
+            choices: [CompletionChoice(index: 0, text: "abc", finishReason: "stop")])
+        let frame = try SSEFramer.frame(chunk)
+        let jsonText = String(decoding: frame, as: UTF8.self)
+            .dropFirst("data: ".count).dropLast(2)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: Data(jsonText.utf8)) as? [String: Any])
+        #expect(object["object"] as? String == "text_completion")
+        let choices = try #require(object["choices"] as? [[String: Any]])
+        #expect(choices[0]["text"] as? String == "abc")
+        #expect(choices[0]["finish_reason"] as? String == "stop")
+    }
+
+    @Test func usageChunkCarriesUsageWithEmptyChoices() throws {
+        let chunk = ChatCompletionChunk(
+            id: "chatcmpl-x",
+            created: 1,
+            model: "m",
+            choices: [],
+            usage: Usage(promptTokens: 3, completionTokens: 4))
+        let frame = try SSEFramer.frame(chunk)
+        let jsonText = String(decoding: frame, as: UTF8.self)
+            .dropFirst("data: ".count).dropLast(2)
+        let object = try #require(
+            try JSONSerialization.jsonObject(with: Data(jsonText.utf8)) as? [String: Any])
+        let usage = try #require(object["usage"] as? [String: Any])
+        #expect(usage["prompt_tokens"] as? Int == 3)
+        #expect(usage["completion_tokens"] as? Int == 4)
+        #expect(usage["total_tokens"] as? Int == 7)
+    }
+}


### PR DESCRIPTION
## What

A new `TurboFieldfareServer` product: an LM Studio-style HTTP API over an existing `.gturbo` installation, built on Hummingbird 2.

| Endpoint | Purpose |
| --- | --- |
| `GET /health` | Liveness check |
| `GET /v1/models` | OpenAI model list |
| `POST /v1/chat/completions` | Chat completion; `stream: true` returns SSE chunks + `[DONE]` |
| `POST /v1/completions` | Raw completion without chat formatting |
| `POST /v1/messages` | Anthropic Messages API; `stream: true` returns the full `message_start → content_block_* → message_delta → message_stop` event sequence |

The model loads once at startup, before the port binds. One generation runs at a time (the runtime's single-in-flight contract); concurrent requests queue FIFO. Disconnecting a streaming client cancels its decode. The HTTP layer is Metal-free behind a `TokenGenerating` seam, so routes, SSE framing, and session logic are fully unit-tested without a GPU.

```bash
swift run -c release TurboFieldfareServer --model scratch/gemma4.gturbo --port 1234
```

## Design notes

- **Validation at the boundary.** `max_tokens` budgeting uses overflow-safe arithmetic (a JSON `max_tokens` near `Int.max` returns 400 instead of trapping the process), non-finite sampling values are rejected, and unsupported semantic fields (`tools`, `tool_choice`, `response_format`, `n != 1`) get an explicit 400 on both API surfaces rather than being silently ignored.
- **Slot handoff.** The FIFO slot releases via a `defer` installed before the cancellation check, so a client cancelled exactly at handoff cannot wedge the queue.
- **Error hygiene.** Runtime errors are sanitized to a generic 500 — internal paths and Metal details never reach HTTP responses.
- **Local-first.** Binds to `127.0.0.1` by default; the README warns that the server has no auth/rate limiting and must not be moved to a routable address without an authenticating proxy.

## Known limitations (documented)

- Anthropic `stop_sequence` is not echoed back: the runtime's `StopReason.stopString` carries no matched string, so reporting it needs a runtime change, not a server change.
- The waiter queue is unbounded (acceptable on localhost; a cap/503 belongs with any non-loopback exposure).
- A mid-stream generation failure ends the SSE body without a protocol-level error event.

## Tests

59 server tests (fake-generator route/SSE/session tests, no Metal required); full suite: 499/499 via `Scripts/test.sh`. Smoke-verified against the real model on an M3 Max: non-stream + stream on both APIs, disconnect cancellation, 400 paths.