### PR TITLE
Add opt-in, fail-closed Tailnet binding for the local API server

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -34,10 +34,13 @@ checks, client setup, prompt reuse, tool loops, and supported API behavior.
 Apply the model-process checks below first; never start a second model process
 or terminate an existing one.
 
-Keep the server on `127.0.0.1`; it has no remote authentication or TLS, so do
-not proxy, tunnel, or expose it. A tool call from the local model never bypasses
-the client's normal permission policy. Keep the execution session alive while
-the server is needed, and stop only a server you launched.
+Keep the server on its default `127.0.0.1` binding unless the user explicitly
+requests `--bind tailnet` and intends the Tailnet ACL to be the access boundary.
+It has no application-level authentication or TLS, so never bind it to a
+wildcard interface or expose it through a proxy or tunnel. A tool call from the
+local model never bypasses the client's normal permission policy. Keep the
+execution session alive while the server is needed, and stop only a server you
+launched.
 
 ## Test rules
 

--- a/README.md
+++ b/README.md
@@ -262,10 +262,13 @@ swift build -c release --product TurboFieldfareServer
   --model scratch/gemma4.gturbo
 ```
 
-It listens on `http://127.0.0.1:8080/v1` and supports Chat Completions,
-streaming, function tools, and single-prefix prompt reuse. The client must
-authorize and run every tool call. Keep the server on loopback; it has no
-remote authentication or TLS.
+By default it listens on `http://127.0.0.1:8080/v1` and supports Chat
+Completions, streaming, function tools, and single-prefix prompt reuse. For
+access from trusted devices in the same Tailnet, pass `--bind tailnet`; the
+server binds only to the detected Tailscale IPv4 address, not a wildcard
+interface. The client must authorize and run every tool call. Tailnet access
+relies on its ACL because the server has no application-level authentication
+or TLS.
 
 See [Local server](docs/OPENAI_SERVER.md) for a test request, Python and
 OpenCode setup, prompt reuse, tool handling, and the supported API subset.

--- a/Sources/TurboFieldfareServer/Command/main.swift
+++ b/Sources/TurboFieldfareServer/Command/main.swift
@@ -15,6 +15,7 @@ do {
 
 do {
     let signals = ServerTerminationSignals()
+    let host = try arguments.bindMode.host()
     let modelURL = URL(fileURLWithPath: arguments.model).standardizedFileURL
     let backend = try await ServerModelSession.load(
         modelDirectory: modelURL,
@@ -24,8 +25,8 @@ do {
         modelID: arguments.modelID,
         queueLimit: arguments.queueLimit,
         backend: backend)
-    _ = try await server.start(port: arguments.port)
-    print("TurboFieldfareServer ready at http://127.0.0.1:\(arguments.port) model=\(arguments.modelID) context=\(arguments.maxContext) prompt_cache=\(arguments.promptCacheMode.rawValue)")
+    _ = try await server.start(host: host, port: arguments.port)
+    print("TurboFieldfareServer ready at http://\(host):\(arguments.port) model=\(arguments.modelID) context=\(arguments.maxContext) prompt_cache=\(arguments.promptCacheMode.rawValue)")
 
     _ = await signals.wait()
     try await server.shutdown()

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -29,7 +29,7 @@ public actor TurboFieldfareHTTPServer {
         self.heartbeatInterval = heartbeatInterval
     }
 
-    public func start(port: Int) async throws -> Channel {
+    public func start(host: String = "127.0.0.1", port: Int) async throws -> Channel {
         let modelID = self.modelID
         let backend = self.backend
         let coordinator = self.coordinator
@@ -53,7 +53,7 @@ public actor TurboFieldfareHTTPServer {
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-        let channel = try await bootstrap.bind(host: "127.0.0.1", port: port).get()
+        let channel = try await bootstrap.bind(host: host, port: port).get()
         self.channel = channel
         return channel
     }

--- a/Sources/TurboFieldfareServer/Core/ServerArguments.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerArguments.swift
@@ -3,6 +3,7 @@ import Foundation
 public struct ServerArguments: Equatable, Sendable {
     public let model: String
     public let port: Int
+    public let bindMode: ServerBindMode
     public let modelID: String
     public let maxContext: Int
     public let queueLimit: Int
@@ -12,7 +13,8 @@ public struct ServerArguments: Equatable, Sendable {
     usage: TurboFieldfareServer --model <completed .gturbo directory> [options]
 
       --model <dir>          Required model directory.
-      --port <1...65535>     Loopback port (default 8080).
+      --port <1...65535>     Listening port (default 8080).
+      --bind <mode>          loopback or tailnet (default loopback).
       --model-id <id>        API model identifier (default gemma-4-26b-a4b-it).
       --max-context <tokens> 4096, 8192, 16384, 32768, or 65536 (default 16384).
       --queue-limit <count>  Maximum queued requests (default 4).
@@ -24,6 +26,7 @@ public struct ServerArguments: Equatable, Sendable {
     public static func parse(_ input: [String]) throws -> ServerArguments {
         var model: String?
         var port = 8080
+        var bindMode = ServerBindMode.loopback
         var modelID = "gemma-4-26b-a4b-it"
         var maxContext = 16_384
         var queueLimit = 4
@@ -45,6 +48,11 @@ public struct ServerArguments: Equatable, Sendable {
                     throw ServerArgumentError.invalid("--port must be between 1 and 65535")
                 }
                 port = parsed
+            case "--bind":
+                guard let parsed = ServerBindMode(rawValue: value) else {
+                    throw ServerArgumentError.invalid("--bind must be loopback or tailnet")
+                }
+                bindMode = parsed
             case "--model-id":
                 guard !value.isEmpty else {
                     throw ServerArgumentError.invalid("--model-id must not be empty")
@@ -74,10 +82,43 @@ public struct ServerArguments: Equatable, Sendable {
         guard let model else { throw ServerArgumentError.invalid("--model is required") }
         return ServerArguments(model: model,
                                port: port,
+                               bindMode: bindMode,
                                modelID: modelID,
                                maxContext: maxContext,
                                queueLimit: queueLimit,
                                promptCacheMode: promptCacheMode)
+    }
+}
+
+public enum ServerBindMode: String, Equatable, Sendable {
+    case loopback
+    case tailnet
+
+    public func host() throws -> String {
+        if self == .loopback { return "127.0.0.1" }
+
+        let process = Process()
+        let output = Pipe()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["tailscale", "ip", "-4"]
+        process.standardOutput = output
+        process.standardError = FileHandle.nullDevice
+        do {
+            try process.run()
+        } catch {
+            throw ServerArgumentError.invalid(
+                "could not run tailscale; ensure its CLI is installed")
+        }
+        process.waitUntilExit()
+        guard process.terminationStatus == 0,
+              let address = String(
+                data: output.fileHandleForReading.readDataToEndOfFile(),
+                encoding: .utf8
+              )?.split(whereSeparator: \.isWhitespace).first else {
+            throw ServerArgumentError.invalid(
+                "could not detect a Tailnet IPv4 address; ensure Tailscale is running")
+        }
+        return String(address)
     }
 }
 

--- a/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
@@ -297,6 +297,7 @@ struct ServerArgumentTests {
     @Test func defaults() throws {
         let arguments = try ServerArguments.parse(["--model", "model.gturbo"])
         #expect(arguments.port == 8080)
+        #expect(arguments.bindMode == .loopback)
         #expect(arguments.maxContext == 16_384)
         #expect(arguments.queueLimit == 4)
         #expect(arguments.promptCacheMode == .singlePrefix)
@@ -317,6 +318,20 @@ struct ServerArgumentTests {
             try ServerArguments.parse([
                 "--model", "model.gturbo",
                 "--prompt-cache-mode", "many",
+            ])
+        }
+    }
+
+    @Test func parsesTailnetBindMode() throws {
+        let arguments = try ServerArguments.parse([
+            "--model", "model.gturbo",
+            "--bind", "tailnet",
+        ])
+        #expect(arguments.bindMode == .tailnet)
+        #expect(throws: ServerArgumentError.self) {
+            try ServerArguments.parse([
+                "--model", "model.gturbo",
+                "--bind", "public",
             ])
         }
     }

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -27,6 +27,22 @@ The server loads the model before opening the port. Wait for
 `TurboFieldfareServer ready`, then keep the process running while clients use
 it.
 
+To make the server available only inside the current Tailnet, let it detect and
+bind the machine's Tailscale IPv4 address:
+
+```bash
+.build/release/TurboFieldfareServer \
+  --model scratch/gemma4.gturbo \
+  --bind tailnet \
+  --port 8080 \
+  --max-context 32768 \
+  --queue-limit 32
+```
+
+The command fails instead of falling back to a broader interface when
+Tailscale is unavailable. Access remains governed by the Tailnet ACL. The
+server still has no application-level authentication or TLS.
+
 Check the server from another terminal:
 
 ```bash

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -1,8 +1,9 @@
 # Local OpenAI-compatible server
 
 `TurboFieldfareServer` exposes a local Chat Completions API for one Gemma
-model. It binds to `127.0.0.1` without authentication or TLS. Do not expose it
-through a proxy or tunnel.
+model. It binds to `127.0.0.1` by default, or to the machine's exact Tailscale
+IPv4 address with `--bind tailnet`. It has no application-level authentication
+or TLS; do not expose it through a wildcard interface, proxy, or tunnel.
 
 ## Start the server
 


### PR DESCRIPTION
## Summary

Allow `TurboFieldfareServer` to serve trusted devices in the same Tailnet without opening the API to the local LAN or requiring a separate proxy.

The server currently binds exclusively to loopback. That is the safest default, but it also prevents using the model from another personally controlled device. A generic `--host` option or `0.0.0.0` binding would make accidental exposure too easy, so this change intentionally provides a narrower option:

```bash
TurboFieldfareServer \
  --model scratch/gemma4.gturbo \
  --bind tailnet
```

When `--bind tailnet` is selected, the server:

- obtains the machine IPv4 address from `tailscale ip -4`;
- binds only to that exact Tailnet address;
- never binds to `0.0.0.0` or another wildcard interface;
- fails instead of falling back when Tailscale cannot be detected.

The default remains `loopback`, so existing commands and their security properties are unchanged.

The README, server guide, and agent instructions now document the same safety boundary: Tailnet binding is explicit, relies on the Tailnet ACL, and does not add application-level authentication or TLS.

## Validation

Passed:

```bash
Scripts/test.sh --filter ServerArgumentTests
swift build -c release --product TurboFieldfareServer
ruby Scripts/check_markdown_links.rb
```

Results:

- All 3 server argument tests passed.
- The release `TurboFieldfareServer` product built successfully.
- All 22 Markdown files passed local link and anchor validation.
- The default bind mode remains `loopback`.
- Unsupported bind modes are rejected.

Tailnet-address API smoke test:

```text
GET http://<tailnet-ip>:8080/health
→ {"status":"ok"}

GET http://<tailnet-ip>:8080/v1/models
→ gemma-4-26b-a4b-it
```

Chat Completions request:

```text
Prompt: 대한민국의 수도는 어디인가요? 한 문장으로 답하세요.
Output: 대한민국의 수도는 서울입니다.
Usage: 29 prompt tokens, 9 completion tokens
```

Test environment:

```text
MacBook Pro (Mac16,7)
Apple M4 Pro, 24 GB
macOS 26.2
Swift 6.3.2
```

## Memory and performance

Not applicable.

This change does not modify model loading, inference, Metal kernels, KV cache, or bounded-memory behavior. It only changes the address passed to the existing SwiftNIO server bootstrap.

## Remaining limitations

- Tailscale must be running and its CLI must be available on `PATH`.
- Tailnet detection currently supports IPv4 only.
- Access control relies on the Tailnet ACL. The API still has no application-level authentication or TLS.
- The smoke test reached the server through the host Tailnet address. A request originating from a second Tailnet device has not yet been recorded.
- The complete serial test suite has not yet been run; validation so far used the focused server argument suite.

- [x] The change does not load a complete checkpoint, shard, or large model tensor into Swift heap memory.
- [x] Logs and artifacts contain no credentials, private paths, or model weights.