### PR TITLE
Handle "/v1/models?" endpoint for Xcode

### DIFF
--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -173,7 +173,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         switch (head.method, head.uri) {
         case (.GET, "/health"):
             writeJSON(context, status: .ok, object: ["status": "ok"])
-        case (.GET, "/v1/models"):
+        case (.GET, "/v1/models"), (.GET, "/v1/models?"):
             let response = OpenAIModelList(
                 object: "list",
                 data: [.init(id: modelID,


### PR DESCRIPTION
Xcode 27 checks for available models at "/v1/models?" instead of "/v1/models".

By also handling "/v1/models?", Xcode can find the available models.