### PR TITLE
Stabilize model path invalidation test

### DIFF
--- a/Tests/TurboFieldfareApp/Core/State/AppModelTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelTests.swift
@@ -323,7 +323,8 @@ import Testing
 
     @MainActor
     @Test func changingModelPathInvalidatesLoadedStateAndDiagnostics() {
-        let model = AppModel(client: MockInferenceClient())
+        let model = AppModel(client: MockInferenceClient(),
+                             installer: MockModelInstallerClient())
         let oldURL = FileManager.default.temporaryDirectory.appendingPathComponent("old.gturbo")
         let newURL = FileManager.default.temporaryDirectory.appendingPathComponent("new.gturbo")
         model.modelPathText = oldURL.path


### PR DESCRIPTION
## Summary

Stabilize the model-path invalidation test by injecting the existing mock installer.

The assertion is about clearing loaded state; it should not vary with the host machine's free disk space.

## Validation

- `Scripts/test.sh --filter changingModelPathInvalidatesLoadedStateAndDiagnostics`
