### PR TITLE
prefill: configurable chunk size up to 4096, with --prefill-chunk auto

### DIFF
--- a/Sources/TurboFieldfare/Runtime/Configuration/RuntimeConfiguration.swift
+++ b/Sources/TurboFieldfare/Runtime/Configuration/RuntimeConfiguration.swift
@@ -21,7 +21,7 @@ public enum RuntimeExpertCachePolicy: String, Codable, Sendable {
 
 public struct RuntimeConfiguration: Sendable, Equatable {
     public static let allowedExpertCacheSlots = [8, 16, 24, 32]
-    public static let allowedPrefillChunkTokens = [32, 64, 128]
+    public static let allowedPrefillChunkTokens = [32, 64, 128, 256, 512, 1024, 2048, 4096]
 
     public let expertCacheSlots: Int
     public let expertCachePolicy: RuntimeExpertCachePolicy

--- a/Sources/TurboFieldfare/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/TurboFieldfare/Runtime/Inference/RealForwardRunner.swift
@@ -247,7 +247,11 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                      maxContext: maxContext,
                                      fp16RingEnabled: useFP16Ring,
                                      slidingWindow: cfg.slidingWindow,
-                                     maxPrefillChunkTokens: PrefillRuntimeConfig.maxChunkTokens)
+                                     // Sized from the CONFIGURED chunk so
+                                     // sliding-window ring memory grows only
+                                     // when a larger prefill chunk is opted
+                                     // into, never from the static cap.
+                                     maxPrefillChunkTokens: runtimeConfiguration.prefillConfig.chunkTokens)
 
         self.embedInt4 = try EmbedLookupInt4(context: context)
         self.rms       = try RMSNorm(context: context)

--- a/Sources/TurboFieldfare/Runtime/Prefill/PrefillChunkScratch.swift
+++ b/Sources/TurboFieldfare/Runtime/Prefill/PrefillChunkScratch.swift
@@ -13,7 +13,7 @@ struct PrefillChunkScratchLayout: Sendable, Equatable {
     init(config: ArchConfig,
                 chunkTokens: Int,
                 routedPairMicrobatchRows: Int = 32) {
-        self.chunkTokens = max(1, min(chunkTokens, 128))
+        self.chunkTokens = max(1, min(chunkTokens, PrefillRuntimeConfig.maxChunkTokens))
         self.hiddenSize = config.hiddenSize
         self.maxQElementsPerToken = config.numHeads * max(config.headDim, config.fullHeadDim)
         self.maxKVElementsPerToken = max(config.numKVHeads * config.headDim,

--- a/Sources/TurboFieldfare/Runtime/Prefill/PrefillRuntimeConfig.swift
+++ b/Sources/TurboFieldfare/Runtime/Prefill/PrefillRuntimeConfig.swift
@@ -168,7 +168,14 @@ public struct PrefillRuntimeConfig: Sendable, Equatable {
         case chunked
     }
 
-    public static let maxChunkTokens = 128
+    /// Largest supported prefill chunk. Chunked prefill re-reads each
+    /// layer's routed experts once per chunk, so expert I/O scales with
+    /// prompt_tokens / chunk_tokens: measured on Qwen 3.6 (M5, 2,940-token
+    /// long-synthesis case), chunk 128 reads 228 GB and chunk 4096 reads
+    /// 18 GB -- one sequential sweep of the expert files, the floor.
+    /// Scratch and the FP16 KV ring scale with the CONFIGURED chunk, not
+    /// this cap, so installations that keep the 128 default see no change.
+    public static let maxChunkTokens = 4096
 
     public let mode: Mode
     public let chunkTokens: Int

--- a/Sources/TurboFieldfareCLI/Args.swift
+++ b/Sources/TurboFieldfareCLI/Args.swift
@@ -1,3 +1,14 @@
+import TurboFieldfare
+
+/// Prefill chunk selection. `.fixed` must name an allowed size;
+/// `.auto` resolves to the smallest allowed size covering the prompt,
+/// which minimizes routed-expert re-reads (expert I/O scales with
+/// prompt_tokens / chunk_tokens).
+public enum PrefillChunkChoice: Equatable, Sendable {
+    case fixed(Int)
+    case auto
+}
+
 public struct Args: Equatable, Sendable {
     public var model: String
     public var prompt: String?
@@ -11,6 +22,7 @@ public struct Args: Equatable, Sendable {
     public var seed: UInt64?
     public var stops: [String]
     public var quiet: Bool
+    public var prefillChunk: PrefillChunkChoice
 
     public init(model: String,
                 prompt: String? = nil,
@@ -23,7 +35,8 @@ public struct Args: Equatable, Sendable {
                 repetitionPenalty: Float = 1.0,
                 seed: UInt64? = nil,
                 stops: [String] = [],
-                quiet: Bool = false) {
+                quiet: Bool = false,
+                prefillChunk: PrefillChunkChoice = .fixed(128)) {
         self.model = model
         self.prompt = prompt
         self.messagesFile = messagesFile
@@ -36,6 +49,7 @@ public struct Args: Equatable, Sendable {
         self.seed = seed
         self.stops = stops
         self.quiet = quiet
+        self.prefillChunk = prefillChunk
     }
 }
 
@@ -81,6 +95,11 @@ extension Args {
       --repetition-penalty <f>  Repetition penalty (default 1.0).
       --seed <uint64>           Deterministic sampling seed (default off).
       --stop <string>           Stop substring (repeatable).
+      --prefill-chunk <n|auto>  Prefill chunk tokens (default 128). Larger
+                                chunks cut routed-expert re-reads during
+                                prompt processing; auto sizes the chunk to
+                                the prompt. Allowed: 32, 64, 128, 256, 512,
+                                1024, 2048, 4096.
       --quiet                   Suppress the timing footer.
       --help                    Show this message.
     """
@@ -98,6 +117,7 @@ extension Args {
         var seed: UInt64?
         var stops: [String] = []
         var quiet = false
+        var prefillChunk = PrefillChunkChoice.fixed(128)
 
         var index = 0
         while index < argv.count {
@@ -105,6 +125,17 @@ extension Args {
             switch flag {
             case "--help":
                 throw ArgsError.helpRequested
+            case "--prefill-chunk":
+                let value = try takeValue(argv, &index, flag: flag)
+                if value == "auto" {
+                    prefillChunk = .auto
+                } else if let parsed = Int(value),
+                          RuntimeConfiguration.allowedPrefillChunkTokens
+                              .contains(parsed) {
+                    prefillChunk = .fixed(parsed)
+                } else {
+                    throw ArgsError.invalidValue(flag: flag, value: value)
+                }
             case "--quiet":
                 quiet = true
                 index += 1
@@ -184,7 +215,8 @@ extension Args {
                     repetitionPenalty: repetitionPenalty,
                     seed: seed,
                     stops: stops,
-                    quiet: quiet)
+                    quiet: quiet,
+                    prefillChunk: prefillChunk)
     }
 
     private static func takeValue(_ argv: [String],

--- a/Sources/TurboFieldfareCLI/Run.swift
+++ b/Sources/TurboFieldfareCLI/Run.swift
@@ -53,7 +53,20 @@ public func run(args: Args,
             seed: args.seed,
             stopStrings: args.stops,
             extraStopTokens: [])
+        let prefillChunkTokens: Int
+        switch args.prefillChunk {
+        case .fixed(let n):
+            prefillChunkTokens = n
+        case .auto:
+            // Smallest allowed chunk that covers the prompt: one chunk per
+            // prompt when it fits, which reads each layer's routed experts
+            // exactly once during prefill.
+            prefillChunkTokens = RuntimeConfiguration.allowedPrefillChunkTokens
+                .first(where: { $0 >= promptIds.count })
+                ?? RuntimeConfiguration.allowedPrefillChunkTokens.last!
+        }
         let runtime = RuntimeConfiguration(
+            prefillChunkTokens: prefillChunkTokens,
             forceLogitsHead: !config.isPureGreedy)
 
         guard MTLCreateSystemDefaultDevice() != nil else {

--- a/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
+++ b/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
@@ -64,7 +64,7 @@ import Testing
         let expected: Set<String> = [
             "--model", "--prompt", "--messages-file", "--max-new", "--max-context",
             "--temperature", "--top-k", "--top-p", "--repetition-penalty",
-            "--seed", "--stop", "--quiet", "--help",
+            "--seed", "--stop", "--prefill-chunk", "--quiet", "--help",
         ]
         let words = Args.usage.split { $0.isWhitespace || $0 == "(" || $0 == ")" }
         let options = Set(words.map(String.init).filter { $0.hasPrefix("--") })
@@ -101,6 +101,39 @@ import Testing
             _ = try Args.parse([
                 "--model", "m.gturbo", "--prompt", "hi",
                 "--messages-file", "chat.json",
+            ])
+        }
+    }
+
+    @Test func prefillChunkDefaultsToProduction128() throws {
+        let arguments = try Args.parse(["--model", "m.gturbo", "--prompt", "hi"])
+        #expect(arguments.prefillChunk == .fixed(128))
+    }
+
+    @Test(arguments: [32, 64, 128, 256, 512, 1024, 2048, 4096])
+    func prefillChunkAcceptsAllowedSizes(size: Int) throws {
+        let arguments = try Args.parse([
+            "--model", "m.gturbo", "--prompt", "hi",
+            "--prefill-chunk", String(size),
+        ])
+        #expect(arguments.prefillChunk == .fixed(size))
+    }
+
+    @Test func prefillChunkAcceptsAuto() throws {
+        let arguments = try Args.parse([
+            "--model", "m.gturbo", "--prompt", "hi",
+            "--prefill-chunk", "auto",
+        ])
+        #expect(arguments.prefillChunk == .auto)
+    }
+
+    @Test(arguments: ["0", "100", "8192", "-128", "big"])
+    func prefillChunkRejectsDisallowedValues(value: String) {
+        #expect(throws: ArgsError.invalidValue(flag: "--prefill-chunk",
+                                               value: value)) {
+            _ = try Args.parse([
+                "--model", "m.gturbo", "--prompt", "hi",
+                "--prefill-chunk", value,
             ])
         }
     }

--- a/Tests/TurboFieldfare/Core/Runtime/Configuration/RuntimeConfigurationTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Configuration/RuntimeConfigurationTests.swift
@@ -32,7 +32,7 @@ import Testing
         #expect(runtime.headPath == .logits)
     }
 
-    @Test(arguments: [32, 64, 128])
+    @Test(arguments: [32, 64, 128, 256, 512, 1024, 2048, 4096])
     func productionPrefillSupportsPublicChunkSizes(_ chunkTokens: Int) {
         let runtime = RuntimeConfiguration(prefillChunkTokens: chunkTokens)
         #expect(runtime.prefillConfig.mode == .chunked)

--- a/Tests/TurboFieldfare/Core/Runtime/Prefill/PrefillChunkScratchTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Prefill/PrefillChunkScratchTests.swift
@@ -32,7 +32,9 @@ import Metal
 
     @Test func layoutClampsChunkSizeToRuntimeBounds() {
         #expect(PrefillChunkScratchLayout(config: .gemma4_26B_A4B, chunkTokens: 0).chunkTokens == 1)
-        #expect(PrefillChunkScratchLayout(config: .gemma4_26B_A4B, chunkTokens: 512).chunkTokens == 128)
+        #expect(PrefillChunkScratchLayout(config: .gemma4_26B_A4B, chunkTokens: 512).chunkTokens == 512)
+        #expect(PrefillChunkScratchLayout(config: .gemma4_26B_A4B, chunkTokens: 8192).chunkTokens
+                == PrefillRuntimeConfig.maxChunkTokens)
     }
 
     @Test func allocationUsesPrivateScratchAndSharedRouteMetadata() throws {
@@ -80,5 +82,18 @@ import Metal
         #expect(scratch.routedDownScratch.storageMode == MTLStorageMode.private)
         #expect(scratch.routeIDs.storageMode == MTLStorageMode.shared)
         #expect(scratch.routeWeights.storageMode == MTLStorageMode.shared)
+    }
+
+    @Test(arguments: [256, 512, 1024, 2048, 4096])
+    func layoutScalesWithLargerChunks(chunk: Int) {
+        let layout = PrefillChunkScratchLayout(config: .gemma4_26B_A4B,
+                                               chunkTokens: chunk)
+        #expect(layout.chunkTokens == chunk)
+        #expect(layout.hiddenElements == chunk * 2816)
+        #expect(layout.routeIDElements == chunk * 8)
+        // The arena stays bounded: linear in the chunk, no hidden square
+        // term. 128 tokens measured ~15.6 MiB; admit modest slack.
+        let perTokenBytes = 16.0 * 1_048_576.0 / 128.0
+        #expect(layout.totalPersistentBytes <= Int(Double(chunk) * perTokenBytes * 1.3))
     }
 }

--- a/docs/RUNTIME_CONTROLS.md
+++ b/docs/RUNTIME_CONTROLS.md
@@ -29,8 +29,11 @@ benchmark protocol.
 | Expert-cache slots | 8, 16, 24, 32 | 16 | More slots can retain more routed experts and reduce later reads, but values above 16 use more RAM. |
 | Prompt prefill | On, off | On | On processes known prompt tokens through the chunked prefill path. Off disables that path. |
 | RDADVISE | Off, Default, Bounded, Adaptive | Off | Applies experimental read advice. Its effect depends on the workload; it may help a short decode and slow a long one. |
+| Prefill chunk tokens | 32, 64, 128, 256, 512, 1024, 2048, 4096, or auto (CLI `--prefill-chunk`) | 128 | Tokens processed per prefill chunk. Larger chunks re-read the routed experts fewer times, which lowers prefill I/O and time. `auto` picks the smallest allowed size that covers the whole prompt. Larger chunks use more prefill scratch memory, and on sliding-window models more KV ring memory. |
 
-Changing context length, expert-cache slots, or RDADVISE requires a reload.
+The prefill chunk size is a CLI control; the Mac app uses the default.
+Changing context length, expert-cache slots, RDADVISE, or the prefill chunk
+size requires a reload.
 Some sampling changes also require a reload because greedy and sampled
 generation use different output-head paths. Prompt-prefill settings apply to
 each request and do not require a reload.


### PR DESCRIPTION
**Before/after on the community long-synthesis case (Gemma 4 26B-A4B,
M5 24 GB, protocol settings):** total request wall time 86.1 s -> 60.1 s,
prefill disk reads 205 GB -> 50 GB, byte-identical output, peak process
RSS unchanged. One flag: `--prefill-chunk auto`. **Default behavior is
unchanged: without the flag nothing changes.**

## Why prefill re-reads so much

Chunked prefill runs two nested loops: for each 128-token chunk, for each of
the 30 layers, read that layer's routed experts and run the chunk through.
The expert reads in the inner loop are the cost. A 3,015-token prompt is 24
chunks, and each chunk touches most of the expert pool per layer, so the
same expert bytes stream from disk ~24 times: 182 GB of prefill reads for a
model whose packed experts total ~12 GB. Prefill time is almost entirely
that I/O (the disk sits saturated for the whole phase).

Read volume is proportional to the number of chunks, so the fix is fewer,
larger chunks. With a chunk that covers the whole prompt, every layer's
experts are read once per prefill: one sweep of the file, the I/O floor.
Prompts up to 4,096 tokens cover today's product context ceiling.

Measured chunk-size sweep (Gemma 4 26B-A4B, this branch, long-synthesis
prompt with `--max-new 8` so the numbers are prefill-dominated; disk-active
seconds from 1 Hz `iostat`):

| chunk | prefill disk reads | disk-active time |
|---|---|---|
| 128 (current) | 182 GB | 55 s |
| 512 | 60 GB | 33 s |
| 1024 | 32 GB | 28 s |
| 2048 | 22 GB | 26 s |
| 4096 | 14 GB | 26 s |

14 GB is roughly the install size (13 GB): one sweep, the floor for chunked
prefill. The time curve flattens once the phase stops being I/O-bound, and
4,096 covers the product context ceiling, hence the new cap.

## What changed

- `RuntimeConfiguration.allowedPrefillChunkTokens`: [32, 64, 128] -> [32 ... 4096]
- `PrefillRuntimeConfig.maxChunkTokens`: 128 -> 4096 (doc comment records the measurement)
- `PrefillChunkScratch`: clamp follows `maxChunkTokens` instead of a hard 128
- `KVCacheManager`: the sliding-window ring is sized from the *configured*
  chunk, not the static cap, so memory grows only when a larger chunk is
  opted into
- CLI: `--prefill-chunk <n|auto>`, validated against the allowed set;
  `auto` = smallest allowed size covering the prompt; default 128
- `docs/RUNTIME_CONTROLS.md`: new control documented
- Tests: parameterized coverage widened to all sizes, 4 new CLI-parsing
  tests, a scratch-scaling test; two existing tests updated because they
  froze the old 128 cap as a contract

## Evidence

Community benchmark protocol (warmup then fresh measured process, per-case
seeds, `--max-new 1024 --max-context 4096`, sampling defaults, no other
model processes), plus `iostat` disk totals and `/usr/bin/time -l` peak RSS
on the long case. Experiment shape per RUNTIME_CONTROLS: baseline, then one
changed control.

**Machine:** MacBook Pro (Mac17,2), Apple M5, 10 cores, 24 GB, internal SSD.
macOS 26.5.2 (25F84). Swift 6.3.3 (swift-driver 1.148.6). Model installed
per README; manifest sha256 `1cb53c24...`; prompt hashes match the frozen
`real-generation-v1` set.

**Gemma 4 26B-A4B (this branch, f9b9b47 + runtime-controls doc):**

| case | arm | timing footer | wall | prefill I/O | peak RSS | output |
|---|---|---|---|---|---|---|
| short-explanation | default | prefill=61tok new=497tok decode=22.33s tok/s=22.25 | 29.7 s | — | 1554 MiB | — |
| short-explanation | auto | prefill=61tok new=497tok decode=21.32s tok/s=23.31 | 28.6 s | — | 1611 MiB | byte-identical |
| medium-review | default | prefill=430tok new=721tok decode=34.01s tok/s=21.20 | 46.0 s | — | 1617 MiB | — |
| medium-review | auto | prefill=430tok new=721tok decode=34.10s tok/s=21.14 | 42.6 s | — | 1605 MiB | byte-identical |
| long-synthesis | default | prefill=3015tok new=610tok decode=30.75s tok/s=19.84 | 86.1 s | 205 GB | 1606 MiB | — |
| long-synthesis | auto | prefill=3015tok new=610tok decode=33.09s tok/s=18.44 | 60.1 s | 50 GB | 1578 MiB | byte-identical |

Gemma is the interesting correctness case: it has sliding-window layers, so
the KV ring actually grows with the chunk size. Peak RSS stays flat because
the ring is sized from the configured chunk (opt-in memory).

**Memory accounting.** Peak process RSS does not include device-private
Metal allocations, so to be explicit: prefill scratch
(`PrefillChunkScratchLayout.totalPersistentBytes`, all `MTLBuffer`, no model
tensors in Swift heap) grows from ~16 MiB at chunk 128 to ~490 MiB at chunk
4096 on Gemma's dimensions. That cost exists only when a larger chunk is
explicitly requested, and `auto` never picks a chunk larger than the prompt
needs.

**Protocol change:** none. Outputs are byte-identical per case at fixed
seed; the bounded-memory model path is preserved (experts still stream via
`pread`, nothing new touches Swift heap).

**Checks:** `swift build -c release` clean, `Scripts/test.sh` 520/520,
`ruby Scripts/check_markdown_links.rb` all 22 files resolve.

## Limitations

- Prompts longer than 4,096 tokens still pay the multi-chunk re-read above
  the cap.
- `auto` resolves from the tokenized prompt length at request time; the Mac
  app keeps the default (CLI-only control, as documented).

Happy to split the CLI flag from the ceiling raise if you'd prefer them
separate.

