### PR TITLE
Fix download ETA countdown updates

### DIFF
--- a/Sources/TurboFieldfareApp/Core/Installation/DownloadETAEstimator.swift
+++ b/Sources/TurboFieldfareApp/Core/Installation/DownloadETAEstimator.swift
@@ -77,10 +77,6 @@ public struct DownloadETAEstimator: Sendable {
         let estimate = Double(observation.totalBytes - completed) / rate
         guard estimate.isFinite, estimate >= 0 else { return .estimating }
 
-        if let lastETA,
-           abs(estimate - lastETA) <= max(60, lastETA * 0.2) {
-            return .remaining(seconds: lastETA)
-        }
         lastETA = estimate
         lastUpdateTime = timestamp
         return .remaining(seconds: estimate)

--- a/Tests/TurboFieldfareApp/Core/Installation/DownloadETAEstimatorTests.swift
+++ b/Tests/TurboFieldfareApp/Core/Installation/DownloadETAEstimatorTests.swift
@@ -23,7 +23,7 @@ struct DownloadETAEstimatorTests {
         #expect(seconds > 9 && seconds < 11)
     }
 
-    @Test func smallChangesKeepTheVisibleEstimateStable() {
+    @Test func holdsVisibleEstimateWithinUpdateInterval() {
         var estimator = DownloadETAEstimator()
         let mib = UInt64(1024 * 1024)
         _ = estimator.update(
@@ -33,9 +33,85 @@ struct DownloadETAEstimatorTests {
             .init(reusedBytes: 0, downloadedThisRunBytes: 100 * mib, totalBytes: 600 * mib),
             timestamp: 10)
         let second = estimator.update(
-            .init(reusedBytes: 0, downloadedThisRunBytes: 210 * mib, totalBytes: 600 * mib),
-            timestamp: 41)
+            .init(reusedBytes: 0, downloadedThisRunBytes: 200 * mib, totalBytes: 600 * mib),
+            timestamp: 39)
         #expect(first == second)
+    }
+
+    @Test func publishesUpdatedEstimateAfterUpdateInterval() {
+        var estimator = DownloadETAEstimator()
+        let mib = UInt64(1024 * 1024)
+        _ = estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 0, totalBytes: 600 * mib),
+            timestamp: 0)
+        let first = estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 100 * mib, totalBytes: 600 * mib),
+            timestamp: 10)
+        let second = estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 200 * mib, totalBytes: 600 * mib),
+            timestamp: 40)
+
+        #expect(first == .remaining(seconds: 50))
+        #expect(second == .remaining(seconds: 80))
+    }
+
+    @Test func steadyDownloadAdvancesVisibleMinuteCountdown() {
+        var estimator = DownloadETAEstimator()
+        let mib = UInt64(1024 * 1024)
+        let total = UInt64(3_640) * mib
+
+        _ = estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 0, totalBytes: total),
+            timestamp: 0)
+        let presentations = [
+            estimator.update(
+                .init(reusedBytes: 0, downloadedThisRunBytes: 40 * mib, totalBytes: total),
+                timestamp: 10),
+            estimator.update(
+                .init(reusedBytes: 0, downloadedThisRunBytes: 280 * mib, totalBytes: total),
+                timestamp: 70),
+            estimator.update(
+                .init(reusedBytes: 0, downloadedThisRunBytes: 520 * mib, totalBytes: total),
+                timestamp: 130),
+            estimator.update(
+                .init(reusedBytes: 0, downloadedThisRunBytes: 760 * mib, totalBytes: total),
+                timestamp: 190),
+        ]
+
+        #expect(presentations.compactMap(DownloadETAFormatter.string) == [
+            "About 15 min remaining",
+            "About 14 min remaining",
+            "About 13 min remaining",
+            "About 12 min remaining",
+        ])
+    }
+
+    @Test func byteCounterRegressionRestartsWarmup() {
+        var estimator = DownloadETAEstimator()
+        let mib = UInt64(1024 * 1024)
+        let total = UInt64(600) * mib
+        _ = estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 0, totalBytes: total),
+            timestamp: 0)
+        #expect(estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 40 * mib, totalBytes: total),
+            timestamp: 10) != .estimating)
+
+        #expect(estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 10 * mib, totalBytes: total),
+            timestamp: 20) == .estimating)
+    }
+
+    @Test func completionHidesETA() {
+        var estimator = DownloadETAEstimator()
+        let mib = UInt64(1024 * 1024)
+        _ = estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 0, totalBytes: 40 * mib),
+            timestamp: 0)
+
+        #expect(estimator.update(
+            .init(reusedBytes: 0, downloadedThisRunBytes: 40 * mib, totalBytes: 40 * mib),
+            timestamp: 10) == .hidden)
     }
 
     @Test func formatterUsesCoarseMinuteBuckets() {


### PR DESCRIPTION
## Summary

- Remove the 20% ETA deadband that froze long estimates.
- Retain the 30-second refresh gate and cumulative-rate smoothing.
- Add regression coverage for countdown updates, throttling, retry resets, and completion.

## Problem

At a 15-minute estimate, the 20% deadband suppressed changes of up to three minutes, so the UI jumped directly from 15 to 12 minutes.

## Testing

- Scripts/test.sh --filter DownloadETAEstimatorTests: 7 tests passed.
- Scripts/test.sh: 513 tests across 108 suites passed.