### PR TITLE
Fix/stream error frame

### DIFF
--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -230,9 +230,13 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                 let started = ContinuousClock.now
                 ServerLog.requestStarted(id: responseID, streaming: request.stream)
                 do {
+                    // Rendering and the context check happen before the head
+                    // is written, so a rejected prompt still gets a status
+                    // code even when the client asked for a stream.
+                    let prepared = try await self.backend.prepare(request)
                     let completion = try await self.coordinator.run(onQueued: startStream) {
                         startStream()
-                        return try await self.backend.generate(request) { event in
+                        return try await self.backend.generate(prepared) { event in
                             guard request.stream else { return }
                             switch event {
                             case .content(let text):

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -227,6 +227,8 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
             }
             activeTask = childChannels.startTask {
                 defer { streamState.stop() }
+                let started = ContinuousClock.now
+                ServerLog.requestStarted(id: responseID, streaming: request.stream)
                 do {
                     let completion = try await self.coordinator.run(onQueued: startStream) {
                         startStream()
@@ -248,6 +250,9 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                             }
                         }
                     }
+                    ServerLog.requestCompleted(id: responseID,
+                                               duration: started.duration(to: .now),
+                                               completion: completion)
                     if request.stream {
                         self.finishStream(contextBox.value,
                                           id: responseID,

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -268,6 +268,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                 } catch {
                     self.handleAsyncError(error,
                                           context: contextBox.value,
+                                          id: responseID,
                                           stream: streamState.isStarted)
                 }
             }
@@ -418,21 +419,49 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
 
     private func handleAsyncError(_ error: Error,
                                   context: ChannelHandlerContext,
+                                  id: String,
                                   stream: Bool) {
+        let (envelope, status) = failure(for: error)
+        ServerLog.requestFailed(id: id, status: status.code, streaming: stream, error: error)
         if stream {
-            let contextBox = SendableContext(context)
-            context.eventLoop.execute {
-                contextBox.value.close(promise: nil)
-            }
+            failStream(context, id: id, envelope: envelope)
+        } else {
+            writeError(context, status: status, envelope)
+        }
+    }
+
+    /// The status a failure would carry if nothing had been written yet. A
+    /// stream reports the same envelope in-band and keeps its committed `200`.
+    private func failure(for error: Error) -> (OpenAIErrorEnvelope, HTTPResponseStatus) {
+        if let requestError = error as? ServerRequestError {
+            return (requestError.envelope,
+                    requestError == .queueFull ? .tooManyRequests : .badRequest)
+        }
+        return (OpenAIErrorEnvelope(message: "generation failed",
+                                    type: "server_error",
+                                    code: "internal_error"),
+                .internalServerError)
+    }
+
+    /// Ends a committed stream on failure: one `error` frame, `[DONE]`, then a
+    /// normal end of the body. Closing the connection instead would reach the
+    /// client as an opaque transport error with no reason attached.
+    private func failStream(_ context: ChannelHandlerContext,
+                            id: String,
+                            envelope: OpenAIErrorEnvelope) {
+        let contextBox = SendableContext(context)
+        guard let data = try? JSONEncoder().encode(envelope) else {
+            ServerLog.streamAborted(id: id, reason: "error envelope could not be encoded")
+            context.eventLoop.execute { contextBox.value.close(promise: nil) }
             return
         }
-        if let requestError = error as? ServerRequestError {
-            let status: HTTPResponseStatus = requestError == .queueFull ? .tooManyRequests : .badRequest
-            writeError(context, status: status, requestError.envelope)
-        } else {
-            writeError(context, status: .internalServerError,
-                       OpenAIErrorEnvelope(message: "generation failed",
-                                           code: "internal_error"))
+        context.eventLoop.execute {
+            var buffer = contextBox.value.channel.allocator.buffer(capacity: data.count + 32)
+            buffer.writeString("data: ")
+            buffer.writeBytes(data)
+            buffer.writeString("\n\ndata: [DONE]\n\n")
+            contextBox.value.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+            contextBox.value.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
         }
     }
 

--- a/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
@@ -11,9 +11,12 @@ public struct OpenAIErrorEnvelope: Codable, Equatable, Sendable {
 
     public let error: Detail
 
-    public init(message: String, param: String? = nil, code: String) {
+    public init(message: String,
+                param: String? = nil,
+                type: String = "invalid_request_error",
+                code: String) {
         error = Detail(message: message,
-                       type: "invalid_request_error",
+                       type: type,
                        param: param,
                        code: code)
     }

--- a/Sources/TurboFieldfareServer/Core/ServerInference.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerInference.swift
@@ -24,9 +24,38 @@ public struct ServerCompletion: Equatable, Sendable {
     }
 }
 
+/// A request that has been rendered and measured against the context window.
+public struct PreparedGeneration: Sendable {
+    public let request: ValidatedChatRequest
+    public let promptIDs: [Int32]
+    public let needsToolTemplate: Bool
+
+    public init(request: ValidatedChatRequest,
+                promptIDs: [Int32] = [],
+                needsToolTemplate: Bool = false) {
+        self.request = request
+        self.promptIDs = promptIDs
+        self.needsToolTemplate = needsToolTemplate
+    }
+}
+
 public protocol ServerInferenceBackend: Sendable {
-    func generate(_ request: ValidatedChatRequest,
+    /// Everything that can reject a request must happen here, because the
+    /// caller commits the response status once `generate` starts: a streaming
+    /// request has `200` and the SSE head on the wire by then, and no status
+    /// left to send.
+    func prepare(_ request: ValidatedChatRequest) async throws -> PreparedGeneration
+
+    func generate(_ prepared: PreparedGeneration,
                   onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void) async throws -> ServerCompletion
+}
+
+extension ServerInferenceBackend {
+    /// Backends that do not tokenize inherit a pass-through. A backend that
+    /// renders a prompt must override this, or `generate` receives no tokens.
+    public func prepare(_ request: ValidatedChatRequest) async throws -> PreparedGeneration {
+        PreparedGeneration(request: request)
+    }
 }
 
 public actor ServerCoordinator {
@@ -193,17 +222,10 @@ public actor ServerModelSession: ServerInferenceBackend {
         self.promptCacheDomain = promptCacheDomain
     }
 
-    public func generate(
-        _ request: ValidatedChatRequest,
-        onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
-    ) async throws -> ServerCompletion {
-        var completed = false
-        defer {
-            if !completed {
-                promptCache.invalidate()
-                runner.reset()
-            }
-        }
+    /// Renders the prompt and checks it against the context window. Runs
+    /// before the response status is committed, and touches no generation
+    /// state, so it is safe to run while another request is generating.
+    public func prepare(_ request: ValidatedChatRequest) throws -> PreparedGeneration {
         let needsToolTemplate = !request.tools.isEmpty
             || request.messages.contains {
                 $0.role == .developer || $0.role == .tool || !$0.toolCalls.isEmpty
@@ -220,6 +242,25 @@ public actor ServerModelSession: ServerInferenceBackend {
                 message: "prompt exceeds the configured context",
                 param: "messages",
                 code: "context_length_exceeded")
+        }
+        return PreparedGeneration(request: request,
+                                  promptIDs: promptIDs,
+                                  needsToolTemplate: needsToolTemplate)
+    }
+
+    public func generate(
+        _ prepared: PreparedGeneration,
+        onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
+    ) async throws -> ServerCompletion {
+        let request = prepared.request
+        let needsToolTemplate = prepared.needsToolTemplate
+        let promptIDs = prepared.promptIDs
+        var completed = false
+        defer {
+            if !completed {
+                promptCache.invalidate()
+                runner.reset()
+            }
         }
 
         let effectivePromptIDs: [Int32]

--- a/Sources/TurboFieldfareServer/Core/ServerLog.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerLog.swift
@@ -1,0 +1,55 @@
+import Foundation
+
+/// Request lifecycle logging. Responses stay deliberately generic so runtime
+/// details never reach a client; the operator needs the opposite, so the log
+/// carries the underlying error verbatim. Local stderr only.
+///
+/// Start and completion are both logged: a long prefill emits no output for
+/// minutes, and without a start line that is indistinguishable from a wedged
+/// server.
+enum ServerLog {
+    static func requestStarted(id: String, streaming: Bool) {
+        write("request \(id) started streaming=\(streaming)")
+    }
+
+    static func requestCompleted(id: String,
+                                 duration: Duration,
+                                 completion: ServerCompletion) {
+        let usage = completion.usage
+        write("""
+        request \(id) completed in \(format(duration)) \
+        prompt=\(usage.promptTokens) \
+        cached=\(usage.promptTokensDetails.cachedTokens) \
+        completion=\(usage.completionTokens) \
+        finish=\(completion.finishReason)
+        """)
+    }
+
+    static func requestFailed(id: String, status: UInt, streaming: Bool, error: any Error) {
+        let detail = switch error {
+        case let error as ServerRequestError: describe(error)
+        default: String(describing: error)
+        }
+        write("request \(id) failed status=\(status) streaming=\(streaming) error=\(detail)")
+    }
+
+    static func streamAborted(id: String, reason: String) {
+        write("request \(id) stream aborted: \(reason)")
+    }
+
+    private static func format(_ duration: Duration) -> String {
+        let seconds = Double(duration.components.seconds)
+            + Double(duration.components.attoseconds) / 1e18
+        return String(format: "%.1fs", seconds)
+    }
+
+    private static func describe(_ error: ServerRequestError) -> String {
+        let detail = error.envelope.error
+        return "\(detail.code): \(detail.message)"
+    }
+
+    private static func write(_ message: String) {
+        let line = "[\(Date().formatted(.iso8601))] \(message)\n"
+        FileHandle.standardError.write(Data(line.utf8))
+    }
+}

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -13,7 +13,7 @@ private actor ScriptedServerBackend: ServerInferenceBackend {
     }
 
     func generate(
-        _ request: ValidatedChatRequest,
+        _ prepared: PreparedGeneration,
         onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
     ) async throws -> ServerCompletion {
         if delayNanoseconds > 0 {
@@ -30,7 +30,7 @@ private actor ScriptedServerBackend: ServerInferenceBackend {
 
 private actor MultipleToolBackend: ServerInferenceBackend {
     func generate(
-        _ request: ValidatedChatRequest,
+        _ prepared: PreparedGeneration,
         onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
     ) async throws -> ServerCompletion {
         let first = ParsedToolCall(
@@ -55,7 +55,7 @@ private actor MultipleToolBackend: ServerInferenceBackend {
 
 private actor ContentAndToolBackend: ServerInferenceBackend {
     func generate(
-        _ request: ValidatedChatRequest,
+        _ prepared: PreparedGeneration,
         onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
     ) async throws -> ServerCompletion {
         let content = "I will read it."
@@ -86,7 +86,7 @@ private actor PipelinedRequestBackend: ServerInferenceBackend {
     }
 
     func generate(
-        _ request: ValidatedChatRequest,
+        _ prepared: PreparedGeneration,
         onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
     ) async throws -> ServerCompletion {
         generationCount += 1
@@ -106,7 +106,7 @@ private struct DecodeFailure: Error {}
 /// failure does mid-generation.
 private actor FailingMidStreamBackend: ServerInferenceBackend {
     func generate(
-        _ request: ValidatedChatRequest,
+        _ prepared: PreparedGeneration,
         onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
     ) async throws -> ServerCompletion {
         onEvent(.content("partial"))
@@ -114,11 +114,12 @@ private actor FailingMidStreamBackend: ServerInferenceBackend {
     }
 }
 
-/// Rejects the request from inside `generate`, the way an overlong prompt does
-/// once the streaming head has been committed.
+/// Rejects from inside `generate`, once the streaming head is committed. The
+/// live equivalent is the effective-prompt check, which cannot run earlier
+/// because it depends on the KV prefix the request will be matched against.
 private actor RejectingBackend: ServerInferenceBackend {
     func generate(
-        _ request: ValidatedChatRequest,
+        _ prepared: PreparedGeneration,
         onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
     ) async throws -> ServerCompletion {
         throw ServerRequestError.invalid(
@@ -128,12 +129,30 @@ private actor RejectingBackend: ServerInferenceBackend {
     }
 }
 
+/// Rejects during `prepare`, the way an overlong prompt does.
+private actor RejectingPrepareBackend: ServerInferenceBackend {
+    func prepare(_ request: ValidatedChatRequest) async throws -> PreparedGeneration {
+        throw ServerRequestError.invalid(
+            message: "prompt exceeds the configured context",
+            param: "messages",
+            code: "context_length_exceeded")
+    }
+
+    func generate(
+        _ prepared: PreparedGeneration,
+        onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
+    ) async throws -> ServerCompletion {
+        Issue.record("generate must not run after prepare fails")
+        throw DecodeFailure()
+    }
+}
+
 private actor CancellableServerBackend: ServerInferenceBackend {
     private(set) var startedCount = 0
     private(set) var cancellationCount = 0
 
     func generate(
-        _ request: ValidatedChatRequest,
+        _ prepared: PreparedGeneration,
         onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
     ) async throws -> ServerCompletion {
         startedCount += 1
@@ -241,6 +260,32 @@ struct HTTPServerTests {
         #expect(text.contains(#""type":"server_error""#))
         #expect(!text.contains(#""finish_reason":"stop""#))
         #expect(text.hasSuffix("data: [DONE]\n\n"))
+
+        try await server.shutdown()
+    }
+
+    @Test func streamingPrepareRejectionKeepsItsStatusCode() async throws {
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: RejectingPrepareBackend())
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(
+            url: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"""
+        {"model":"test-model","messages":[{"role":"user","content":"hi"}],"stream":true}
+        """#.utf8)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        let httpResponse = try #require(response as? HTTPURLResponse)
+        // Rejected before the head, so the stream was never opened.
+        #expect(httpResponse.statusCode == 400)
+        #expect(httpResponse.value(forHTTPHeaderField: "content-type") == "application/json")
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains(#""code":"context_length_exceeded""#))
+        #expect(!text.contains("data:"))
 
         try await server.shutdown()
     }

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -100,6 +100,34 @@ private actor PipelinedRequestBackend: ServerInferenceBackend {
     }
 }
 
+private struct DecodeFailure: Error {}
+
+/// Fails after `onEvent` has already put content on the wire, the way a decode
+/// failure does mid-generation.
+private actor FailingMidStreamBackend: ServerInferenceBackend {
+    func generate(
+        _ request: ValidatedChatRequest,
+        onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
+    ) async throws -> ServerCompletion {
+        onEvent(.content("partial"))
+        throw DecodeFailure()
+    }
+}
+
+/// Rejects the request from inside `generate`, the way an overlong prompt does
+/// once the streaming head has been committed.
+private actor RejectingBackend: ServerInferenceBackend {
+    func generate(
+        _ request: ValidatedChatRequest,
+        onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
+    ) async throws -> ServerCompletion {
+        throw ServerRequestError.invalid(
+            message: "prompt exceeds the configured context",
+            param: "messages",
+            code: "context_length_exceeded")
+    }
+}
+
 private actor CancellableServerBackend: ServerInferenceBackend {
     private(set) var startedCount = 0
     private(set) var cancellationCount = 0
@@ -186,6 +214,65 @@ struct HTTPServerTests {
         #expect(text.contains(#""prompt_tokens":3"#))
         #expect(text.contains(#""cached_tokens":0"#))
         #expect(text.hasSuffix("data: [DONE]\n\n"))
+
+        try await server.shutdown()
+    }
+
+    @Test func streamingFailureAfterHeadReportsErrorInBand() async throws {
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: FailingMidStreamBackend())
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(
+            url: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"""
+        {"model":"test-model","messages":[{"role":"user","content":"hi"}],"stream":true}
+        """#.utf8)
+        // A dropped connection fails this call: the body must end normally.
+        let (data, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains(#""content":"partial""#))
+        #expect(text.contains(#""code":"internal_error""#))
+        #expect(text.contains(#""type":"server_error""#))
+        #expect(!text.contains(#""finish_reason":"stop""#))
+        #expect(text.hasSuffix("data: [DONE]\n\n"))
+
+        try await server.shutdown()
+    }
+
+    @Test func streamingRejectionAfterHeadNamesTheCause() async throws {
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: RejectingBackend())
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(
+            url: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"""
+        {"model":"test-model","messages":[{"role":"user","content":"hi"}],"stream":true}
+        """#.utf8)
+        let (data, _) = try await URLSession.shared.data(for: request)
+        let text = String(decoding: data, as: UTF8.self)
+        #expect(text.contains(#""code":"context_length_exceeded""#))
+        #expect(text.contains(#""param":"messages""#))
+        #expect(text.hasSuffix("data: [DONE]\n\n"))
+
+        // The same request without a stream still gets a real status code.
+        request.httpBody = Data(#"""
+        {"model":"test-model","messages":[{"role":"user","content":"hi"}]}
+        """#.utf8)
+        let (blocking, blockingResponse) = try await URLSession.shared.data(for: request)
+        #expect((blockingResponse as? HTTPURLResponse)?.statusCode == 400)
+        #expect(String(decoding: blocking, as: UTF8.self)
+            .contains(#""code":"context_length_exceeded""#))
 
         try await server.shutdown()
     }

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -88,6 +88,39 @@ OpenCode:
 
 Select `turbofieldfare/gemma-4-26b-a4b-it` in OpenCode.
 
+Pi, in `~/.pi/agent/models.json`:
+
+```json
+{
+  "providers": {
+    "turbofieldfare": {
+      "baseUrl": "http://127.0.0.1:8080/v1",
+      "api": "openai-completions",
+      "apiKey": "local",
+      "compat": {
+        "supportsReasoningEffort": false,
+        "supportsStrictMode": false,
+        "supportsUsageInStreaming": true
+      },
+      "models": [
+        {
+          "id": "gemma-4-26b-a4b-it",
+          "name": "Gemma 4 26B-A4B IT",
+          "reasoning": false,
+          "contextWindow": 16384,
+          "maxTokens": 4096
+        }
+      ]
+    }
+  }
+}
+```
+
+Keep `contextWindow` at or below the server's `--max-context`, or Pi will send
+histories the server rejects. The `compat` flags match the unsupported
+features listed under [Supported API](#supported-api). Select the model with
+`/model` in Pi, or make it the default in `~/.pi/agent/settings.json`.
+
 ## Prompt reuse
 
 Single-prefix KV reuse is on by default. Send the complete message history with

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -151,6 +151,29 @@ the connection, so a client that sees an aborted transport (`TypeError:
 terminated` under undici, for example) should look for a dead server process
 or its own timeout rather than a generation error.
 
+## Server log
+
+The server writes one line per request to stderr:
+
+```text
+[2026-07-31T17:03:10Z] request chatcmpl-f6a02587… started streaming=true
+[2026-07-31T17:03:12Z] request chatcmpl-f6a02587… completed in 2.4s prompt=812 cached=768 completion=96 finish=stop
+```
+
+The start line is written before the model runs, so a long prefill — which
+emits nothing for minutes — is distinguishable from a wedged server. The
+completion line reports how much of the prompt the KV prefix supplied in
+`cached`, matching `usage.prompt_tokens_details.cached_tokens`.
+
+A failed request logs the status it would have carried, whether or not a
+stream had already committed `200`, along with the underlying error — which is
+more detail than the response carries, since responses deliberately do not
+leak runtime internals:
+
+```text
+[2026-07-31T17:09:32Z] request chatcmpl-b36dd1ed… failed status=400 streaming=true error=context_length_exceeded: prompt exceeds the configured context
+```
+
 ## Supported API
 
 Endpoints:

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -119,6 +119,38 @@ The server accepts only function tools. Omit `tool_choice` or set it to `auto`
 to allow calls. Set it to `none` to disable them. The server does not support
 `required`, named tool selection, or `parallel_tool_calls: false`.
 
+## Errors
+
+The prompt is rendered and checked against the context window before any
+response is written, so an overlong prompt, an unknown model, an unsupported
+parameter, an oversized body, or a full queue comes back as a JSON error
+envelope with a real status code — `400`, `404`, `413`, `415`, or `429` — and
+no stream is started. Asking for `"stream": true` does not change this.
+
+A failure raised after that point cannot change the status, because a
+streaming request already has `200` and the SSE head on the wire. It is
+reported in-band instead: one frame carrying an `error` object, then
+`data: [DONE]`, then a normal end of the chunked body.
+
+```text
+data: {"error":{"message":"generation failed","code":"internal_error","type":"server_error"}}
+
+data: [DONE]
+
+```
+
+The frame carries the same envelope the blocking path would have returned, so
+a failure that can only surface once generation is under way still names its
+cause. Reusing a KV prefix is the case that reaches it: whether the retained
+prefix plus the new turn fits the context window is known only after the
+prompt cache has been matched, which happens after the head is committed.
+
+Treat any frame with an `error` key as fatal for that request; no
+`finish_reason` chunk precedes it. The stream is never terminated by dropping
+the connection, so a client that sees an aborted transport (`TypeError:
+terminated` under undici, for example) should look for a dead server process
+or its own timeout rather than a generation error.
+
 ## Supported API
 
 Endpoints:


### PR DESCRIPTION
# Make streaming failures legible to agent clients and Pi compatibility

Addresses #20 (PI Agent compatibility). Disclamer - this (and the code) is AI generated, but human reviewed and tested. I'm able to use Pi with TurboFieldfare locally :)

## Summary

A `"stream": true` request commits `200` and the SSE head before generation
starts, so a later failure could not change the status the server closed the
connection instead. That is the failure in #20 `TypeError: terminated` / `SocketError: other side closed` after a `200
text/event-stream` response, with no reason anywhere, and nothing in the server
output either.

Two changes make it legible:

**Rejections happen before the head is written.** `ServerInferenceBackend`
gains a `prepare` step that renders the prompt and checks it against the
context window — the work that used to open `generate` — so an over-budget
prompt returns `400 context_length_exceeded` instead of a committed `200`
followed by a dropped socket. Backends that do not tokenize inherit a
pass-through `prepare`, so existing test backends only changed signature.

**Failures after the head are reported in-band.** When a request fails once
generation is under way, the stream ends the way a successful one ends — an
`error` frame, `data: [DONE]`, then a normal end of the chunked body — carrying
the envelope the blocking path would have returned:

```text
data: {"error":{"message":"generation failed","code":"internal_error","type":"server_error"}}

data: [DONE]

```

Also included: one stderr line per request at start and settle, since a long
prefill is otherwise indistinguishable from a wedged server, and a failure line
naming the cause the response deliberately omits. `docs/OPENAI_SERVER.md` gains
an **Errors** section, a **Server log** section, and a Pi provider block for
`~/.pi/agent/models.json`.

## Validation

```bash
swift build -c release                # Build complete
Scripts/test.sh                       # 518 tests in 108 suites passed
ruby Scripts/check_markdown_links.rb  # 23 files, all links and anchors resolve
```

Three new tests in `HTTPServerTests.swift` cover a rejection in `prepare`
(`400`, no SSE frame), a failure after the head (error frame, `[DONE]`, clean
body end), and a `ServerRequestError` raised mid-generation. None need a model.

The #20 signature, reproduced on an M3 Pro with `--max-context 4096` and an
over-budget streaming prompt:

| | before | after |
| --- | --- | --- |
| Response | `200` `text/event-stream` | `400` `application/json` |
| Body | role chunk, then socket closed | `context_length_exceeded`, `param: messages` |
| `curl` | exit 18, transfer closed | exit 0 |
| Server log | *(nothing)* | `failed status=400 … context_length_exceeded` |

Chunked framing was also confirmed over a raw socket, since `URLSession` hides
it: on a mid-generation failure the body now ends
`…data: [DONE]\n\n\r\n0\r\n\r\n` rather than mid-chunk on a closed socket.

A real PI Agent session against this build completes end to end —
`prompt=3778 cached=0 completion=34 finish=stop` in 152.1 s with 9 tool
schemas, first byte 30 ms. KV prefix reuse is unchanged on both the plain and
tool paths (1,224 and 1,261 cached tokens; 93 s → 1.3 s on the warm turn).

## Memory and performance

Nothing on the streaming path buffers a response: the error frame is one
encoded envelope in one `ByteBuffer`, flushed like any other chunk. `prepare`
hands `generate` the same `[Int32]` prompt array it already built, one call
earlier. No checkpoint, shard, or model tensor enters Swift heap memory.

No performance change expected or observed — prefill, decode, and the prefix
cache are unmodified. `prepare` measures ~150 ms for a 12.8K-token agent
prompt, against 152 s for a cold 3,778-token request dominated by prefill.

## Remaining limitations

- This makes a failure legible; it does not make every generation succeed. A
  cause that still fails now arrives as a named error frame and a logged
  reason instead of an aborted socket.
- The effective-prompt check still runs after the head is committed, so on a
  cache hit an over-budget continuation is reported in-band under a `200`.
  Hoisting it means matching the KV prefix outside the coordinator's slot,
  which is not safe as the cache is written today.
- `prepare` is actor-isolated, so it serializes behind an in-flight
  generation. At ~150 ms a concurrent request still receives its head and
  heartbeats without delay.

- [x] The change does not load a complete checkpoint, shard, or large model
      tensor into Swift heap memory.
- [x] Logs and artifacts contain no credentials, private paths, or model
      weights.
