### PR TITLE
feat: Support union tool schemas and repeated system msg 

### DIFF
--- a/Sources/TurboFieldfare/Tokenization/JSONValue.swift
+++ b/Sources/TurboFieldfare/Tokenization/JSONValue.swift
@@ -90,6 +90,69 @@ public indirect enum JSONValue: Codable, Equatable, Sendable {
         return value
     }
 
+    /// Rewrites this JSON Schema fragment so every property the Gemma tool
+    /// template renders carries a concrete scalar `type`. The template evaluates
+    /// `value['type'] | upper` unconditionally for each property, so union
+    /// (`anyOf`/`oneOf`/`allOf`), array-typed (`"type": ["string", "null"]`), or
+    /// type-less properties would abort rendering. Unions collapse to their first
+    /// branch that resolves to a concrete type (merging in the parent's sibling
+    /// keys, e.g. `description`); an array `type` takes its first non-null member;
+    /// a type-less node defaults to `object` when it carries `properties`,
+    /// otherwise `string`. Every nested `properties` value and `items` schema is
+    /// normalized recursively. Non-object values are returned unchanged.
+    public func gemmaSchemaNormalized() -> JSONValue {
+        guard case .object(var object) = self else { return self }
+
+        if !object.hasScalarStringType,
+           case .array(let members)? = object["type"],
+           let concrete = members.firstNonNullTypeName {
+            object["type"] = .string(concrete)
+        }
+        if !object.hasScalarStringType {
+            for keyword in Self.unionKeywords {
+                guard case .array(let branches)? = object[keyword] else { continue }
+                return Self.collapsedUnion(parent: object, branches: branches)
+            }
+        }
+        if !object.hasScalarStringType {
+            object["type"] = object["properties"] != nil
+                ? .string("object")
+                : .string("string")
+        }
+
+        if case .object(let properties)? = object["properties"] {
+            object["properties"] = .object(
+                properties.mapValues { $0.gemmaSchemaNormalized() })
+        }
+        switch object["items"] {
+        case .object?:
+            object["items"] = object["items"]?.gemmaSchemaNormalized()
+        case .array(let items)?:
+            object["items"] = .array(items.map { $0.gemmaSchemaNormalized() })
+        default:
+            break
+        }
+        return .object(object)
+    }
+
+    private static let unionKeywords = ["anyOf", "oneOf", "allOf"]
+
+    private static func collapsedUnion(parent: [String: JSONValue],
+                                       branches: [JSONValue]) -> JSONValue {
+        for branch in branches {
+            guard case .object(var merged) = branch.gemmaSchemaNormalized(),
+                  merged.hasScalarStringType else { continue }
+            for (key, value) in parent where !unionKeywords.contains(key) {
+                if merged[key] == nil { merged[key] = value }
+            }
+            return .object(merged)
+        }
+        var fallback = parent
+        for keyword in unionKeywords { fallback[keyword] = nil }
+        fallback["type"] = .string("string")
+        return .object(fallback)
+    }
+
     public func encoded(sortedKeys: Bool = true) throws -> String {
         let encoder = JSONEncoder()
         if sortedKeys { encoder.outputFormatting = [.sortedKeys, .withoutEscapingSlashes] }
@@ -134,5 +197,23 @@ public indirect enum JSONValue: Codable, Equatable, Sendable {
         case .null:
             return "null"
         }
+    }
+}
+
+private extension Dictionary where Key == String, Value == JSONValue {
+    /// True when `type` is present as a single JSON string, which is the only
+    /// shape the Gemma template can feed to its `| upper` filter.
+    var hasScalarStringType: Bool {
+        if case .string? = self["type"] { return true }
+        return false
+    }
+}
+
+private extension Array where Element == JSONValue {
+    /// The first `type` member that names a concrete (non-`"null"`) type, used to
+    /// flatten `"type": ["string", "null"]` into a single scalar type.
+    var firstNonNullTypeName: String? {
+        for case .string(let name) in self where name != "null" { return name }
+        return nil
     }
 }

--- a/Sources/TurboFieldfare/Tokenization/Tokenizer.swift
+++ b/Sources/TurboFieldfare/Tokenization/Tokenizer.swift
@@ -262,7 +262,8 @@ public struct GFTokenizer: @unchecked Sendable {
                 "function": [
                     "name": tool.name,
                     "description": tool.description,
-                    "parameters": try tool.parameters.jinjaSendableValue(),
+                    "parameters": try tool.parameters
+                        .gemmaSchemaNormalized().jinjaSendableValue(),
                 ] as [String: any Sendable],
             ]
         }

--- a/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
@@ -445,11 +445,31 @@ public enum OpenAIRequestValidator {
                 throw invalid("message content is required",
                               "messages", "invalid_message")
             }
-            result.append(GFTokenizer.Message(role: role,
-                                              content: content,
-                                              toolCalls: calls,
-                                              toolCallID: message.toolCallID,
-                                              name: message.name))
+            // Merge consecutive same-role guidance into one message. The Gemma
+            // template only accepts a single leading system block, so clients
+            // that split guidance across several system (or developer) messages
+            // — e.g. an opencode plugin appending its own system prompt — would
+            // otherwise fail to render. System and developer runs stay distinct.
+            if (role == .system || role == .developer),
+               calls.isEmpty,
+               let previous = result.last,
+               previous.role == role {
+                let merged = [previous.content, content]
+                    .compactMap { $0 }
+                    .joined(separator: "\n\n")
+                result[result.count - 1] = GFTokenizer.Message(
+                    role: role,
+                    content: merged.isEmpty ? nil : merged,
+                    toolCalls: previous.toolCalls,
+                    toolCallID: previous.toolCallID,
+                    name: previous.name)
+            } else {
+                result.append(GFTokenizer.Message(role: role,
+                                                  content: content,
+                                                  toolCalls: calls,
+                                                  toolCallID: message.toolCallID,
+                                                  name: message.name))
+            }
         }
         return result
     }

--- a/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
@@ -198,6 +198,91 @@ struct OpenAIValidationTests {
         #expect(parsed.arguments.objectValue?["file-path"] == .string("/tmp/x"))
     }
 
+    @Test func unionAndTypelessToolSchemasRenderWithoutThrowing() async throws {
+        // pi's `mcp` tool (anyOf string|object), a kagi-style nullable integer
+        // (anyOf integer|null), a github-style anyOf string|array, and a bare
+        // enum with no `type` — every shape that used to abort template rendering.
+        let data = Data(#"""
+        {
+          "model":"m",
+          "messages":[{"role":"user","content":"hi"}],
+          "tools":[{
+            "type":"function",
+            "function":{
+              "name":"mcp",
+              "description":"gateway",
+              "parameters":{
+                "type":"object",
+                "properties":{
+                  "args":{"description":"tool args","anyOf":[
+                    {"type":"string"},
+                    {"type":"object","properties":{},"additionalProperties":true}
+                  ]},
+                  "limit":{"anyOf":[{"type":"integer"},{"type":"null"}]},
+                  "files":{"anyOf":[
+                    {"type":"string"},
+                    {"type":"array","items":{"type":"string"}}
+                  ]},
+                  "mode":{"enum":["a","b"]},
+                  "nick":{"type":["string","null"]}
+                }
+              }
+            }
+          }]
+        }
+        """#.utf8)
+        let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+        let validated = try OpenAIRequestValidator.validate(request, modelID: "m")
+        let tokenizer = try await GFTokenizer.load()
+        let rendered = tokenizer.decode(
+            try tokenizer.encodeToolChat(
+                messages: validated.messages, tools: validated.tools),
+            skipSpecialTokens: false)
+        #expect(rendered.contains("mcp"))
+        #expect(rendered.contains("args"))
+    }
+
+    @Test func unionSchemaCollapsesToFirstConcreteBranch() throws {
+        let schema = try JSONDecoder().decode(JSONValue.self, from: Data(#"""
+        {"description":"d","anyOf":[{"type":"string"},{"type":"object"}]}
+        """#.utf8))
+        let normalized = schema.gemmaSchemaNormalized().objectValue
+        #expect(normalized?["type"] == .string("string"))
+        #expect(normalized?["description"] == .string("d"))
+        #expect(normalized?["anyOf"] == nil)
+    }
+
+    @Test func nullableTypeArrayCollapsesToConcreteType() throws {
+        let schema = try JSONDecoder().decode(JSONValue.self, from: Data(#"""
+        {"type":["null","integer"]}
+        """#.utf8))
+        #expect(schema.gemmaSchemaNormalized().objectValue?["type"] == .string("integer"))
+    }
+
+    @Test func typelessSchemaDefaultsByShape() throws {
+        let object = try JSONDecoder().decode(JSONValue.self, from: Data(#"""
+        {"properties":{"a":{"type":"string"}}}
+        """#.utf8))
+        #expect(object.gemmaSchemaNormalized().objectValue?["type"] == .string("object"))
+        let scalar = try JSONDecoder().decode(JSONValue.self, from: Data(#"{"title":"x"}"#.utf8))
+        #expect(scalar.gemmaSchemaNormalized().objectValue?["type"] == .string("string"))
+    }
+
+    @Test func consecutiveSystemMessagesCoalesceButKeepDeveloperDistinct() throws {
+        let data = Data(#"""
+        {"model":"m","messages":[
+          {"role":"system","content":"first"},
+          {"role":"system","content":"second"},
+          {"role":"developer","content":"dev"},
+          {"role":"user","content":"hello"}
+        ]}
+        """#.utf8)
+        let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+        let validated = try OpenAIRequestValidator.validate(request, modelID: "m")
+        #expect(validated.messages.map(\.role) == [.system, .developer, .user])
+        #expect(validated.messages.first?.content == "first\n\nsecond")
+    }
+
     @Test func ambiguousParameterKeysFailValidation() throws {
         let data = Data(#"""
         {


### PR DESCRIPTION
## Summary

- This support the tool calling from OpenCode and Pi agent.
- Also allow for repeated system message when opencode is used with plugins like https://github.com/alfaoz/opencode-see-image

## Validation

1. Recompile
2. Add config of turbo-fieldfare to opencode
3. Add an MCP server
4. Test with a prompt in opencode

## Memory and performance

N/A

## Remaining limitations

N/A
