### PR TITLE
Fix streaming detokenizer dropping combining marks (Thai and other Indic-family scripts)

### DIFF
--- a/Sources/TurboFieldfare/Tokenization/Detokenizer.swift
+++ b/Sources/TurboFieldfare/Tokenization/Detokenizer.swift
@@ -59,16 +59,22 @@ struct GFDetokenizer {
 
     @usableFromInline
     mutating func commitDelta(_ current: String) -> String {
-        guard current.hasPrefix(emitted) else {
-            // Decoder altered the prefix — extremely rare in append-only streams.
-            // Resync rather than emit garbage; the user-visible loss is bounded
-            // to whatever was retokenized.
+        // Compare at the UTF-8 byte level, NOT with String.hasPrefix/dropFirst:
+        // those operate on grapheme clusters, so a token boundary that splits a
+        // combining-mark cluster (Thai sara/tone marks: "ห" then "้าม") makes
+        // hasPrefix("ห") fail against "ห้าม" and the resync path silently drops
+        // the delta. Byte-wise, append-only decodes are always a strict prefix.
+        let cur = Array(current.utf8)
+        let old = Array(emitted.utf8)
+        guard cur.count >= old.count, cur.starts(with: old) else {
+            // Decoder truly altered the prefix — extremely rare in append-only
+            // streams. Resync rather than emit garbage; the user-visible loss
+            // is bounded to whatever was retokenized.
             emitted = current
             return ""
         }
-        let delta = String(current.dropFirst(emitted.count))
         emitted = current
-        return delta
+        return String(decoding: cur[old.count...], as: UTF8.self)
     }
 
     @usableFromInline


### PR DESCRIPTION
## Bug

`GFDetokenizer.commitDelta` compares the newly decoded text against previously emitted text with `String.hasPrefix` and slices the delta with `dropFirst`. Both operate on Swift's extended grapheme clusters with canonical equivalence.

When a token boundary splits a grapheme cluster — a base consonant in one token and its combining vowel/tone mark in the next, which is extremely common for Thai, Lao, Khmer, Burmese, Hindi, Arabic, and for emoji ZWJ sequences — the new string no longer has the emitted string as a *grapheme-level* prefix:

```
emitted = "ห"          // graphemes: [ห]
current = "ห้าม"        // graphemes: [ห้, า, ม]  ← "ห้" ≠ "ห"
current.hasPrefix(emitted)  // false
```

The guard then takes the resync path and returns `""`, silently discarding the delta. Every word whose marks arrive in a separate token loses them:

| expected | streamed |
|---|---|
| การคัดกรอง (screening) | การคกรอง |
| ห้าม (prohibited) | ห |
| สัปดาห์ (week) | สดาห์ |

This corrupts output even at temperature 0 on a verbatim-copy prompt, and is invisible in English-only testing since ASCII never splits clusters.

## Fix

Compare and slice at the UTF-8 byte level. Append-only decodes are always a strict byte prefix of the next decode, and deltas stay on codepoint boundaries because byte-fallback tokens are already held back until complete. The resync path is preserved for genuine retokenization.

## Verification

- `swift test`: 515 tests, 108 suites, all passing
- Temperature-0 echo of Thai text with mixed tone/vowel marks: output now byte-identical to input (previously corrupted as above)
- ASCII-only prompt forcing Thai output (`water, seven, prohibited, week`): น้ำ เจ็ด ห้าม สัปดาห์ — all correct (previously เจ, ห, สดาห์)
- A 5-question Thai writing exam (Gemma-4-26B-A4B .gturbo) that previously corrupted every answer now produces clean text throughout

🤖 Generated with [Claude Code](https://claude.com/claude-code)