### PR TITLE
Support macOS 15 and Swift 6.1 while keeping the Metal 4 prefill path

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -25,7 +25,7 @@ body:
     id: environment
     attributes:
       label: macOS and Swift versions
-      placeholder: macOS 26.x, Swift 6.2
+      placeholder: macOS 15.x, Swift 6.1
     validations:
       required: true
   - type: textarea

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,12 +22,28 @@ concurrency:
 jobs:
   test:
     if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
-    runs-on: macos-26
+    # macos-15 holds the Swift 6.1 / macOS 15 SDK floor; macos-26 exercises the
+    # MSL 4.0 tensor-ops path. Both must build.
+    strategy:
+      fail-fast: false
+      matrix:
+        runner:
+          - macos-15
+          - macos-26
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
+      - name: Report toolchain
+        run: swift --version
       - name: Build release products
         run: swift build -c release
       - name: Run serial tests
         run: Scripts/test.sh
+
+  docs:
+    if: github.event_name != 'pull_request' || github.event.pull_request.draft == false
+    runs-on: macos-26
+    steps:
+      - uses: actions/checkout@v4
       - name: Check Markdown links
         run: ruby Scripts/check_markdown_links.rb

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,7 +41,7 @@ the server is needed, and stop only a server you launched.
 
 ## Test rules
 
-Before a model run, require macOS 26+, Swift 6.2+, enough disk, acceptable `memory_pressure -Q`, a completed `scratch/gemma4.gturbo`, and no process from `pgrep -fl 'TurboFieldfareServer|TurboFieldfareMac|TurboFieldfareDecodeService|TurboFieldfareCLI|TurboFieldfarePackageTests|swiftpm-testing-helper|mlx_lm|mlx-lm'`. If a check fails, inform the user and stop; do not terminate apps or delete or reinstall the model.
+Before a model run, require macOS 15+, Swift 6.1+, enough disk, acceptable `memory_pressure -Q`, a completed `scratch/gemma4.gturbo`, and no process from `pgrep -fl 'TurboFieldfareServer|TurboFieldfareMac|TurboFieldfareDecodeService|TurboFieldfareCLI|TurboFieldfarePackageTests|swiftpm-testing-helper|mlx_lm|mlx-lm'`. If a check fails, inform the user and stop; do not terminate apps or delete or reinstall the model.
 
 Run package tests through `Scripts/test.sh`. Run only one app, CLI, or model-using test at a time.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -5,7 +5,9 @@ benchmark reports from Apple Silicon Macs.
 
 ## Before opening a change
 
-- Keep the package compatible with macOS 26, Swift 6.2, and Metal 4.
+- Keep the package compatible with macOS 15 and Swift 6.1. Metal 4 tensor-ops
+  code must stay behind `__HAVE_TENSOR__` in the shaders and behind the
+  `MetalSDKCompatibility.swift` shims in Swift, with a working fallback path.
 - Preserve the bounded-memory model path. Never load a complete checkpoint,
   shard, or large model tensor into Swift heap memory.
 - Keep public runtime controls limited to those documented in

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,6 +1,15 @@
 {
-  "originHash" : "fcd8c6c7b3bdc1b2987889f5525974610779e7fe094361a13b5cd2b27afa046b",
+  "originHash" : "0a9539656019b82257d25bfcd5cc1fe23bfa9a0f576ffa44952b26c4124896f5",
   "pins" : [
+    {
+      "identity" : "async-http-client",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/async-http-client.git",
+      "state" : {
+        "revision" : "3a5b74a58782c3b4c1f0bc75e9b67b10c2494e8f",
+        "version" : "1.33.1"
+      }
+    },
     {
       "identity" : "eventsource",
       "kind" : "remoteSourceControl",
@@ -8,6 +17,15 @@
       "state" : {
         "revision" : "a3a85a85214caf642abaa96ae664e4c772a59f6e",
         "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-algorithms.git",
+      "state" : {
+        "revision" : "87e50f483c54e6efd60e885f7f5aa946cee68023",
+        "version" : "1.2.1"
       }
     },
     {
@@ -20,12 +38,30 @@
       }
     },
     {
+      "identity" : "swift-async-algorithms",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-async-algorithms.git",
+      "state" : {
+        "revision" : "3da39bbc4e687d4192af7c9cf4eab805745a0b9c",
+        "version" : "1.1.5"
+      }
+    },
+    {
       "identity" : "swift-atomics",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
         "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
         "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-certificates",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-certificates.git",
+      "state" : {
+        "revision" : "449dbbecd0f31e82b510ada227ca152caa8b5e98",
+        "version" : "1.19.4"
       }
     },
     {
@@ -47,6 +83,33 @@
       }
     },
     {
+      "identity" : "swift-distributed-tracing",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-distributed-tracing.git",
+      "state" : {
+        "revision" : "dc4030184203ffafbb2ec614352487235d747fe0",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-http-structured-headers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-structured-headers.git",
+      "state" : {
+        "revision" : "933538faa42c432d385f02e07df0ace7c5ecfc47",
+        "version" : "1.7.0"
+      }
+    },
+    {
+      "identity" : "swift-http-types",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-http-types.git",
+      "state" : {
+        "revision" : "db774a277f60063a32d854f2980299caf06da041",
+        "version" : "1.6.0"
+      }
+    },
+    {
       "identity" : "swift-huggingface",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-huggingface.git",
@@ -65,12 +128,84 @@
       }
     },
     {
+      "identity" : "swift-log",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-log.git",
+      "state" : {
+        "revision" : "a878e7f8f46cfc0e1125e565b5c08e7d5272dc9a",
+        "version" : "1.14.0"
+      }
+    },
+    {
       "identity" : "swift-nio",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
         "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
         "version" : "2.99.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-extras",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-extras.git",
+      "state" : {
+        "revision" : "88a51340f59cf181ebde888bd1b749296b3ec029",
+        "version" : "1.34.3"
+      }
+    },
+    {
+      "identity" : "swift-nio-http2",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-http2.git",
+      "state" : {
+        "revision" : "45bdf670248be5f16ec0340e125dca285536f0fb",
+        "version" : "1.45.0"
+      }
+    },
+    {
+      "identity" : "swift-nio-ssl",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-ssl.git",
+      "state" : {
+        "revision" : "d930168b86f46ca51a4bc09c5ca45c1833db8067",
+        "version" : "2.37.2"
+      }
+    },
+    {
+      "identity" : "swift-nio-transport-services",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-nio-transport-services.git",
+      "state" : {
+        "revision" : "67787bb645a5e67d2edcdfbe48a216cc549222d5",
+        "version" : "1.28.0"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics.git",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-service-context",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-service-context.git",
+      "state" : {
+        "revision" : "d0997351b0c7779017f88e7a93bc30a1878d7f29",
+        "version" : "1.3.0"
+      }
+    },
+    {
+      "identity" : "swift-service-lifecycle",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/swift-server/swift-service-lifecycle.git",
+      "state" : {
+        "revision" : "9829955b385e5bb88128b73f1b8389e9b9c3191a",
+        "version" : "2.11.0"
       }
     },
     {
@@ -89,6 +224,15 @@
       "state" : {
         "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
         "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swift-xet",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-xet.git",
+      "state" : {
+        "revision" : "341bfd4172f6a57119bfd49bafa11cf5d21fab75",
+        "version" : "0.2.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -1,11 +1,14 @@
-// swift-tools-version: 6.2
+// swift-tools-version: 6.1
 import PackageDescription
 
+// macOS 15 / iOS 18 is the floor set by `Synchronization.Mutex` and SwiftUI's
+// `WindowDragGesture`. Building against a newer SDK still lights up the MSL 4.0
+// tensor-ops kernels at runtime; see `MetalSDKCompatibility.swift`.
 let package = Package(
     name: "TurboFieldfare",
     platforms: [
-        .macOS(.v26),
-        .iOS(.v26),
+        .macOS(.v15),
+        .iOS(.v18),
     ],
     products: [
         .library(name: "TurboFieldfare", targets: ["TurboFieldfare"]),

--- a/README.md
+++ b/README.md
@@ -10,9 +10,9 @@
 </p>
 
 <p align="center">
-  <img alt="Swift 6.2" src="https://img.shields.io/badge/Swift-6.2-F05138?logo=swift&logoColor=white">
-  <img alt="Metal 4" src="https://img.shields.io/badge/Metal-4-5E5CE6">
-  <img alt="macOS 26 or later" src="https://img.shields.io/badge/macOS-26%2B-000000?logo=apple&logoColor=white">
+  <img alt="Swift 6.1 or later" src="https://img.shields.io/badge/Swift-6.1%2B-F05138?logo=swift&logoColor=white">
+  <img alt="Metal 3.2 or later" src="https://img.shields.io/badge/Metal-3.2%2B-5E5CE6">
+  <img alt="macOS 15 or later" src="https://img.shields.io/badge/macOS-15%2B-000000?logo=apple&logoColor=white">
   <a href="LICENSE"><img alt="Apache 2.0 license" src="https://img.shields.io/badge/License-Apache%202.0-2ea44f"></a>
 </p>
 
@@ -69,7 +69,7 @@ your prompt, and press **Generate**.
 | Memory          | ~2 GB of weights and 4K KV cache                                                                                         |
 | Storage         | About 14.3 GB for the installed text-only model                                                                          |
 | Hardware        | Apple Silicon Mac; 8 GB of RAM                                                                                            |
-| Platform        | macOS 26, Metal 4, Swift 6.2                                                                                             |
+| Platform        | macOS 15+, Metal 3.2, Swift 6.1+; macOS 26 on Apple10 adds the Metal 4 tensor-ops prefill path                            |
 | M2 measured decode | [5.1-6.3 tok/s](docs/BENCHMARKS.md#m2-measured-decode) on an 8 GB M2 MacBook Air |
 | M5 measured decode | [31-35 tok/s](docs/BENCHMARKS.md#m5-measured-decode) on a 24 GB M5 Pro |
 
@@ -99,12 +99,16 @@ The Swift package exposes six products:
 ### Requirements
 
 - An Apple Silicon Mac; the validated target is an 8 GB M2 MacBook Air
-- macOS 26 with Metal 4
-- Xcode 26 and Swift 6.2 or newer
+- macOS 15 or later, with Metal 3.2
+- Xcode 16.3 and Swift 6.1 or newer
 - Enough free storage for the ~14.3 GB model installation
 - An internet connection for the first model install
 
-The package is arm64-only. Older macOS and Metal versions are not supported.
+The package is arm64-only; earlier macOS versions are not supported. Building
+on macOS 26 with Xcode 26 additionally compiles the shaders at MSL 4.0, which
+enables the Metal 4 tensor-ops prefill kernels on Apple10 GPUs. Every other
+supported configuration selects the non-tensor kernels automatically, so the
+runtime is functionally identical and differs only in prefill throughput.
 
 ### Prompting the model
 

--- a/Sources/TurboFieldfare/Infrastructure/Metal/MetalContext.swift
+++ b/Sources/TurboFieldfare/Infrastructure/Metal/MetalContext.swift
@@ -101,9 +101,11 @@ public final class MetalContext: @unchecked Sendable {
 
     /// MSL version used for every runtime shader compile.
     ///
-    /// The MPP prefill path requires MSL 4.0 tensor operations, which need both
-    /// a macOS 26 SDK to name the enum case and a macOS 26 runtime to accept it.
-    /// When either is missing we compile at 3.2; the shader sources guard their
+    /// The MPP prefill path requires MSL 4.0 tensor operations, which the Metal
+    /// compiler only accepts on macOS 26. `MTLLanguageVersion.msl4_0` is built
+    /// from a raw value and is non-nil on every SDK, so the `#available` check
+    /// is what actually keeps MSL 4.0 away from older systems — do not remove
+    /// it. Below macOS 26 we compile at 3.2; the shader sources guard their
     /// tensor-ops kernels behind `__HAVE_TENSOR__`, so those kernels drop out of
     /// the library and their Swift callers take the non-tensor path.
     private static var shaderLanguageVersion: MTLLanguageVersion {

--- a/Sources/TurboFieldfare/Infrastructure/Metal/MetalContext.swift
+++ b/Sources/TurboFieldfare/Infrastructure/Metal/MetalContext.swift
@@ -99,6 +99,20 @@ public final class MetalContext: @unchecked Sendable {
                                  subdirectory: subdirectory)
     }
 
+    /// MSL version used for every runtime shader compile.
+    ///
+    /// The MPP prefill path requires MSL 4.0 tensor operations, which need both
+    /// a macOS 26 SDK to name the enum case and a macOS 26 runtime to accept it.
+    /// When either is missing we compile at 3.2; the shader sources guard their
+    /// tensor-ops kernels behind `__HAVE_TENSOR__`, so those kernels drop out of
+    /// the library and their Swift callers take the non-tensor path.
+    private static var shaderLanguageVersion: MTLLanguageVersion {
+        if #available(macOS 26.0, iOS 26.0, *), let version4 = MTLLanguageVersion.msl4_0 {
+            return version4
+        }
+        return .version3_2
+    }
+
     private static func compileShaderLibrary(device: MTLDevice) throws -> MTLLibrary {
         var combined = ""
         for name in shaderModules {
@@ -110,8 +124,7 @@ public final class MetalContext: @unchecked Sendable {
         }
         do {
             let opts = MTLCompileOptions()
-            // The MPP prefill path requires MSL 4.0 tensor operations.
-            opts.languageVersion = .version4_0
+            opts.languageVersion = shaderLanguageVersion
             return try device.makeLibrary(source: combined, options: opts)
         } catch {
             throw MetalError.libraryCompileFailed("\(error)")
@@ -125,7 +138,7 @@ public final class MetalContext: @unchecked Sendable {
         }
         let src = try String(contentsOf: url, encoding: .utf8)
         let opts = MTLCompileOptions()
-        opts.languageVersion = .version4_0
+        opts.languageVersion = shaderLanguageVersion
         do {
             return try device.makeLibrary(source: src, options: opts)
         } catch {

--- a/Sources/TurboFieldfare/Infrastructure/Metal/MetalSDKCompatibility.swift
+++ b/Sources/TurboFieldfare/Infrastructure/Metal/MetalSDKCompatibility.swift
@@ -5,32 +5,37 @@ import Metal
 ///
 /// The package deploys to macOS 15 so it can be built by the Swift 6.1
 /// toolchain, whose SDK does not declare `MTLLanguageVersion.version4_0` or
-/// `MTLGPUFamily.apple10`. Both are integer-backed `NS_ENUM`s, so we look them
-/// up by raw value instead of naming the case: the lookup returns `nil` on the
-/// older SDK and the real case on the newer one. That keeps the MPP tensor-ops
-/// fast path available to anyone building with Xcode 26 without breaking the
-/// older toolchain.
+/// `MTLGPUFamily.apple10`. Both are integer-backed `NS_ENUM`s, so we pass their
+/// raw values through instead of naming the cases.
+///
+/// These import as non-frozen enums, so `init?(rawValue:)` does **not** reject
+/// undeclared values — it constructs one, and `MetalSDKCompatibilityTests` pins
+/// that. Nothing here can tell you whether the SDK knows a case, so callers must
+/// gate on the runtime OS instead:
+///
+/// - `MTLGPUFamily` is safe to pass through. `supportsFamily` is a runtime
+///   query, so a system with no Apple10 answers `false`.
+/// - `MTLLanguageVersion` is **not** safe to pass through. Handing MSL 4.0 to
+///   the macOS 15 Metal compiler fails the entire shader library, which takes
+///   the whole runtime down — so `MetalContext.shaderLanguageVersion` guards it
+///   with `#available` and must keep doing so.
 
 extension MTLLanguageVersion {
     /// MSL 4.0 — the version that enables the MPP tensor-ops kernels.
-    /// `nil` when compiled against an SDK that predates it.
     ///
     /// `MTLLanguageVersion` encodes its raw value as `(major << 16) + minor`.
+    /// Never hand this to Metal outside a macOS 26 availability check.
     static var msl4_0: MTLLanguageVersion? { MTLLanguageVersion(rawValue: 4 << 16) }
-}
-
-extension MTLGPUFamily {
-    /// `MTLGPUFamily.apple10` — the first family with MPP tensor support.
-    /// `nil` when compiled against an SDK that predates it.
-    static var apple10IfAvailable: MTLGPUFamily? { MTLGPUFamily(rawValue: 1010) }
 }
 
 extension MTLDevice {
     /// Whether this device supports the Apple10 MPP tensor operations that back
-    /// the TensorOps prefill kernels. Always `false` when the package is built
-    /// against an SDK that has no Apple10 family to ask about.
+    /// the TensorOps prefill kernels.
+    ///
+    /// Safe to ask on any OS: an older system simply reports `false` for a
+    /// family it has never heard of.
     var supportsApple10TensorOps: Bool {
-        guard let family = MTLGPUFamily.apple10IfAvailable else { return false }
+        guard let family = MTLGPUFamily(rawValue: 1010) else { return false }
         return supportsFamily(family)
     }
 }

--- a/Sources/TurboFieldfare/Infrastructure/Metal/MetalSDKCompatibility.swift
+++ b/Sources/TurboFieldfare/Infrastructure/Metal/MetalSDKCompatibility.swift
@@ -1,0 +1,36 @@
+import Foundation
+import Metal
+
+/// Shims for Metal symbols that exist only in the macOS 26 / iOS 26 SDK.
+///
+/// The package deploys to macOS 15 so it can be built by the Swift 6.1
+/// toolchain, whose SDK does not declare `MTLLanguageVersion.version4_0` or
+/// `MTLGPUFamily.apple10`. Both are integer-backed `NS_ENUM`s, so we look them
+/// up by raw value instead of naming the case: the lookup returns `nil` on the
+/// older SDK and the real case on the newer one. That keeps the MPP tensor-ops
+/// fast path available to anyone building with Xcode 26 without breaking the
+/// older toolchain.
+
+extension MTLLanguageVersion {
+    /// MSL 4.0 — the version that enables the MPP tensor-ops kernels.
+    /// `nil` when compiled against an SDK that predates it.
+    ///
+    /// `MTLLanguageVersion` encodes its raw value as `(major << 16) + minor`.
+    static var msl4_0: MTLLanguageVersion? { MTLLanguageVersion(rawValue: 4 << 16) }
+}
+
+extension MTLGPUFamily {
+    /// `MTLGPUFamily.apple10` — the first family with MPP tensor support.
+    /// `nil` when compiled against an SDK that predates it.
+    static var apple10IfAvailable: MTLGPUFamily? { MTLGPUFamily(rawValue: 1010) }
+}
+
+extension MTLDevice {
+    /// Whether this device supports the Apple10 MPP tensor operations that back
+    /// the TensorOps prefill kernels. Always `false` when the package is built
+    /// against an SDK that has no Apple10 family to ask about.
+    var supportsApple10TensorOps: Bool {
+        guard let family = MTLGPUFamily.apple10IfAvailable else { return false }
+        return supportsFamily(family)
+    }
+}

--- a/Sources/TurboFieldfare/Kernels/Attention/PrefillAttention.swift
+++ b/Sources/TurboFieldfare/Kernels/Attention/PrefillAttention.swift
@@ -48,7 +48,7 @@ final class PrefillAttention {
     init(context: MetalContext) throws {
         self.context = context
         self.psoCausalTiled = try context.pipeline("attention_prefill_causal_tiled")
-        self.psoFullTensorOps2DValidityV2 = context.device.supportsFamily(.apple10)
+        self.psoFullTensorOps2DValidityV2 = context.device.supportsApple10TensorOps
             ? try? context.pipeline("attention_prefill_full_tensorops_2d_validity_v2")
             : nil
     }
@@ -79,12 +79,17 @@ final class PrefillAttention {
         let pipeline: MTLComputePipelineState
         if let tensorOpsPipeline {
             pipeline = tensorOpsPipeline
-        } else if tensorOpsShape && path == .fullTensorOps2DValidityV2 {
+        } else if tensorOpsShape
+                    && path == .fullTensorOps2DValidityV2
+                    && context.device.supportsApple10TensorOps {
+            // The device advertises MPP tensor support, so a missing pipeline
+            // means the kernel failed to build — a bug, not a platform limit.
             preconditionFailure(
-                "TensorOps 2D prefill attention requires Apple10 MPP tensor support")
+                "TensorOps 2D prefill attention pipeline is missing on an Apple10 device")
         } else {
-            // Explicit mode also falls back for incompatible shapes. Benchmark
-            // fixtures must use 512/16/2 to prove that TensorOps ran.
+            // Explicit mode also falls back for incompatible shapes, and on
+            // hosts without Apple10 MPP tensor support or without MSL 4.0.
+            // Benchmark fixtures must use 512/16/2 to prove that TensorOps ran.
             pipeline = causalTiledPipeline(kvRingCapacity: kvRingCapacity)
         }
         let headDim = Int(params.headDim)

--- a/Sources/TurboFieldfare/Kernels/Attention/PrefillAttention.swift
+++ b/Sources/TurboFieldfare/Kernels/Attention/PrefillAttention.swift
@@ -45,6 +45,11 @@ final class PrefillAttention {
     private let psoCausalTiled: MTLComputePipelineState
     private let psoFullTensorOps2DValidityV2: MTLComputePipelineState?
 
+    /// Whether the Apple10 MPP tensor-ops prefill kernel is usable here. False
+    /// on hosts without Apple10 support and on shader libraries compiled below
+    /// MSL 4.0, in which case `encodeCausal` uses the causal-tiled kernel.
+    var tensorOpsPipelineAvailable: Bool { psoFullTensorOps2DValidityV2 != nil }
+
     init(context: MetalContext) throws {
         self.context = context
         self.psoCausalTiled = try context.pipeline("attention_prefill_causal_tiled")

--- a/Tests/TurboFieldfare/Core/Infrastructure/Metal/MetalSDKCompatibilityTests.swift
+++ b/Tests/TurboFieldfare/Core/Infrastructure/Metal/MetalSDKCompatibilityTests.swift
@@ -4,44 +4,34 @@ import Metal
 
 /// Guards the raw-value lookups in `MetalSDKCompatibility.swift`.
 ///
-/// Those shims decide whether shaders compile at MSL 4.0. If they silently
-/// answer "no" on a Metal 4 machine, the TensorOps prefill kernels drop out of
-/// the library and prefill falls back to the causal-tiled path — everything
-/// still builds, still runs, and still produces correct output, just slower.
-/// These tests exist so that failure mode is loud instead.
+/// Those values decide whether shaders compile at MSL 4.0. Get the encoding
+/// wrong in one direction and a Metal 4 machine silently drops its tensor-ops
+/// kernels — everything still builds and produces correct output, just slower.
+/// Get it wrong in the other and the entire shader library fails to compile.
 @Suite struct MetalSDKCompatibilityTests {
 
     /// `MTLLanguageVersion` encodes its raw value as `(major << 16) + minor`.
-    /// Pin that against cases every supported SDK declares, so a wrong
-    /// assumption is caught even on a toolchain that has never heard of
-    /// MSL 4.0 and therefore cannot exercise `msl4_0` directly.
+    /// Pin that against cases the macOS 15 SDK declares, so a wrong assumption
+    /// is caught on the floor toolchain, which cannot name MSL 4.0 at all.
     @Test func languageVersionRawValueUsesMajorMinorEncoding() {
         #expect(MTLLanguageVersion(rawValue: 3 << 16) == .version3_0)
         #expect(MTLLanguageVersion(rawValue: (3 << 16) + 2) == .version3_2)
     }
 
-    /// The shims depend on `init?(rawValue:)` rejecting values the SDK does not
-    /// declare. If it ever started returning a constructed value instead, they
-    /// would claim Metal 4 support on every SDK, and `shaderLanguageVersion`
-    /// would hand `MTLCompileOptions` a version the compiler cannot honor.
-    @Test func unknownRawValuesAreRejected() {
-        #expect(MTLLanguageVersion(rawValue: 99 << 16) == nil)
-        #expect(MTLGPUFamily(rawValue: 9_999) == nil)
+    /// The value handed to `MTLCompileOptions` on macOS 26 must be exactly
+    /// MSL 4.0. It is built by raw value, so nothing else type-checks it.
+    @Test func msl4ShimCarriesTheMSL4RawValue() {
+        #expect(MTLLanguageVersion.msl4_0?.rawValue == 4 << 16)
     }
 
-    /// `MTLLanguageVersion.version4_0` and `MTLGPUFamily.apple10` both ship in
-    /// the macOS 26 SDK, so the two lookups must agree: either this build can
-    /// see Metal 4 or it cannot. A split means one raw value is wrong, and the
-    /// shims would misreport what the toolchain supports.
-    @Test func metal4ShimsResolveTogether() {
-        let hasMSL4 = MTLLanguageVersion.msl4_0 != nil
-        let hasApple10 = MTLGPUFamily.apple10IfAvailable != nil
-        #expect(hasMSL4 == hasApple10, """
-            Metal 4 SDK shims disagree: MTLLanguageVersion.msl4_0 \
-            \(hasMSL4 ? "resolved" : "was nil") but MTLGPUFamily.apple10IfAvailable \
-            \(hasApple10 ? "resolved" : "was nil"). Both are declared in the macOS 26 \
-            SDK, so either both resolve or neither does. Check the raw values in \
-            MetalSDKCompatibility.swift.
-            """)
+    /// Metal's enums import as non-frozen, so `init?(rawValue:)` constructs
+    /// undeclared values instead of rejecting them. That means nil-ness cannot
+    /// be used to detect whether the SDK knows a case, which is why
+    /// `MetalContext.shaderLanguageVersion` gates on `#available` instead.
+    /// If this ever starts failing, that guard could be simplified — until
+    /// then, removing it would hand MSL 4.0 to a macOS 15 Metal compiler.
+    @Test func unknownRawValuesAreConstructedNotRejected() {
+        #expect(MTLLanguageVersion(rawValue: 99 << 16) != nil)
+        #expect(MTLGPUFamily(rawValue: 9_999) != nil)
     }
 }

--- a/Tests/TurboFieldfare/Core/Infrastructure/Metal/MetalSDKCompatibilityTests.swift
+++ b/Tests/TurboFieldfare/Core/Infrastructure/Metal/MetalSDKCompatibilityTests.swift
@@ -1,0 +1,47 @@
+import Testing
+import Metal
+@testable import TurboFieldfare
+
+/// Guards the raw-value lookups in `MetalSDKCompatibility.swift`.
+///
+/// Those shims decide whether shaders compile at MSL 4.0. If they silently
+/// answer "no" on a Metal 4 machine, the TensorOps prefill kernels drop out of
+/// the library and prefill falls back to the causal-tiled path — everything
+/// still builds, still runs, and still produces correct output, just slower.
+/// These tests exist so that failure mode is loud instead.
+@Suite struct MetalSDKCompatibilityTests {
+
+    /// `MTLLanguageVersion` encodes its raw value as `(major << 16) + minor`.
+    /// Pin that against cases every supported SDK declares, so a wrong
+    /// assumption is caught even on a toolchain that has never heard of
+    /// MSL 4.0 and therefore cannot exercise `msl4_0` directly.
+    @Test func languageVersionRawValueUsesMajorMinorEncoding() {
+        #expect(MTLLanguageVersion(rawValue: 3 << 16) == .version3_0)
+        #expect(MTLLanguageVersion(rawValue: (3 << 16) + 2) == .version3_2)
+    }
+
+    /// The shims depend on `init?(rawValue:)` rejecting values the SDK does not
+    /// declare. If it ever started returning a constructed value instead, they
+    /// would claim Metal 4 support on every SDK, and `shaderLanguageVersion`
+    /// would hand `MTLCompileOptions` a version the compiler cannot honor.
+    @Test func unknownRawValuesAreRejected() {
+        #expect(MTLLanguageVersion(rawValue: 99 << 16) == nil)
+        #expect(MTLGPUFamily(rawValue: 9_999) == nil)
+    }
+
+    /// `MTLLanguageVersion.version4_0` and `MTLGPUFamily.apple10` both ship in
+    /// the macOS 26 SDK, so the two lookups must agree: either this build can
+    /// see Metal 4 or it cannot. A split means one raw value is wrong, and the
+    /// shims would misreport what the toolchain supports.
+    @Test func metal4ShimsResolveTogether() {
+        let hasMSL4 = MTLLanguageVersion.msl4_0 != nil
+        let hasApple10 = MTLGPUFamily.apple10IfAvailable != nil
+        #expect(hasMSL4 == hasApple10, """
+            Metal 4 SDK shims disagree: MTLLanguageVersion.msl4_0 \
+            \(hasMSL4 ? "resolved" : "was nil") but MTLGPUFamily.apple10IfAvailable \
+            \(hasApple10 ? "resolved" : "was nil"). Both are declared in the macOS 26 \
+            SDK, so either both resolve or neither does. Check the raw values in \
+            MetalSDKCompatibility.swift.
+            """)
+    }
+}

--- a/Tests/TurboFieldfare/Core/Kernels/Attention/PrefillAttentionTests.swift
+++ b/Tests/TurboFieldfare/Core/Kernels/Attention/PrefillAttentionTests.swift
@@ -191,6 +191,26 @@ import TurboFieldfareValidationSupport
         }
     }
 
+    /// The other TensorOps tests return early when the path is unavailable, so
+    /// on their own they would stay green if the kernel silently disappeared
+    /// from the shader library. This one fails loudly instead: once a device
+    /// reports Apple10 MPP tensor support, the pipeline must exist.
+    @Test func apple10DevicesMustProvideTheTensorOpsPipeline() throws {
+        let context = try MetalContext()
+        // A false reading means either a non-Apple10 GPU or a build against an
+        // SDK with no Apple10 family to ask about. Neither is a regression, and
+        // the second case cannot be distinguished from the first, so skip.
+        guard context.device.supportsApple10TensorOps else { return }
+        let prefill = try PrefillAttention(context: context)
+        #expect(prefill.tensorOpsPipelineAvailable, """
+            This device reports Apple10 MPP tensor support, but the TensorOps \
+            prefill pipeline is missing, so prefill silently fell back to the \
+            causal-tiled kernel. The usual cause is MetalContext's \
+            shaderLanguageVersion resolving below MSL 4.0, which drops every \
+            kernel guarded by __HAVE_TENSOR__ from the shader library.
+            """)
+    }
+
     private static func makeFixture(start: Int,
                                     chunk: Int,
                                     window: Int,

--- a/Tests/TurboFieldfare/Core/Kernels/Attention/PrefillAttentionTests.swift
+++ b/Tests/TurboFieldfare/Core/Kernels/Attention/PrefillAttentionTests.swift
@@ -141,7 +141,7 @@ import TurboFieldfareValidationSupport
         let context = try MetalContext()
         // Hosted CI has no Apple10 GPU, so it returns without dispatching this
         // kernel. Run this suite on Apple10 before changing the TensorOps path.
-        guard context.device.supportsFamily(.apple10) else { return }
+        guard context.device.supportsApple10TensorOps else { return }
         let fixture = Self.makeFixture(start: visibleKeys - 1,
                                        chunk: 1,
                                        window: 0,
@@ -185,7 +185,7 @@ import TurboFieldfareValidationSupport
                 "preferred TensorOps maxAbs=\(maxAbs) rel=\(rel)")
         #expect(rel <= 2e-2,
                 "preferred TensorOps rel=\(rel) maxAbs=\(maxAbs)")
-        if !context.device.supportsFamily(.apple10) {
+        if !context.device.supportsApple10TensorOps {
             let baseline = try Self.runKernel(fixture, path: .causalTiled)
             #expect(preferred == baseline)
         }


### PR DESCRIPTION
## Summary

  Lower the package baseline from macOS 26 / Swift 6.2 to macOS 15 / Swift 6.1
  without giving up the Metal 4 tensor-ops prefill path.

  The macOS 26 requirement was not earned by the code. There are no Swift 6.2
  language or stdlib features anywhere in the tree, the SwiftUI layer tops out at
  `WindowDragGesture`, and every dependency resolves against Swift 6.1 or earlier.
  The only macOS 26 symbols were `MTLLanguageVersion.version4_0` and
  `MTLGPUFamily.apple10`, both named in two files. macOS 15 / iOS 18 is the real
  floor, set by `Synchronization.Mutex` and `WindowDragGesture`.

  `MetalSDKCompatibility.swift` passes those two symbols to Metal by raw value
  instead of naming the cases, so one source tree builds on both SDKs. MSL 4.0 is
  selected behind an `#available(macOS 26.0, *)` check; below that the shaders
  compile at 3.2 and the kernels already guarded by `__HAVE_TENSOR__` drop out of
  the library on their own. Their Swift callers were already written to fall back,
  so no call site changed behavior.

  Building with Xcode 26 still compiles at MSL 4.0 and still builds the Apple10
  tensor-ops pipeline. The `preconditionFailure` for an explicitly requested
  TensorOps path is narrowed to devices that actually advertise Apple10 support,
  where a missing pipeline is a build bug rather than a platform limit.

  CI now builds and tests both `macos-15` and `macos-26` so the floor toolchain
  cannot regress.

  ## Validation

  - `swift build -c release` on macOS 15, Swift 6.1.2 (`arm64-apple-macosx15.0`).
  - `Scripts/test.sh` in CI on `macos-15` and `macos-26`: 519 tests, 109 suites,
    green on both legs.
  - `ruby Scripts/check_markdown_links.rb` in CI.
  - Mac app model install, then load and generation on macOS 15 across several
    context lengths and expert-cache slot counts. Responses were coherent.

  The Metal suites construct a `MetalContext`, which compiles the combined shader
  library, so the MSL 3.2 compile is covered by CI independently of any one
  machine.

  An earlier revision of `MetalSDKCompatibilityTests` asserted that
  `init?(rawValue:)` rejects values the SDK does not declare. CI disproved it on
  both legs: Metal's enums import as non-frozen and construct unknown values. The
  runtime never depended on that — `supportsFamily` is answered by the running OS,
  and the `#available` check is what gates MSL 4.0 — so only the documentation and
  the assertion were wrong. Both are corrected in `beb84e1`.

## Memory and performance

  Bounded-memory behavior is unchanged. This touches shader-library language
  selection and compute-pipeline selection only. No buffer, allocation, expert
  streaming, KV cache, or installer path is modified. `MetalContext` still compiles
  one library and `PrefillAttention` still holds one optional pipeline.

  No before/after measurements are included because no code path that executes on
  previously supported hardware changed:

  - macOS 26 + Apple10 + Xcode 26 still resolves MSL 4.0 and still builds the
    tensor-ops pipeline. Identical dispatch.
  - Every other host already failed the `supportsFamily(.apple10)` gate and already
    ran `attention_prefill_causal_tiled`. Identical dispatch.
  - Newly possible: an Xcode 16.3 build running on macOS 26 + Apple10 also selects
    MSL 4.0, because `#available` is a runtime check and the raw value is correct.
    That gains the fast path rather than losing it.

  `MPPPrefillInt4QMM` continues to degrade to a nil pipeline when its library will
  not compile, falling through to `prefillQMM` and the per-row INT4 path.

  ## Remaining limitations

  - No Apple10 hardware ran this. GitHub runners have no M5, so the tensor-ops
    prefill kernels are still uncovered, and `MPPPrefillInt4QMMTests` skips three
    cases with "Requires runtime MPP TensorOps support".
    `apple10DevicesMustProvideTheTensorOpsPipeline` is added to fail loudly the
    first time this meets real hardware, but it has never fired.
  - The `#available(macOS 26.0, *)` check in `MetalContext.shaderLanguageVersion`
    is load-bearing, not defensive. `MTLLanguageVersion.msl4_0` is non-nil on every
    SDK, so removing the check would hand MSL 4.0 to the macOS 15 Metal compiler
    and fail the entire shader library. Both files say so.
  - `Package.resolved` is toolchain-dependent. Swift 6.2 prunes dependencies gated
    behind swift-huggingface's disabled `Xet` trait; Swift 6.1 does not, so the
    file carries 16 extra transitive pins. The superset is committed because 6.1 is
    the declared floor. Expect it to show as dirty on an Xcode 26 machine; both CI
    legs build either way.
  - macOS 14 was not attempted. It would require replacing six `Mutex` uses and
    `WindowDragGesture`.
  - `docs/BENCHMARKS.md` still records macOS 26.5.1 / Swift 6.3.3, which is the
    environment those measurements actually ran in and should not be rewritten.
    The frozen README copy inside
    `docs/benchmark-prompts/real-generation-v1/long-synthesis.json` is a benchmark
    input and is deliberately left stale.
  - Running `swift test` locally can fail with a `PreviewsMacros` plugin error if
    `xcode-select` points at CommandLineTools, because the `#Preview` blocks in
    `OutputPaneView.swift` are inside `#if DEBUG` and are skipped by release
    builds. This is pre-existing and environmental; CI runners have full Xcode.

  - [x] The change does not load a complete checkpoint, shard, or large model
        tensor into Swift heap memory.
  - [x] Logs and artifacts contain no credentials, private paths, or model
        weights.