### PR TITLE
Add agent install guide and turbofieldfare-api skill

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -30,7 +30,9 @@ The installer streams the pinned model without staging the full source checkpoin
 ## Local server
 
 Follow the [server guide](docs/OPENAI_SERVER.md) for launch commands, health
-checks, client setup, prompt reuse, tool loops, and supported API behavior.
+checks, client setup, prompt reuse, tool loops, and supported API behavior. For
+a single-run agent prompt that installs TurboFieldfare and registers the
+`turbofieldfare-api` skill, see the [Agent guide](docs/AGENT_GUIDE.md).
 Apply the model-process checks below first; never start a second model process
 or terminate an existing one.
 

--- a/README.md
+++ b/README.md
@@ -268,7 +268,9 @@ authorize and run every tool call. Keep the server on loopback; it has no
 remote authentication or TLS.
 
 See [Local server](docs/OPENAI_SERVER.md) for a test request, Python and
-OpenCode setup, prompt reuse, tool handling, and the supported API subset.
+OpenCode setup, prompt reuse, tool handling, and the supported API subset. To
+install TurboFieldfare and register the agent skill in a single run, follow the
+[Agent guide](docs/AGENT_GUIDE.md).
 
 ## Test and contribute
 
@@ -346,6 +348,7 @@ audited entries as optional evidence.
 Useful entry points:
 
 - [Local OpenAI-compatible server](docs/OPENAI_SERVER.md)
+- [Agent guide (installation + skill)](docs/AGENT_GUIDE.md)
 - [System design](docs/SYSTEM_DESIGN.md)
 - [Benchmarks](docs/BENCHMARKS.md)
 - [The experiments that shaped TurboFieldfare](docs/OPTIMIZATION_JOURNEY.md)

--- a/docs/AGENT_GUIDE.md
+++ b/docs/AGENT_GUIDE.md
@@ -1,0 +1,221 @@
+# TurboFieldfare: AI Installation, Agent Skill & API Usage Guide
+
+This guide gives an autonomous coding agent everything it needs to install **TurboFieldfare** (Gemma 4 26B-A4B IT) in a single run, then documents the local API server, token budgeting, parameter mapping, and the bundled agent skill.
+
+---
+
+## 📋 Table of Contents
+
+1. [Automated AI Agent Prompt](#1-automated-ai-agent-prompt)
+2. [Local OpenAI-Compatible API Server](#2-local-openai-compatible-api-server)
+3. [Token Budgeting & Context Window Boundaries](#3-token-budgeting-context-window-boundaries)
+4. [GUI Sidebar Settings vs. API Parameter Mapping](#4-gui-sidebar-settings-vs-api-parameter-mapping)
+5. [One Model Process at a Time](#5-one-model-process-at-a-time)
+6. [Agent Skill Specification (`turbofieldfare-api`)](#6-agent-skill-specification-turbofieldfare-api)
+- [Appendix A. Build Artifacts](#appendix-a-build-artifacts)
+- [Appendix B. Model Path Notes](#appendix-b-model-path-notes)
+
+---
+
+## 1. Automated AI Agent Prompt
+
+Copy and pass the prompt below to an autonomous coding agent (Antigravity, Claude, Codex, etc.) to perform complete installation, app bundling, and skill registration in a single run. It is **self-contained** — it does not require the rest of this guide.
+
+```text
+Install TurboFieldfare in ~/fork/turbo-fieldfare, package it as a native macOS application in ~/Applications/TurboFieldfare.app, configure local API server persistence, and register agent skills.
+
+[Background]
+- TurboFieldfare runs Gemma 4 26B-A4B IT on Apple Silicon (macOS 26+, Swift 6.2+, Metal 4).
+- A release build produces five binaries in .build/release/:
+    TurboFieldfareMac          — native macOS GUI app (loads its own decode service)
+    TurboFieldfareDecodeService — backing Metal decode engine (sibling of the Mac app)
+    TurboFieldfareServer        — OpenAI-compatible local API server
+    TurboFieldfareCLI           — command-line interface
+    TurboFieldfareRepack        — streaming model installer and install verifier
+- Only ONE model-owning process may run at a time (app, CLI, or server are mutually exclusive).
+
+[Steps to Execute]
+1. Clone & Build:
+   - Clone https://github.com/drumih/turbo-fieldfare.git into ~/fork/turbo-fieldfare
+   - Execute: swift build -c release
+
+2. Model Download & Repack:
+   - Launch .build/release/TurboFieldfareMac and monitor the ~15 GB Gemma 4 26B-A4B IT model download, streaming repack, and hash verification to complete. The completed model lands at scratch/gemma4.gturbo (about 14.3 GB).
+
+3. macOS App Packaging & Path Fix (only if running the packaged .app from outside the checkout):
+   - Create the macOS app bundle at ~/Applications/TurboFieldfare.app with Info.plist, AppIcon.icns, and the five compiled binaries.
+   - Copy the verified model directory to ~/Library/Application Support/TurboFieldfare/gemma4.gturbo and update modelDirectoryPath in verified-install.json so launching ~/Applications/TurboFieldfare.app initializes into the Ready state instantly without re-downloading.
+   - Note: when launched from the checkout, the app/CLI/server read scratch/gemma4.gturbo directly — no copy is needed.
+
+4. API Server & Agent Skill Registration:
+   - Start TurboFieldfareServer on loopback 127.0.0.1, port 52642 (http://127.0.0.1:52642/v1/chat/completions). The server's code default port is 8080, but use 52642 to avoid collisions: 8080/3000/5000 are heavily used by dev servers, while 52642 is in the macOS ephemeral range (49152–65535) with no IANA-registered service. The server binds to loopback with no auth or TLS, so never proxy, tunnel, or expose it.
+   - Create the turbofieldfare-api agent skill in ~/.agents/skills, ~/.claude/skills, and ~/.codex/skills.
+   - Register TurboFieldfare as a provider in OpenCode (opencode.json): use the @ai-sdk/openai-compatible npm package with baseURL http://127.0.0.1:52642/v1 and apiKey "local" (the server ignores the key). Add a model entry named gemma-4-26b-a4b-it with limit.context 16384 and limit.output 8192, and set temperature/topP/topK defaults under options (0.2/0.95/64). Set the top-level model key to turbofieldfare/gemma-4-26b-a4b-it so OpenCode picks it by default. The limit values are required — without them OpenCode does not know the model's token budget and may fail to generate.
+
+5. Final Verification:
+   - Perform text generation tests via both GUI and API, confirm successful output, and output summary. Run only ONE of the GUI app or the server at a time.
+```
+
+---
+
+## 2. Local OpenAI-Compatible API Server
+
+`TurboFieldfareServer` runs a lightweight loopback HTTP server. It binds to `127.0.0.1` with **no authentication and no TLS** — keep it on loopback and never proxy, tunnel, or expose it. The server's *code* default port is `8080`, but this guide uses **`52642`** to avoid collisions with heavily-used dev ports (`8080`, `3000`, `5000`, `8000`); `52642` sits in the macOS ephemeral range (`49152–65535`), which has no IANA-registered service. (Caveat: the OS can hand ephemeral ports to transient sockets — if a bind fails, retry or pick another value in the range.) Override the port with any `1–65535` value via `--port`. Before starting, confirm no other TurboFieldfare model process is running:
+
+```bash
+pgrep -fl 'TurboFieldfareServer|TurboFieldfareMac|TurboFieldfareDecodeService|TurboFieldfareCLI|TurboFieldfarePackageTests|swiftpm-testing-helper|mlx_lm|mlx-lm'
+```
+
+If it prints a match, do not start the server — only one model-owning process may run at a time.
+
+### Starting the API Server
+
+```bash
+.build/release/TurboFieldfareServer \
+  --model "$HOME/Library/Application Support/TurboFieldfare/gemma4.gturbo" \
+  --port 52642 \
+  --max-context 16384
+```
+
+Single-prefix KV reuse is **on by default** (`--prompt-cache-mode single-prefix`),
+so the flag is shown for clarity but can be omitted. Other server options include
+`--queue-limit <count>` (default `4`), `--model-id <id>` (default
+`gemma-4-26b-a4b-it`), and `--prompt-cache-mode off` to disable prefix reuse.
+Wait for `TurboFieldfareServer ready` before sending requests; the model loads
+before the port opens.
+
+### Stopping the API Server
+
+Stop the server from the terminal that launched it with `Control-C`. Only stop a
+server you started.
+
+### Connect a client
+
+The base URL is `http://127.0.0.1:52642/v1`. Some client libraries require an
+API key, but the server ignores it — pass any non-empty value.
+
+**OpenCode** (`opencode.json`) — the maintainer's reference client setup:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "turbofieldfare/gemma-4-26b-a4b-it",
+  "provider": {
+    "turbofieldfare": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "TurboFieldfare",
+      "options": {
+        "baseURL": "http://127.0.0.1:52642/v1",
+        "apiKey": "local"
+      },
+      "models": {
+        "gemma-4-26b-a4b-it": {
+          "name": "Gemma 4 26B-A4B IT",
+          "limit": { "context": 16384, "output": 8192 },
+          "options": { "temperature": 0.2, "topP": 0.95, "topK": 64 }
+        }
+      }
+    }
+  }
+}
+```
+
+Set the top-level `model` to `turbofieldfare/gemma-4-26b-a4b-it` so OpenCode selects
+it by default. The `limit` block is required — without it OpenCode does not know the
+model's token budget and may fail to generate. The `options` block sets sane sampling
+defaults (match the GUI defaults of temperature 0.2, Top-K 64, Top-P 0.95).
+
+> **Two practical OpenCode limits.** (1) Pass `--title <name>` to `opencode run` —
+> otherwise OpenCode's auto session-title request collides with the main request and
+> the server returns `generation queue is full` (it serves one generation at a time).
+> (2) OpenCode's agent context (system prompt + skills + tool schemas) is large, so a
+> turn takes minutes on Gemma 4. For plain chat, use the Python/cURL path above. See
+> the skill's OpenCode section for full details.
+
+**Python** (openai SDK):
+
+```python
+from openai import OpenAI
+
+client = OpenAI(base_url="http://127.0.0.1:52642/v1", api_key="local")
+response = client.chat.completions.create(
+    model="gemma-4-26b-a4b-it",
+    messages=[{"role": "user", "content": "Say hello in one sentence."}],
+)
+print(response.choices[0].message.content)
+```
+
+---
+
+## 3. Token Budgeting & Context Window Boundaries
+
+In LLM architectures, total context memory equals the sum of prompt tokens (In) and generated tokens (Out):
+
+$$\text{Total Tokens} = \text{Prompt Tokens (In)} + \text{Completion Tokens (Out)}$$
+
+### Context Boundary Rules
+1. **Server Context Limit (`--max-context`)**:
+   - Supported values: `4096`, `8192`, `16384` (Server Default), `32768` (32K), `65536` (64K). (Note: the Mac app / CLI default to 4K; the server defaults to 16K.)
+   - If a prompt exceeds the server's `--max-context`, `TurboFieldfareServer` returns a `400 Invalid Request` error (`prompt exceeds the configured context`).
+2. **Output Token Cap (`max_completion_tokens`)**:
+   - Agents MUST ensure: `max_completion_tokens <= max_context - prompt_tokens`.
+3. **KV Cache Efficiency (`prompt_tokens_details.cached_tokens`)**:
+   - `TurboFieldfareServer` enables single-prefix KV caching by default (`--prompt-cache-mode single-prefix`). When conversation prefixes match, prefill is skipped for cached tokens, significantly reducing TTFT (Time-To-First-Token). Disable with `--prompt-cache-mode off`.
+
+---
+
+## 4. GUI Sidebar Settings vs. API Parameter Mapping
+
+| GUI Sidebar Setting | Scope | API / CLI Equivalent | Supported Values |
+| --- | --- | --- | --- |
+| **Context** | Memory / Server | Server CLI: `--max-context` | `4096`, `8192`, `16384`, `32768`, `65536` (Server default `16384`) |
+| **Expert-cache Slots** | Memory / App only | Mac app only — **no server/CLI flag** | `8`, `16`, `24`, `32` (Default `16`) |
+| **Temperature** | Generation / Request | Request JSON: `"temperature"` | `0.0` to `2.0` (Default: `0.2`) |
+| **Top-K** | Generation / Request | Request JSON: `"top_k"` | `1` to `256` (Default: `64`) |
+| **Top-P** | Generation / Request | Request JSON: `"top_p"` | `> 0` to `1.0` (Default: `0.95`) |
+| **Repetition Penalty** | Generation / Request | Request JSON: `"repetition_penalty"` | Float > 0 (Default: `1.0`) |
+| **Prompt prefill / KV Cache** | Runtime / Server | Server CLI: `--prompt-cache-mode` | `off`, `single-prefix` (Default: `single-prefix`) |
+
+> **Sampling constraints (server):** `top_p` must be `> 0` and `<= 1`; `top_k`
+> must be `1–256`. At `temperature 0` the server decodes greedily, so `top_p`
+> and `top_k` have no sampling effect. `expert-cache slots` is a Mac-app runtime
+> control only — the server and CLI do not expose a `--slots` flag.
+
+---
+
+## 5. One Model Process at a Time
+
+> ⚠️ **Do not run the GUI app and the API server at the same time.** Each one
+> loads its own copy of the model, so running both creates two model-owning
+> processes.
+
+TurboFieldfare is designed to keep memory low (~1.35 GB of core weights in RAM,
+experts streamed from SSD), but the Mac app (`TurboFieldfare.app` with its
+`TurboFieldfareDecodeService`) and the API server (`TurboFieldfareServer`) are
+**separate model-owning processes**. Run only one of them at a time. Before
+starting either, confirm no other TurboFieldfare process is running:
+
+```bash
+pgrep -fl 'TurboFieldfareServer|TurboFieldfareMac|TurboFieldfareDecodeService|TurboFieldfareCLI|TurboFieldfarePackageTests|swiftpm-testing-helper|mlx_lm|mlx-lm'
+```
+
+If it prints a match, do not start a second process. Close the other product
+before switching.
+
+---
+
+## 6. Agent Skill Specification (`turbofieldfare-api`)
+
+This repository includes a pre-configured Agent Skill specification at [`skills/turbofieldfare-api/SKILL.md`](../skills/turbofieldfare-api/SKILL.md). It covers server lifecycle, token budgeting, task-specific parameter presets, and a CLI fallback.
+
+---
+
+## Appendix A. Build Artifacts
+
+A release build (`swift build -c release`) from the repo root generates five binaries in `.build/release/`: `TurboFieldfareMac` (GUI app), `TurboFieldfareDecodeService` (Metal decode engine), `TurboFieldfareServer` (OpenAI-compatible API server), `TurboFieldfareCLI` (CLI), and `TurboFieldfareRepack` (streaming installer/verifier).
+
+---
+
+## Appendix B. Model Path Notes
+
+When launched from the repository checkout, the app, CLI, and server read the relative `scratch/gemma4.gturbo` path directly — no copy is needed. Only the packaged `TurboFieldfare.app` run from outside the checkout (e.g. `~/Applications`) resolves its model from `~/Library/Application Support/TurboFieldfare/gemma4.gturbo`; to avoid a re-download prompt, copy the verified model there and set `modelDirectoryPath` in `verified-install.json`.

--- a/skills/turbofieldfare-api/SKILL.md
+++ b/skills/turbofieldfare-api/SKILL.md
@@ -1,0 +1,282 @@
+---
+name: turbofieldfare-api
+description: Manage and call the TurboFieldfare local OpenAI-compatible Chat Completions API server (Gemma 4 26B-A4B IT) with token budgeting rules, max context boundaries, and task-specific preset profiles.
+user-invocable: true
+argument-hint: "[start|stop|status|chat] [code|structured|creative|balanced|long] [prompt]"
+---
+
+# TurboFieldfare API Skill
+
+Quick reference for AI agents to launch and query the local **TurboFieldfare** OpenAI-compatible API server with strict token budgeting and task-optimized parameter presets.
+
+> Paths use `$HOME` / `~` so the skill is portable. The model is a ~14.3 GB
+> `.gturbo` directory; only one model-owning process may run at a time
+> (server, Mac app, CLI, or decode service are mutually exclusive).
+
+---
+
+## 📍 Environment & Endpoint
+
+- **Server Binary**: `.build/release/TurboFieldfareServer` (build with `swift build -c release --product TurboFieldfareServer` from the repo root)
+- **Model Path**: `"$HOME/Library/Application Support/TurboFieldfare/gemma4.gturbo"` (packaged app location), or `scratch/gemma4.gturbo` from a checkout
+- **Base URL**: `http://127.0.0.1:52642/v1`
+- **Port `52642`**: the server's *code* default is `8080`, but this guide uses
+  **`52642`** instead to avoid collisions. `8080`, `3000`, `5000`, and `8000` are
+  heavily used by dev servers; `52642` sits in the macOS ephemeral range
+  (`49152–65535`), which has no IANA-registered service, so it rarely clashes
+  with another app's fixed port. (Caveat: the OS can hand ephemeral ports to
+  transient sockets, so if a bind fails, retry or pick another value in the
+  range.) Override with `--port`.
+- **Model ID**: `gemma-4-26b-a4b-it` (server default; override with `--model-id`)
+- **Loopback only**: `127.0.0.1`. No auth, no TLS — never proxy, tunnel, or expose.
+
+---
+
+## 📏 1. Context Window & Token Budgeting Rules
+
+Total Context Budget: **`Total Tokens = Prompt Tokens (In) + Completion Tokens (Out)`**
+
+- **Server Context Limit (`--max-context`)**: Default `16384` (Supports `4096`, `8192`, `16384`, `32768`, `65536`).
+- **Safety Boundary Formula**: `max_completion_tokens <= max_context - prompt_tokens`
+- **Context Overflow**: If the prompt exceeds `--max-context`, the server returns `400 Invalid Request` (`prompt exceeds the configured context`).
+- **KV Cache Optimization**: Single-prefix KV reuse is **on by default** (`--prompt-cache-mode single-prefix`). System prompts & conversation prefixes are reused; reused token count is reported in `usage.prompt_tokens_details.cached_tokens`. Disable with `--prompt-cache-mode off`.
+
+---
+
+## 🚀 2. Server Lifecycle & Context Setup
+
+> **Before starting**, confirm no other TurboFieldfare model process is running:
+> ```bash
+> pgrep -fl 'TurboFieldfareServer|TurboFieldfareMac|TurboFieldfareDecodeService|TurboFieldfareCLI|TurboFieldfarePackageTests|swiftpm-testing-helper|mlx_lm|mlx-lm'
+> ```
+> If it prints a match, **do not start** — only one model process at a time.
+
+### Standard Startup (16K Context Window, guide port 52642)
+```bash
+.build/release/TurboFieldfareServer \
+  --model "$HOME/Library/Application Support/TurboFieldfare/gemma4.gturbo" \
+  --port 52642 \
+  --max-context 16384
+```
+
+### Extended Startup (32K / 64K Context Window for Large Context)
+```bash
+.build/release/TurboFieldfareServer \
+  --model "$HOME/Library/Application Support/TurboFieldfare/gemma4.gturbo" \
+  --port 52642 \
+  --max-context 32768
+```
+
+Optional server flags:
+- `--queue-limit <count>` — maximum queued requests (default `4`).
+- `--prompt-cache-mode <off|single-prefix>` — KV reuse mode (default `single-prefix`).
+
+### Stop the Server
+
+Stop the server from the **terminal where you launched it** with `Control-C`.
+The server listens for `SIGINT`/`SIGTERM` and shuts down cleanly.
+
+> Only stop a server **you** launched. Do not terminate a server (or Mac app)
+> started by the user or another session. If you must clean up a process you own,
+> target it explicitly rather than blanket-killing by name.
+
+### Health Check
+```bash
+curl --silent --show-error http://127.0.0.1:52642/health
+curl --silent --show-error http://127.0.0.1:52642/v1/models
+```
+Wait for `TurboFieldfareServer ready` before sending requests; the model loads
+before the port opens.
+
+---
+
+## 🎯 3. Preset Parameter Profiles for Task-Specific Requests
+
+> `top_p` must be `> 0` and `<= 1`; `top_k` must be `1–256`. At `temperature 0`
+> the server uses greedy decoding, so `top_p` / `top_k` have no sampling effect.
+
+| Preset | Target Use-Case | `temperature` | `top_k` | `top_p` | `repetition_penalty` | Recommended `max_completion_tokens` |
+| --- | --- | --- | --- | --- | --- | --- |
+| **`code`** | Code Generation & Debugging | `0.1` | `32` | `0.90` | `1.05` | `2048` |
+| **`structured`** | JSON & Tool Calling (deterministic) | `0.0` (greedy) | N/A (greedy) | N/A (greedy) | `1.00` | `1024` |
+| **`creative`** | Brainstorming & Writing | `0.7` | `100` | `0.95` | `1.10` | `2048` |
+| **`balanced`** | General Chat & Summaries | `0.2` | `64` | `0.95` | `1.00` | `1024` |
+| **`long`** | Long-context synthesis (start server with `--max-context 32768`) | `0.3` | `64` | `0.95` | `1.05` | `4096` |
+
+---
+
+## 💬 4. Profile Request Examples (cURL)
+
+### Code Generation (`code` profile)
+```bash
+curl -s http://127.0.0.1:52642/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gemma-4-26b-a4b-it",
+    "messages": [
+      {"role": "system", "content": "You are an expert Swift software engineer."},
+      {"role": "user", "content": "Write an async/await HTTP fetch utility in Swift."}
+    ],
+    "temperature": 0.1,
+    "top_k": 32,
+    "top_p": 0.90,
+    "repetition_penalty": 1.05,
+    "max_completion_tokens": 2048
+  }'
+```
+
+### Structured / JSON (`structured` profile, greedy)
+```bash
+curl -s http://127.0.0.1:52642/v1/chat/completions \
+  -H 'Content-Type: application/json' \
+  -d '{
+    "model": "gemma-4-26b-a4b-it",
+    "messages": [
+      {"role": "user", "content": "Return a JSON object with keys \"name\" and \"age\" for a fictional persona."}
+    ],
+    "temperature": 0,
+    "max_completion_tokens": 1024
+  }'
+```
+
+---
+
+## 🔌 5. Connect OpenCode (maintainer's reference client)
+
+TurboFieldfare's server docs use **OpenCode** as the reference client setup. To
+run an OpenCode coding agent backed by the local Gemma model, register a
+`turbofieldfare` provider in `opencode.json`. The server ignores the API key, so
+any non-empty value works.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "model": "turbofieldfare/gemma-4-26b-a4b-it",
+  "provider": {
+    "turbofieldfare": {
+      "npm": "@ai-sdk/openai-compatible",
+      "name": "TurboFieldfare",
+      "options": {
+        "baseURL": "http://127.0.0.1:52642/v1",
+        "apiKey": "local"
+      },
+      "models": {
+        "gemma-4-26b-a4b-it": {
+          "name": "Gemma 4 26B-A4B IT",
+          "limit": { "context": 16384, "output": 8192 },
+          "options": { "temperature": 0.2, "topP": 0.95, "topK": 64 }
+        }
+      }
+    }
+  }
+}
+```
+
+- Set the top-level `model` key so OpenCode picks TurboFieldfare by default.
+- The `limit` block is **required** — without `context`/`output`, OpenCode does
+  not know the model's token budget and may fail to generate.
+- The `options` block sets sampling defaults via the AI SDK names
+  (`temperature`, `topP`, `topK`, `maxOutputTokens`). Note: `repetition_penalty`
+  is a TurboFieldfare extension, **not** an AI SDK standard option, so OpenCode
+  cannot pass it — leave it at the server default (1.0).
+- For a Python client, use the `openai` SDK with the same base URL and pass
+  `repetition_penalty` directly in the request body.
+
+### ⚠️ Known OpenCode + TurboFieldfare limits (empirically verified)
+
+The server runs **one generation at a time** and queues up to four (`--queue-limit`).
+Two practical limits surface when driving it from OpenCode:
+
+1. **Auto-title generation causes `generation queue is full`.** OpenCode fires a
+   `small=true agent=title` request (to name the session) at almost the same time
+   as the real `agent=build` request. The second one hits the queue and fails with
+   `AI_APICallError: generation queue is full`, then AI SDK retries 3× and stalls.
+   **Fix:** pass `--title <name>` to `opencode run` so it skips the title request:
+   ```bash
+   opencode run -m turbofieldfare/gemma-4-26b-a4b-it --title "session" "your prompt"
+   ```
+
+2. **The agent context is large and slow on Gemma.** OpenCode's `build` agent sends
+   the system prompt + every skill definition + tool schemas (tens of thousands of
+   tokens) on every turn, so a single agent turn can take minutes. For plain chat,
+   prefer the raw cURL/Python path in §4 — it is much faster because it sends only
+   the prompt, not the full agent context.
+
+
+---
+
+## 🧪 6. CLI Fallback (when the server is unsuitable)
+
+Prefer the server (§2) for repeated calls, conversations, and tool loops — it
+loads the model once and reuses the KV prefix. Use the **CLI** only for:
+
+- A **single one-shot** generation (diagnostic, benchmark, smoke test).
+- A **fully reproducible** sample via `--seed`.
+- When you cannot keep a long-lived process alive.
+
+> **Cost:** the CLI reloads the entire model on every invocation (tokenizer →
+> Metal context → `Model.load` with SHA-256 verification → runner setup). It has
+> no KV reuse and **cannot make tool calls**. Do not use it in a multi-turn loop.
+
+### Binary & invocation
+
+```bash
+.build/release/TurboFieldfareCLI \
+  --model "$HOME/Library/Application Support/TurboFieldfare/gemma4.gturbo" \
+  --max-context 4096 \
+  --max-new 1024 \
+  --temperature 0.2 \
+  --quiet
+```
+
+Input modes (**mutually exclusive**):
+
+- `--prompt "<string>"` — raw completion, no chat formatting. Use for reproducible
+  comparisons.
+- `--messages-file <path>` — JSON array of `{"role","content"}` chat messages,
+  formatted the same way as the Mac app. Supported roles: `user`, `model`, and
+  optional `system`.
+
+```bash
+# messages.json
+[
+  {"role": "user", "content": "Explain chunked prefill in one sentence."}
+]
+
+.build/release/TurboFieldfareCLI \
+  --model "$HOME/Library/Application Support/TurboFieldfare/gemma4.gturbo" \
+  --messages-file messages.json \
+  --quiet
+```
+
+### CLI generation flags
+
+| Flag | Default | Notes |
+| --- | --- | --- |
+| `--max-new <int>` | `1024` | Generated-token limit. The CLI caps it to `max-context - prompt_tokens`. |
+| `--max-context <int>` | `4096` | CLI/app default is 4K (the server defaults to 16K). |
+| `--temperature <f>` | `0.2` | `0` = greedy. |
+| `--top-k <int>` | `64` | `1–256`; **`0` disables** truncation. |
+| `--top-p <f>` | `0.95` | `> 0` and `<= 1`. |
+| `--repetition-penalty <f>` | `1.0` | Float `> 0`. |
+| `--seed <uint64>` | off | Deterministic sampling seed (server has no per-request equivalent advantage). |
+| `--stop <string>` | none | Stop substring, **repeatable**. |
+| `--quiet` | off | Suppresses the `[stop=… tok/s=…]` timing footer on stderr. |
+
+### CLI sampling constraint (stricter than the server)
+
+The CLI **enforces** what the server only accepts silently: with
+`temperature > 0`, if `top_p < 1` then `top_k` must be between `1` and `256`.
+To disable both truncation controls, pass `--top-k 0 --top-p 1`.
+
+### Output
+
+Generated text goes to **stdout**; the timing footer goes to **stderr**. In
+scripts, capture text with `$(… 2>/dev/null)` or pass `--quiet`.
+
+### When to switch back to the server
+
+For any second request in the same task — especially tool-call loops or
+multi-turn chat — start the server (§2) instead. The CLI's per-call model load
+makes repeated invocation inefficient, and it cannot emit or resolve tool calls.
+


### PR DESCRIPTION
## Summary

Documentation-only change. Adds a self-contained one-run agent install prompt and an API skill so an autonomous agent can install TurboFieldfare and register the skill in a single pass.

- **Branch:** `feat/agent-install-guide-and-skill` → `main`
- **Commit:** `8b5ad89`
- **Files:** `docs/AGENT_GUIDE.md` (new, 221 lines), `skills/turbofieldfare-api/SKILL.md` (new, 282 lines), `README.md` (2 links), `AGENTS.md` (1 link)

## Behavior change

No code or runtime change. Adds documentation and a skill only. Public runtime controls stay limited to those documented in `RUNTIME_CONTROLS.md` — the `--slots` flag is documented as Mac-app-only (no server/CLI flag), and no new server flag is introduced.

## What it adds

- **`docs/AGENT_GUIDE.md`** — a self-contained agent install prompt (build → model download → packaging → server + skill + OpenCode → verification), plus local server reference, client wiring (OpenCode/Python), token-budgeting rules, GUI→API parameter mapping, and a single-process warning.
- **`skills/turbofieldfare-api/SKILL.md`** — server lifecycle, task-specific parameter presets (`code`/`structured`/`creative`/`balanced`/`long`), OpenCode integration, and a CLI fallback.

## Tests run

- `ruby Scripts/check_markdown_links.rb` → all local links/anchors resolve (23 files)
- No model download or load required (docs-only change)
- Cross-checked every option/default against `Sources/TurboFieldfareServer` (`ServerArguments.swift`, `ServerInference.swift`, `OpenAIModels.swift`)

## Verification highlights

- Port/options/defaults verified against `ServerArguments.swift` (server default port `8080`; guide uses `52642` to avoid collisions, documented as a non-default choice).
- `400 Invalid Request` on context overflow verified against `ServerInference.swift`.
- `--slots` is **not** a server/CLI flag — removed the incorrect mapping from the earlier draft.
- `--max-context` clarified: server default `16384` vs Mac app/CLI default `4096`.

## Found via real OpenCode testing

1. `limit.context`/`limit.output` are **required** in `opencode.json` — without them OpenCode does not know the model's token budget and fails to generate.
2. `opencode run --title <name>` is required — auto session-title generation fires a concurrent request that triggers `generation queue is full` (the server serves one generation at a time, queues up to four).
3. OpenCode's agent context (system prompt + 49 skill definitions + tool schemas) is heavy; a single agent turn did not complete within 10 minutes. Plain chat should use the cURL/Python path (~12s for the same prompt). This is documented as a known limit in the skill.

## Remaining limitations

- OpenCode agent turns are slow on Gemma 4; the skill documents the cURL fallback for plain chat.
- `repetition_penalty` is a TurboFieldfare extension, **not** an AI SDK standard option, so it cannot be passed through OpenCode (left at the server default `1.0`).

## CONTRIBUTING checklist

- [x] Personal paths removed (`/Users/*` → `$HOME`/`~`)
- [x] Narrow, single-concern PR
- [x] Markdown link check passes
- [x] Apache 2.0 — no license conflict
