### PR TITLE
Add local batch API

### DIFF
--- a/README.md
+++ b/README.md
@@ -263,7 +263,9 @@ OpenCode setup, prompt reuse, tool handling, and the supported API subset.
 The local server implements the OpenAI Files → Batch flow for non-streaming
 `/v1/chat/completions`: upload a `.jsonl` file with `purpose=batch` to `POST
 /v1/files`, then create a batch with its `input_file_id`, endpoint, and
-`completion_window: "24h"`. Each JSONL line contains `custom_id`, `method`,
+`completion_window: "24h"`; optional `output_expires_after` accepts
+`{"anchor":"created_at","seconds":3600...2592000}` and removes generated
+output/error JSONL after that interval. Each JSONL line contains `custom_id`, `method`,
 `url`, and the normal Chat Completions `body`.
 
 `GET /v1/batches/{id}`, `POST /v1/batches/{id}/cancel`, and `GET /v1/batches`

--- a/README.md
+++ b/README.md
@@ -270,7 +270,8 @@ The local server implements the OpenAI Files → Batch flow for non-streaming
 provide lifecycle status. Download `output_file_id` and, when present,
 `error_file_id` through `GET /v1/files/{id}/content`. Requests run through the
 same single-model queue as interactive requests; only Chat Completions batches
-are supported.
+are supported. Batch and Files state is in-memory/process-local and is removed
+when the server restarts.
 
 ## Test and contribute
 

--- a/README.md
+++ b/README.md
@@ -272,8 +272,9 @@ output/error JSONL after that interval. Each JSONL line contains `custom_id`, `m
 provide lifecycle status. Download `output_file_id` and, when present,
 `error_file_id` through `GET /v1/files/{id}/content`. Requests run through the
 same single-model queue as interactive requests; only Chat Completions batches
-are supported. Batch and Files state is in-memory/process-local and is removed
-when the server restarts.
+are supported. Generated File objects expose the optional `expires_at` when an
+expiry policy is set. Batch and Files state is in-memory/process-local and is
+removed when the server restarts.
 
 ## Test and contribute
 

--- a/README.md
+++ b/README.md
@@ -268,6 +268,10 @@ The local server implements the OpenAI Files → Batch flow for non-streaming
 output/error JSONL after that interval. Each JSONL line contains `custom_id`, `method`,
 `url`, and the normal Chat Completions `body`.
 
+If a stored JSONL input fails Batch validation, creation returns a Batch in
+`failed` state with an `errors` list; malformed Batch request parameters still
+return the usual HTTP error envelope.
+
 `GET /v1/batches/{id}`, `POST /v1/batches/{id}/cancel`, and `GET /v1/batches`
 provide lifecycle status. Download `output_file_id` and, when present,
 `error_file_id` through `GET /v1/files/{id}/content`. Requests run through the

--- a/README.md
+++ b/README.md
@@ -258,19 +258,19 @@ remote authentication or TLS.
 See [Local server](docs/OPENAI_SERVER.md) for a test request, Python and
 OpenCode setup, prompt reuse, tool handling, and the supported API subset.
 
-#### Local batch requests
+#### Batch requests
 
-`POST /v1/batches` accepts `{ "requests": [...] }`, where every item is a
-normal non-streaming Chat Completions request. Items run in order through the
-same single-model queue as normal requests. An optional `custom_id` on an item
-is copied to its output record.
+The local server implements the OpenAI Files → Batch flow for non-streaming
+`/v1/chat/completions`: upload a `.jsonl` file with `purpose=batch` to `POST
+/v1/files`, then create a batch with its `input_file_id`, endpoint, and
+`completion_window: "24h"`. Each JSONL line contains `custom_id`, `method`,
+`url`, and the normal Chat Completions `body`.
 
-`GET /v1/batches/{id}` retrieves its lifecycle status, `POST
-/v1/batches/{id}/cancel` stops unstarted work, and `GET /v1/batches?limit=20&after={id}`
-lists in-memory batches. Each batch exposes an `output_file_id`; the server
-writes one OpenAI-style response/error object per completed item as local JSONL.
-This is a loopback convenience API: input files, batch persistence across a
-server restart, and `/v1/files/{id}/content` are intentionally not implemented.
+`GET /v1/batches/{id}`, `POST /v1/batches/{id}/cancel`, and `GET /v1/batches`
+provide lifecycle status. Download `output_file_id` and, when present,
+`error_file_id` through `GET /v1/files/{id}/content`. Requests run through the
+same single-model queue as interactive requests; only Chat Completions batches
+are supported.
 
 ## Test and contribute
 

--- a/README.md
+++ b/README.md
@@ -258,6 +258,20 @@ remote authentication or TLS.
 See [Local server](docs/OPENAI_SERVER.md) for a test request, Python and
 OpenCode setup, prompt reuse, tool handling, and the supported API subset.
 
+#### Local batch requests
+
+`POST /v1/batches` accepts `{ "requests": [...] }`, where every item is a
+normal non-streaming Chat Completions request. Items run in order through the
+same single-model queue as normal requests. An optional `custom_id` on an item
+is copied to its output record.
+
+`GET /v1/batches/{id}` retrieves its lifecycle status, `POST
+/v1/batches/{id}/cancel` stops unstarted work, and `GET /v1/batches?limit=20&after={id}`
+lists in-memory batches. Each batch exposes an `output_file_id`; the server
+writes one OpenAI-style response/error object per completed item as local JSONL.
+This is a loopback convenience API: input files, batch persistence across a
+server restart, and `/v1/files/{id}/content` are intentionally not implemented.
+
 ## Test and contribute
 
 Run the public test suite serially:

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -70,7 +70,7 @@ public actor BatchFileStore {
         return generatedFile(id: id, url: output, fallbackBytes: 0)
     }
 
-    public func list() -> [File] {
+    public func list(order: String = "desc", purpose: String? = nil) -> [File] {
         var ids = Set(files.keys)
         if let urls = try? FileManager.default.contentsOfDirectory(at: directory,
                                                                      includingPropertiesForKeys: nil) {
@@ -78,7 +78,14 @@ public actor BatchFileStore {
                 ids.insert(url.deletingPathExtension().lastPathComponent)
             }
         }
-        return ids.sorted().compactMap(get)
+        return ids.compactMap(get)
+            .filter { purpose == nil || $0.purpose == purpose }
+            .sorted {
+                if $0.createdAt != $1.createdAt {
+                    return order == "asc" ? $0.createdAt < $1.createdAt : $0.createdAt > $1.createdAt
+                }
+                return order == "asc" ? $0.id < $1.id : $0.id > $1.id
+            }
     }
 
     public func delete(_ id: String) throws -> Bool {

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -10,10 +10,12 @@ public actor BatchFileStore {
         public let filename: String
         public let purpose: String
         public let status = "processed"
+        public let expiresAt: Int?
 
         enum CodingKeys: String, CodingKey {
             case id, object, bytes, filename, purpose, status
             case createdAt = "created_at"
+            case expiresAt = "expires_at"
         }
     }
 
@@ -46,28 +48,38 @@ public actor BatchFileStore {
     }
 
     /// Registers a result file produced by BatchRegistry, whose historical path is `<id>.jsonl`.
-    public func registerBatchOutput(_ id: String) throws -> File {
+    public func registerBatchOutput(_ id: String, expiresAt: Int?) throws -> File {
         if let file = files[id] { return file }
         let url = directory.appendingPathComponent(id).appendingPathExtension("jsonl")
         let bytes = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
         let file = File(id: id, bytes: bytes, createdAt: Int(Date().timeIntervalSince1970),
-                        filename: id + ".jsonl", purpose: "batch")
+                        filename: id + ".jsonl", purpose: "batch_output", expiresAt: expiresAt)
         files[id] = file
         try persist()
+        if let expiresAt {
+            Task { [weak self] in
+                let delay = max(0, expiresAt - Int(Date().timeIntervalSince1970))
+                try? await Task.sleep(for: .seconds(delay))
+                await self?.expire(id)
+            }
+        }
         return file
     }
 
     public func get(_ id: String) -> File? {
         if let file = files[id] {
+            if let expiresAt = file.expiresAt, expiresAt <= Int(Date().timeIntervalSince1970) {
+                return nil
+            }
             let output = url(for: id).appendingPathExtension("jsonl")
             if FileManager.default.fileExists(atPath: output.path) {
-                return generatedFile(id: id, url: output, fallbackBytes: file.bytes)
+                return generatedFile(id: id, url: output, fallback: file)
             }
             return file
         }
         let output = url(for: id).appendingPathExtension("jsonl")
         guard FileManager.default.fileExists(atPath: output.path) else { return nil }
-        return generatedFile(id: id, url: output, fallbackBytes: 0)
+        return generatedFile(id: id, url: output, fallback: nil)
     }
 
     public func list(order: String = "desc", purpose: String? = nil) -> [File] {
@@ -100,7 +112,7 @@ public actor BatchFileStore {
     }
 
     public func contents(_ id: String) throws -> Data? {
-        guard files[id] != nil || FileManager.default.fileExists(atPath: url(for: id).appendingPathExtension("jsonl").path) else { return nil }
+        guard get(id) != nil else { return nil }
         let direct = url(for: id)
         let output = direct.appendingPathExtension("jsonl")
         return try Data(contentsOf: FileManager.default.fileExists(atPath: direct.path) ? direct : output)
@@ -116,14 +128,14 @@ public actor BatchFileStore {
         try handle.write(contentsOf: line)
         metadata = File(id: metadata.id, bytes: metadata.bytes + line.count,
                         createdAt: metadata.createdAt, filename: metadata.filename,
-                        purpose: metadata.purpose)
+                        purpose: metadata.purpose, expiresAt: metadata.expiresAt)
         files[id] = metadata
         try persist()
     }
 
     private func write(filename: String, purpose: String, contents: Data) throws -> File {
         let id = "file-" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
-        let file = File(id: id, bytes: contents.count, createdAt: Int(Date().timeIntervalSince1970), filename: filename, purpose: purpose)
+        let file = File(id: id, bytes: contents.count, createdAt: Int(Date().timeIntervalSince1970), filename: filename, purpose: purpose, expiresAt: nil)
         try contents.write(to: url(for: id), options: .atomic)
         files[id] = file
         try persist()
@@ -132,12 +144,18 @@ public actor BatchFileStore {
 
     private func url(for id: String) -> URL { directory.appendingPathComponent(id) }
 
-    private func generatedFile(id: String, url: URL, fallbackBytes: Int) -> File {
+    private func generatedFile(id: String, url: URL, fallback: File?) -> File {
         let values = try? url.resourceValues(forKeys: [.fileSizeKey, .creationDateKey])
-        let bytes = values?.fileSize ?? fallbackBytes
-        let createdAt = Int((values?.creationDate ?? Date()).timeIntervalSince1970)
+        let bytes = values?.fileSize ?? fallback?.bytes ?? 0
+        let createdAt = Int((values?.creationDate ?? fallback.map { Date(timeIntervalSince1970: TimeInterval($0.createdAt)) } ?? Date()).timeIntervalSince1970)
         return File(id: id, bytes: bytes, createdAt: createdAt,
-                    filename: id + ".jsonl", purpose: "batch_output")
+                    filename: id + ".jsonl", purpose: "batch_output", expiresAt: fallback?.expiresAt)
+    }
+
+    private func expire(_ id: String) {
+        files.removeValue(forKey: id)
+        try? FileManager.default.removeItem(at: url(for: id).appendingPathExtension("jsonl"))
+        try? persist()
     }
 
     private func persist() throws {

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -58,12 +58,30 @@ public actor BatchFileStore {
     }
 
     public func get(_ id: String) -> File? {
-        if let file = files[id] { return file }
+        if let file = files[id] {
+            let output = url(for: id).appendingPathExtension("jsonl")
+            if FileManager.default.fileExists(atPath: output.path) {
+                let bytes = (try? output.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? file.bytes
+                return File(id: file.id, bytes: bytes, createdAt: file.createdAt,
+                            filename: file.filename, purpose: file.purpose)
+            }
+            return file
+        }
         let output = url(for: id).appendingPathExtension("jsonl")
         guard FileManager.default.fileExists(atPath: output.path) else { return nil }
         let bytes = (try? output.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
         return File(id: id, bytes: bytes, createdAt: Int(Date().timeIntervalSince1970),
                     filename: id + ".jsonl", purpose: "batch")
+    }
+
+    public func list() -> [File] { files.keys.sorted().compactMap(get) }
+
+    public func delete(_ id: String) throws -> Bool {
+        guard let file = files.removeValue(forKey: id) else { return false }
+        try? FileManager.default.removeItem(at: url(for: file.id))
+        try? FileManager.default.removeItem(at: url(for: file.id).appendingPathExtension("jsonl"))
+        try persist()
+        return true
     }
 
     public func contents(_ id: String) throws -> Data? {

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -61,17 +61,13 @@ public actor BatchFileStore {
         if let file = files[id] {
             let output = url(for: id).appendingPathExtension("jsonl")
             if FileManager.default.fileExists(atPath: output.path) {
-                let bytes = (try? output.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? file.bytes
-                return File(id: file.id, bytes: bytes, createdAt: file.createdAt,
-                            filename: file.filename, purpose: file.purpose)
+                return generatedFile(id: id, url: output, fallbackBytes: file.bytes)
             }
             return file
         }
         let output = url(for: id).appendingPathExtension("jsonl")
         guard FileManager.default.fileExists(atPath: output.path) else { return nil }
-        let bytes = (try? output.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
-        return File(id: id, bytes: bytes, createdAt: Int(Date().timeIntervalSince1970),
-                    filename: id + ".jsonl", purpose: "batch")
+        return generatedFile(id: id, url: output, fallbackBytes: 0)
     }
 
     public func list() -> [File] {
@@ -128,6 +124,14 @@ public actor BatchFileStore {
     }
 
     private func url(for id: String) -> URL { directory.appendingPathComponent(id) }
+
+    private func generatedFile(id: String, url: URL, fallbackBytes: Int) -> File {
+        let values = try? url.resourceValues(forKeys: [.fileSizeKey, .creationDateKey])
+        let bytes = values?.fileSize ?? fallbackBytes
+        let createdAt = Int((values?.creationDate ?? Date()).timeIntervalSince1970)
+        return File(id: id, bytes: bytes, createdAt: createdAt,
+                    filename: id + ".jsonl", purpose: "batch_output")
+    }
 
     private func persist() throws {
         let data = try JSONEncoder().encode(files)

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -20,10 +20,13 @@ public actor BatchFileStore {
     }
 
     private let directory: URL
+    private let maximumInputBytes: Int
     private var files: [String: File] = [:]
 
-    public init(directory: URL) {
+    public init(directory: URL,
+                maximumInputBytes: Int = TurboFieldfareHTTPServer.maximumBatchFileBytes) {
         self.directory = directory
+        self.maximumInputBytes = maximumInputBytes
         // The loopback server deliberately has no cross-process persistence.
         // Starting a new server instance discards Files and Batch artifacts.
         try? FileManager.default.removeItem(at: directory)
@@ -37,7 +40,7 @@ public actor BatchFileStore {
         guard filename.lowercased().hasSuffix(".jsonl") else {
             throw ServerRequestError.invalid(message: "batch files must use the .jsonl extension", param: "file", code: "invalid_value")
         }
-        guard contents.count <= TurboFieldfareHTTPServer.maximumBatchFileBytes else {
+        guard contents.count <= maximumInputBytes else {
             throw ServerRequestError.invalid(message: "batch files may not exceed 200 MiB", param: "file", code: "invalid_value")
         }
         return try write(filename: filename, purpose: purpose, contents: contents)

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -74,12 +74,24 @@ public actor BatchFileStore {
                     filename: id + ".jsonl", purpose: "batch")
     }
 
-    public func list() -> [File] { files.keys.sorted().compactMap(get) }
+    public func list() -> [File] {
+        var ids = Set(files.keys)
+        if let urls = try? FileManager.default.contentsOfDirectory(at: directory,
+                                                                     includingPropertiesForKeys: nil) {
+            for url in urls where url.pathExtension == "jsonl" {
+                ids.insert(url.deletingPathExtension().lastPathComponent)
+            }
+        }
+        return ids.sorted().compactMap(get)
+    }
 
     public func delete(_ id: String) throws -> Bool {
-        guard let file = files.removeValue(forKey: id) else { return false }
-        try? FileManager.default.removeItem(at: url(for: file.id))
-        try? FileManager.default.removeItem(at: url(for: file.id).appendingPathExtension("jsonl"))
+        let file = files.removeValue(forKey: id)
+        let direct = url(for: id)
+        let output = direct.appendingPathExtension("jsonl")
+        guard file != nil || FileManager.default.fileExists(atPath: output.path) else { return false }
+        try? FileManager.default.removeItem(at: direct)
+        try? FileManager.default.removeItem(at: output)
         try persist()
         return true
     }

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -56,10 +56,17 @@ public actor BatchFileStore {
         return file
     }
 
-    public func get(_ id: String) -> File? { files[id] }
+    public func get(_ id: String) -> File? {
+        if let file = files[id] { return file }
+        let output = url(for: id).appendingPathExtension("jsonl")
+        guard FileManager.default.fileExists(atPath: output.path) else { return nil }
+        let bytes = (try? output.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        return File(id: id, bytes: bytes, createdAt: Int(Date().timeIntervalSince1970),
+                    filename: id + ".jsonl", purpose: "batch")
+    }
 
     public func contents(_ id: String) throws -> Data? {
-        guard files[id] != nil else { return nil }
+        guard files[id] != nil || FileManager.default.fileExists(atPath: url(for: id).appendingPathExtension("jsonl").path) else { return nil }
         let direct = url(for: id)
         let output = direct.appendingPathExtension("jsonl")
         return try Data(contentsOf: FileManager.default.fileExists(atPath: direct.path) ? direct : output)

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -22,12 +22,10 @@ public actor BatchFileStore {
 
     public init(directory: URL) {
         self.directory = directory
+        // The loopback server deliberately has no cross-process persistence.
+        // Starting a new server instance discards Files and Batch artifacts.
+        try? FileManager.default.removeItem(at: directory)
         try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
-        let metadata = directory.appendingPathComponent("files.json")
-        if let data = try? Data(contentsOf: metadata),
-           let decoded = try? JSONDecoder().decode([String: File].self, from: data) {
-            files = decoded
-        }
     }
 
     public func create(filename: String, purpose: String, contents: Data) throws -> File {

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -1,0 +1,98 @@
+import Foundation
+
+/// Small durable subset of the OpenAI Files API used by the local Batch API.
+public actor BatchFileStore {
+    public struct File: Codable, Sendable {
+        public let id: String
+        public let object = "file"
+        public let bytes: Int
+        public let createdAt: Int
+        public let filename: String
+        public let purpose: String
+        public let status = "processed"
+
+        enum CodingKeys: String, CodingKey {
+            case id, object, bytes, filename, purpose, status
+            case createdAt = "created_at"
+        }
+    }
+
+    private let directory: URL
+    private var files: [String: File] = [:]
+
+    public init(directory: URL) {
+        self.directory = directory
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        let metadata = directory.appendingPathComponent("files.json")
+        if let data = try? Data(contentsOf: metadata),
+           let decoded = try? JSONDecoder().decode([String: File].self, from: data) {
+            files = decoded
+        }
+    }
+
+    public func create(filename: String, purpose: String, contents: Data) throws -> File {
+        guard purpose == "batch" else {
+            throw ServerRequestError.invalid(message: "only purpose=batch is supported", param: "purpose", code: "unsupported_value")
+        }
+        guard filename.lowercased().hasSuffix(".jsonl") else {
+            throw ServerRequestError.invalid(message: "batch files must use the .jsonl extension", param: "file", code: "invalid_value")
+        }
+        return try write(filename: filename, purpose: purpose, contents: contents)
+    }
+
+    public func createOutput(filename: String) throws -> File {
+        try write(filename: filename, purpose: "batch", contents: Data())
+    }
+
+    /// Registers a result file produced by BatchRegistry, whose historical path is `<id>.jsonl`.
+    public func registerBatchOutput(_ id: String) throws -> File {
+        if let file = files[id] { return file }
+        let url = directory.appendingPathComponent(id).appendingPathExtension("jsonl")
+        let bytes = (try? url.resourceValues(forKeys: [.fileSizeKey]).fileSize) ?? 0
+        let file = File(id: id, bytes: bytes, createdAt: Int(Date().timeIntervalSince1970),
+                        filename: id + ".jsonl", purpose: "batch")
+        files[id] = file
+        try persist()
+        return file
+    }
+
+    public func get(_ id: String) -> File? { files[id] }
+
+    public func contents(_ id: String) throws -> Data? {
+        guard files[id] != nil else { return nil }
+        let direct = url(for: id)
+        let output = direct.appendingPathExtension("jsonl")
+        return try Data(contentsOf: FileManager.default.fileExists(atPath: direct.path) ? direct : output)
+    }
+
+    public func appendJSONL(_ object: [String: Any], to id: String) throws {
+        guard var metadata = files[id] else { throw CocoaError(.fileNoSuchFile) }
+        var line = try JSONSerialization.data(withJSONObject: object)
+        line.append(0x0A)
+        let handle = try FileHandle(forWritingTo: url(for: id))
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: line)
+        metadata = File(id: metadata.id, bytes: metadata.bytes + line.count,
+                        createdAt: metadata.createdAt, filename: metadata.filename,
+                        purpose: metadata.purpose)
+        files[id] = metadata
+        try persist()
+    }
+
+    private func write(filename: String, purpose: String, contents: Data) throws -> File {
+        let id = "file-" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+        let file = File(id: id, bytes: contents.count, createdAt: Int(Date().timeIntervalSince1970), filename: filename, purpose: purpose)
+        try contents.write(to: url(for: id), options: .atomic)
+        files[id] = file
+        try persist()
+        return file
+    }
+
+    private func url(for id: String) -> URL { directory.appendingPathComponent(id) }
+
+    private func persist() throws {
+        let data = try JSONEncoder().encode(files)
+        try data.write(to: directory.appendingPathComponent("files.json"), options: .atomic)
+    }
+}

--- a/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchFileStore.swift
@@ -35,6 +35,9 @@ public actor BatchFileStore {
         guard filename.lowercased().hasSuffix(".jsonl") else {
             throw ServerRequestError.invalid(message: "batch files must use the .jsonl extension", param: "file", code: "invalid_value")
         }
+        guard contents.count <= TurboFieldfareHTTPServer.maximumBatchFileBytes else {
+            throw ServerRequestError.invalid(message: "batch files may not exceed 200 MiB", param: "file", code: "invalid_value")
+        }
         return try write(filename: filename, purpose: purpose, contents: contents)
     }
 

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -225,7 +225,7 @@ public actor BatchRegistry {
                              inputFileID: String,
                              completionWindow: String,
                              metadata: [String: String]?,
-                             error: BatchError) -> Snapshot {
+                             errors: [BatchError]) -> Snapshot {
         let id = "batch_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
         let created = Int(Date().timeIntervalSince1970)
         jobs[id] = Job(status: .failed,
@@ -239,7 +239,7 @@ public actor BatchRegistry {
                        failedAt: created,
                        expiresAt: created + 86_400,
                        outputExpiresAfterSeconds: nil,
-                       batchErrors: [error])
+                       batchErrors: errors)
         return snapshot(id)!
     }
 

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -62,12 +62,14 @@ public actor BatchRegistry {
         public let inputTokens: Int
         public let inputTokensDetails: InputTokensDetails
         public let outputTokens: Int
+        public let outputTokensDetails: OutputTokensDetails
         public let totalTokens: Int
 
         enum CodingKeys: String, CodingKey {
             case inputTokens = "input_tokens"
             case inputTokensDetails = "input_tokens_details"
             case outputTokens = "output_tokens"
+            case outputTokensDetails = "output_tokens_details"
             case totalTokens = "total_tokens"
         }
     }
@@ -75,6 +77,11 @@ public actor BatchRegistry {
     public struct InputTokensDetails: Codable, Sendable {
         public let cachedTokens: Int
         enum CodingKeys: String, CodingKey { case cachedTokens = "cached_tokens" }
+    }
+
+    public struct OutputTokensDetails: Codable, Sendable {
+        public let reasoningTokens: Int
+        enum CodingKeys: String, CodingKey { case reasoningTokens = "reasoning_tokens" }
     }
 
     public struct BatchError: Codable, Sendable {
@@ -333,6 +340,7 @@ public actor BatchRegistry {
                             ? Usage(inputTokens: job.inputTokens,
                                     inputTokensDetails: .init(cachedTokens: job.cachedTokens),
                                     outputTokens: job.outputTokens,
+                                    outputTokensDetails: .init(reasoningTokens: 0),
                                     totalTokens: job.inputTokens + job.outputTokens)
                             : nil)
     }

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -20,6 +20,7 @@ public actor BatchRegistry {
         public let object = "batch"
         public let status: Status
         public let endpoint: String
+        public let model: String
         public let errors: [BatchError]?
         public let inputFileID: String?
         public let completionWindow: String?
@@ -36,9 +37,10 @@ public actor BatchRegistry {
         public let outputFileID: String?
         public let errorFileID: String?
         public let metadata: [String: String]?
+        public let usage: Usage?
 
         enum CodingKeys: String, CodingKey {
-            case id, object, status, endpoint, errors, metadata
+            case id, object, status, endpoint, model, errors, metadata, usage
             case inputFileID = "input_file_id"
             case completionWindow = "completion_window"
             case createdAt = "created_at"
@@ -54,6 +56,25 @@ public actor BatchRegistry {
             case outputFileID = "output_file_id"
             case errorFileID = "error_file_id"
         }
+    }
+
+    public struct Usage: Codable, Sendable {
+        public let inputTokens: Int
+        public let inputTokensDetails: InputTokensDetails
+        public let outputTokens: Int
+        public let totalTokens: Int
+
+        enum CodingKeys: String, CodingKey {
+            case inputTokens = "input_tokens"
+            case inputTokensDetails = "input_tokens_details"
+            case outputTokens = "output_tokens"
+            case totalTokens = "total_tokens"
+        }
+    }
+
+    public struct InputTokensDetails: Codable, Sendable {
+        public let cachedTokens: Int
+        enum CodingKeys: String, CodingKey { case cachedTokens = "cached_tokens" }
     }
 
     public struct BatchError: Codable, Sendable {
@@ -87,6 +108,7 @@ public actor BatchRegistry {
     private struct Job {
         var status: Status
         let endpoint: String
+        let model: String
         let inputFileID: String?
         let completionWindow: String?
         let metadata: [String: String]?
@@ -107,6 +129,9 @@ public actor BatchRegistry {
         var expiredAt: Int?
         var cancellingAt: Int?
         var cancelledAt: Int?
+        var inputTokens = 0
+        var cachedTokens = 0
+        var outputTokens = 0
     }
 
     private let outputDirectory: URL
@@ -131,6 +156,7 @@ public actor BatchRegistry {
         let created = Int(Date().timeIntervalSince1970)
         jobs[id] = Job(status: .validating,
                        endpoint: "/v1/chat/completions",
+                       model: modelID,
                        inputFileID: inputFileID,
                        completionWindow: completionWindow,
                        metadata: metadata,
@@ -226,6 +252,9 @@ public actor BatchRegistry {
                           completion: completion,
                           modelID: modelID)
         job.completed += 1
+        job.inputTokens += completion.usage.promptTokens
+        job.cachedTokens += completion.usage.promptTokensDetails.cachedTokens
+        job.outputTokens += completion.usage.completionTokens
         jobs[id] = job
     }
 
@@ -281,6 +310,7 @@ public actor BatchRegistry {
         return Snapshot(id: id,
                         status: job.status,
                         endpoint: job.endpoint,
+                        model: job.model,
                         errors: nil,
                         inputFileID: job.inputFileID,
                         completionWindow: job.completionWindow,
@@ -298,7 +328,13 @@ public actor BatchRegistry {
                                              failed: job.failed),
                         outputFileID: (job.status == .completed || job.status == .cancelled) ? job.outputFileID : nil,
                         errorFileID: (job.status == .completed || job.status == .cancelled) ? job.errorFileID : nil,
-                        metadata: job.metadata)
+                        metadata: job.metadata,
+                        usage: job.status == .completed || job.status == .cancelled
+                            ? Usage(inputTokens: job.inputTokens,
+                                    inputTokensDetails: .init(cachedTokens: job.cachedTokens),
+                                    outputTokens: job.outputTokens,
+                                    totalTokens: job.inputTokens + job.outputTokens)
+                            : nil)
     }
 
 

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -80,6 +80,8 @@ public actor BatchRegistry {
         let total: Int
         let outputFileID: String
         let outputURL: URL
+        var errorFileID: String?
+        var errorURL: URL?
         var completed = 0
         var failed = 0
         var task: Task<Void, Never>?
@@ -206,7 +208,14 @@ public actor BatchRegistry {
     private func failed(_ id: String, customID: String, error: Error) {
         guard var job = jobs[id] else { return }
         do {
-            try appendFailure(to: job.outputURL, customID: customID, error: error)
+            if job.errorFileID == nil {
+                let errorFileID = "file_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+                let errorURL = outputDirectory.appendingPathComponent(errorFileID).appendingPathExtension("jsonl")
+                try Data().write(to: errorURL, options: .withoutOverwriting)
+                job.errorFileID = errorFileID
+                job.errorURL = errorURL
+            }
+            try appendFailure(to: job.errorURL!, customID: customID, error: error)
         } catch {
             // The original inference error remains the result of this item.
         }
@@ -245,7 +254,7 @@ public actor BatchRegistry {
                                              completed: job.completed,
                                              failed: job.failed),
                         outputFileID: job.outputFileID,
-                        errorFileID: nil,
+                        errorFileID: job.errorFileID,
                         metadata: job.metadata)
     }
 

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -288,7 +288,7 @@ public actor BatchRegistry {
                            modelID: String) async throws {
         guard var job = jobs[id] else { return }
         if job.outputFileID == nil {
-            let outputFileID = "file_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+            let outputFileID = "file-" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
             let outputURL = outputDirectory.appendingPathComponent(outputFileID).appendingPathExtension("jsonl")
             try Data().write(to: outputURL, options: .withoutOverwriting)
             job.outputFileID = outputFileID
@@ -311,7 +311,7 @@ public actor BatchRegistry {
         guard var job = jobs[id] else { return }
         do {
             if job.errorFileID == nil {
-                let errorFileID = "file_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+                let errorFileID = "file-" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
                 let errorURL = outputDirectory.appendingPathComponent(errorFileID).appendingPathExtension("jsonl")
                 try Data().write(to: errorURL, options: .withoutOverwriting)
                 job.errorFileID = errorFileID

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -92,8 +92,8 @@ public actor BatchRegistry {
         let metadata: [String: String]?
         let createdAt: Int
         let total: Int
-        let outputFileID: String
-        let outputURL: URL
+        var outputFileID: String?
+        var outputURL: URL?
         var errorFileID: String?
         var errorURL: URL?
         var completed = 0
@@ -125,11 +125,8 @@ public actor BatchRegistry {
                        completionWindow: String? = nil,
                        metadata: [String: String]? = nil) throws -> Snapshot {
         let id = "batch_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
-        let outputFileID = "file_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
-        let outputURL = outputDirectory.appendingPathComponent(outputFileID).appendingPathExtension("jsonl")
         try FileManager.default.createDirectory(at: outputDirectory,
                                                 withIntermediateDirectories: true)
-        try Data().write(to: outputURL, options: .withoutOverwriting)
 
         let created = Int(Date().timeIntervalSince1970)
         jobs[id] = Job(status: .validating,
@@ -139,8 +136,6 @@ public actor BatchRegistry {
                        metadata: metadata,
                        createdAt: created,
                        total: requests.count,
-                       outputFileID: outputFileID,
-                       outputURL: outputURL,
                        expiresAt: completionWindow == "24h" ? created + 86_400 : nil)
         let task = Task { [weak self] in
             guard let self else { return }
@@ -219,7 +214,14 @@ public actor BatchRegistry {
                            completion: ServerCompletion,
                            modelID: String) throws {
         guard var job = jobs[id] else { return }
-        try appendSuccess(to: job.outputURL,
+        if job.outputFileID == nil {
+            let outputFileID = "file_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+            let outputURL = outputDirectory.appendingPathComponent(outputFileID).appendingPathExtension("jsonl")
+            try Data().write(to: outputURL, options: .withoutOverwriting)
+            job.outputFileID = outputFileID
+            job.outputURL = outputURL
+        }
+        try appendSuccess(to: job.outputURL!,
                           customID: customID,
                           completion: completion,
                           modelID: modelID)

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -143,11 +143,14 @@ public actor BatchRegistry {
     }
 
     private let outputDirectory: URL
+    private let onOutputFileCreated: @Sendable (String, Int?) async -> Void
     private var jobs: [String: Job] = [:]
 
     public init(outputDirectory: URL = FileManager.default.temporaryDirectory
-        .appendingPathComponent("TurboFieldfare/batches", isDirectory: true)) {
+        .appendingPathComponent("TurboFieldfare/batches", isDirectory: true),
+        onOutputFileCreated: @escaping @Sendable (String, Int?) async -> Void = { _, _ in }) {
         self.outputDirectory = outputDirectory
+        self.onOutputFileCreated = onOutputFileCreated
     }
 
     public func create(requests: [BatchRequest],
@@ -248,7 +251,7 @@ public actor BatchRegistry {
     private func succeeded(_ id: String,
                            customID: String,
                            completion: ServerCompletion,
-                           modelID: String) throws {
+                           modelID: String) async throws {
         guard var job = jobs[id] else { return }
         if job.outputFileID == nil {
             let outputFileID = "file_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
@@ -256,9 +259,8 @@ public actor BatchRegistry {
             try Data().write(to: outputURL, options: .withoutOverwriting)
             job.outputFileID = outputFileID
             job.outputURL = outputURL
-            scheduleExpiry(of: outputURL,
-                           createdAt: job.createdAt,
-                           after: job.outputExpiresAfterSeconds)
+            await onOutputFileCreated(outputFileID,
+                                      job.outputExpiresAfterSeconds.map { job.createdAt + $0 })
         }
         try appendSuccess(to: job.outputURL!,
                           customID: customID,
@@ -271,7 +273,7 @@ public actor BatchRegistry {
         jobs[id] = job
     }
 
-    private func failed(_ id: String, customID: String, error: Error) {
+    private func failed(_ id: String, customID: String, error: Error) async {
         guard var job = jobs[id] else { return }
         do {
             if job.errorFileID == nil {
@@ -280,9 +282,8 @@ public actor BatchRegistry {
                 try Data().write(to: errorURL, options: .withoutOverwriting)
                 job.errorFileID = errorFileID
                 job.errorURL = errorURL
-                scheduleExpiry(of: errorURL,
-                               createdAt: job.createdAt,
-                               after: job.outputExpiresAfterSeconds)
+                await onOutputFileCreated(errorFileID,
+                                          job.outputExpiresAfterSeconds.map { job.createdAt + $0 })
             }
             try appendFailure(to: job.errorURL!, customID: customID, error: error)
         } catch {
@@ -319,15 +320,6 @@ public actor BatchRegistry {
         job.status = .completed
         job.completedAt = Int(Date().timeIntervalSince1970)
         jobs[id] = job
-    }
-
-    private func scheduleExpiry(of url: URL, createdAt: Int, after seconds: Int?) {
-        guard let seconds else { return }
-        let delay = max(0, createdAt + seconds - Int(Date().timeIntervalSince1970))
-        Task.detached {
-            try? await Task.sleep(for: .seconds(delay))
-            try? FileManager.default.removeItem(at: url)
-        }
     }
 
     private func snapshot(_ id: String) -> Snapshot? {

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -381,9 +381,13 @@ public actor BatchRegistry {
     private func appendFailure(to url: URL, customID: String, error: Error) throws {
         let detail: [String: Any]
         if let error = error as? ServerRequestError {
-            detail = ["code": error.envelope.error.code, "message": error.envelope.error.message]
+            detail = ["code": error.envelope.error.code,
+                      "message": error.envelope.error.message,
+                      "type": error.envelope.error.type,
+                      "param": error.envelope.error.param ?? NSNull()]
         } else {
-            detail = ["code": "internal_error", "message": "generation failed"]
+            detail = ["code": "internal_error", "message": "generation failed",
+                      "type": "server_error", "param": NSNull()]
         }
         try appendLine([
             "id": "batch_req_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""),

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -12,7 +12,7 @@ public struct BatchRequest: Sendable {
 
 public actor BatchRegistry {
     public enum Status: String, Codable, Sendable {
-        case validating, inProgress = "in_progress", completed, failed, cancelling, cancelled
+        case validating, inProgress = "in_progress", finalizing, completed, failed, expired, cancelling, cancelled
     }
 
     public struct Snapshot: Codable, Sendable {
@@ -26,10 +26,13 @@ public actor BatchRegistry {
         public let inProgressAt: Int?
         public let completedAt: Int?
         public let failedAt: Int?
+        public let expiresAt: Int?
+        public let finalizingAt: Int?
+        public let expiredAt: Int?
         public let cancellingAt: Int?
         public let cancelledAt: Int?
         public let requestCounts: Counts
-        public let outputFileID: String
+        public let outputFileID: String?
         public let errorFileID: String?
         public let metadata: [String: String]?
 
@@ -41,6 +44,9 @@ public actor BatchRegistry {
             case inProgressAt = "in_progress_at"
             case completedAt = "completed_at"
             case failedAt = "failed_at"
+            case expiresAt = "expires_at"
+            case finalizingAt = "finalizing_at"
+            case expiredAt = "expired_at"
             case cancellingAt = "cancelling_at"
             case cancelledAt = "cancelled_at"
             case requestCounts = "request_counts"
@@ -88,6 +94,9 @@ public actor BatchRegistry {
         var inProgressAt: Int?
         var completedAt: Int?
         var failedAt: Int?
+        var expiresAt: Int?
+        var finalizingAt: Int?
+        var expiredAt: Int?
         var cancellingAt: Int?
         var cancelledAt: Int?
     }
@@ -232,6 +241,9 @@ public actor BatchRegistry {
 
     private func finish(_ id: String) {
         guard var job = jobs[id], job.status != .cancelled else { return }
+        job.status = .finalizing
+        job.finalizingAt = Int(Date().timeIntervalSince1970)
+        jobs[id] = job
         job.status = .completed
         job.completedAt = Int(Date().timeIntervalSince1970)
         jobs[id] = job
@@ -248,13 +260,16 @@ public actor BatchRegistry {
                         inProgressAt: job.inProgressAt,
                         completedAt: job.completedAt,
                         failedAt: job.failedAt,
+                        expiresAt: job.expiresAt,
+                        finalizingAt: job.finalizingAt,
+                        expiredAt: job.expiredAt,
                         cancellingAt: job.cancellingAt,
                         cancelledAt: job.cancelledAt,
                         requestCounts: .init(total: job.total,
                                              completed: job.completed,
                                              failed: job.failed),
-                        outputFileID: job.outputFileID,
-                        errorFileID: job.errorFileID,
+                        outputFileID: (job.status == .completed || job.status == .cancelled) ? job.outputFileID : nil,
+                        errorFileID: (job.status == .completed || job.status == .cancelled) ? job.errorFileID : nil,
                         metadata: job.metadata)
     }
 

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -1,0 +1,270 @@
+import Foundation
+
+public struct BatchRequest: Sendable {
+    public let customID: String
+    public let request: ValidatedChatRequest
+
+    public init(customID: String, request: ValidatedChatRequest) {
+        self.customID = customID
+        self.request = request
+    }
+}
+
+public actor BatchRegistry {
+    public enum Status: String, Codable, Sendable {
+        case validating, inProgress = "in_progress", completed, failed, cancelling, cancelled
+    }
+
+    public struct Snapshot: Codable, Sendable {
+        public let id: String
+        public let object = "batch"
+        public let status: Status
+        public let endpoint: String
+        public let createdAt: Int
+        public let requestCounts: Counts
+        public let outputFileID: String
+
+        enum CodingKeys: String, CodingKey {
+            case id, object, status, endpoint
+            case createdAt = "created_at"
+            case requestCounts = "request_counts"
+            case outputFileID = "output_file_id"
+        }
+    }
+
+    public struct Counts: Codable, Sendable {
+        public let total: Int
+        public let completed: Int
+        public let failed: Int
+    }
+
+    public struct List: Codable, Sendable {
+        public let object = "list"
+        public let data: [Snapshot]
+        public let firstID: String?
+        public let lastID: String?
+        public let hasMore: Bool
+
+        enum CodingKeys: String, CodingKey {
+            case object, data
+            case firstID = "first_id"
+            case lastID = "last_id"
+            case hasMore = "has_more"
+        }
+    }
+
+    private struct Job {
+        var status: Status
+        let endpoint: String
+        let createdAt: Int
+        let total: Int
+        let outputFileID: String
+        let outputURL: URL
+        var completed = 0
+        var failed = 0
+        var task: Task<Void, Never>?
+    }
+
+    private let outputDirectory: URL
+    private var jobs: [String: Job] = [:]
+
+    public init(outputDirectory: URL = FileManager.default.temporaryDirectory
+        .appendingPathComponent("TurboFieldfare/batches", isDirectory: true)) {
+        self.outputDirectory = outputDirectory
+    }
+
+    public func create(requests: [BatchRequest],
+                       backend: any ServerInferenceBackend,
+                       coordinator: ServerCoordinator,
+                       modelID: String) throws -> Snapshot {
+        let id = "batch_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+        let outputFileID = "file_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+        let outputURL = outputDirectory.appendingPathComponent(outputFileID).appendingPathExtension("jsonl")
+        try FileManager.default.createDirectory(at: outputDirectory,
+                                                withIntermediateDirectories: true)
+        try Data().write(to: outputURL, options: .withoutOverwriting)
+
+        let created = Int(Date().timeIntervalSince1970)
+        jobs[id] = Job(status: .validating,
+                       endpoint: "/v1/chat/completions",
+                       createdAt: created,
+                       total: requests.count,
+                       outputFileID: outputFileID,
+                       outputURL: outputURL)
+        let task = Task { [weak self] in
+            guard let self else { return }
+            await self.start(id)
+            for item in requests {
+                if Task.isCancelled {
+                    await self.cancelled(id)
+                    return
+                }
+                do {
+                    let completion = try await coordinator.run {
+                        try await backend.generate(item.request) { _ in }
+                    }
+                    try await self.succeeded(id,
+                                             customID: item.customID,
+                                             completion: completion,
+                                             modelID: modelID)
+                } catch is CancellationError {
+                    await self.cancelled(id)
+                    return
+                } catch {
+                    await self.failed(id, customID: item.customID, error: error)
+                }
+            }
+            await self.finish(id)
+        }
+        jobs[id]?.task = task
+        return snapshot(id)!
+    }
+
+    public func get(_ id: String) -> Snapshot? { snapshot(id) }
+
+    public func list(limit: Int, after: String?) -> List {
+        let ordered = jobs.keys.sorted { lhs, rhs in
+            let left = jobs[lhs]!
+            let right = jobs[rhs]!
+            if left.createdAt != right.createdAt { return left.createdAt > right.createdAt }
+            return lhs > rhs
+        }
+        let start: Int
+        if let after, let index = ordered.firstIndex(of: after) {
+            start = index + 1
+        } else {
+            start = 0
+        }
+        let ids = Array(ordered.dropFirst(start).prefix(limit))
+        return List(data: ids.compactMap(snapshot),
+                    firstID: ids.first,
+                    lastID: ids.last,
+                    hasMore: start + ids.count < ordered.count)
+    }
+
+    public func cancel(_ id: String) -> Snapshot? {
+        guard var job = jobs[id] else { return nil }
+        guard job.status == .validating || job.status == .inProgress else { return snapshot(id) }
+        job.status = .cancelling
+        job.task?.cancel()
+        jobs[id] = job
+        return snapshot(id)
+    }
+
+    private func start(_ id: String) {
+        guard var job = jobs[id], job.status == .validating else { return }
+        job.status = .inProgress
+        jobs[id] = job
+    }
+
+    private func succeeded(_ id: String,
+                           customID: String,
+                           completion: ServerCompletion,
+                           modelID: String) throws {
+        guard var job = jobs[id] else { return }
+        try appendSuccess(to: job.outputURL,
+                          customID: customID,
+                          completion: completion,
+                          modelID: modelID)
+        job.completed += 1
+        jobs[id] = job
+    }
+
+    private func failed(_ id: String, customID: String, error: Error) {
+        guard var job = jobs[id] else { return }
+        do {
+            try appendFailure(to: job.outputURL, customID: customID, error: error)
+        } catch {
+            // The original inference error remains the result of this item.
+        }
+        job.failed += 1
+        jobs[id] = job
+    }
+
+    private func cancelled(_ id: String) {
+        guard var job = jobs[id] else { return }
+        job.status = .cancelled
+        jobs[id] = job
+    }
+
+    private func finish(_ id: String) {
+        guard var job = jobs[id], job.status != .cancelled else { return }
+        job.status = job.failed == 0 ? .completed : .failed
+        jobs[id] = job
+    }
+
+    private func snapshot(_ id: String) -> Snapshot? {
+        guard let job = jobs[id] else { return nil }
+        return Snapshot(id: id,
+                        status: job.status,
+                        endpoint: job.endpoint,
+                        createdAt: job.createdAt,
+                        requestCounts: .init(total: job.total,
+                                             completed: job.completed,
+                                             failed: job.failed),
+                        outputFileID: job.outputFileID)
+    }
+
+    private func appendSuccess(to url: URL,
+                               customID: String,
+                               completion: ServerCompletion,
+                               modelID: String) throws {
+        let content: Any = completion.content.isEmpty && !completion.toolCalls.isEmpty
+            ? NSNull() : completion.content
+        var message: [String: Any] = ["role": "assistant", "content": content]
+        if !completion.toolCalls.isEmpty {
+            message["tool_calls"] = completion.toolCalls.map {
+                ["id": $0.id,
+                 "type": "function",
+                 "function": ["name": $0.name, "arguments": $0.argumentsJSON]]
+            }
+        }
+        let created = Int(Date().timeIntervalSince1970)
+        let completionID = "chatcmpl-" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+        let body: [String: Any] = [
+            "id": completionID,
+            "object": "chat.completion",
+            "created": created,
+            "model": modelID,
+            "choices": [["index": 0, "message": message, "finish_reason": completion.finishReason]],
+            "usage": usageObject(completion.usage),
+        ]
+        try appendLine([
+            "id": "batch_req_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""),
+            "custom_id": customID,
+            "response": ["status_code": 200, "request_id": completionID, "body": body],
+            "error": NSNull(),
+        ], to: url)
+    }
+
+    private func appendFailure(to url: URL, customID: String, error: Error) throws {
+        let detail: [String: Any]
+        if let error = error as? ServerRequestError {
+            detail = ["code": error.envelope.error.code, "message": error.envelope.error.message]
+        } else {
+            detail = ["code": "internal_error", "message": "generation failed"]
+        }
+        try appendLine([
+            "id": "batch_req_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: ""),
+            "custom_id": customID,
+            "response": NSNull(),
+            "error": detail,
+        ], to: url)
+    }
+
+    private func appendLine(_ object: [String: Any], to url: URL) throws {
+        var data = try JSONSerialization.data(withJSONObject: object)
+        data.append(0x0A)
+        let handle = try FileHandle(forWritingTo: url)
+        defer { try? handle.close() }
+        try handle.seekToEnd()
+        try handle.write(contentsOf: data)
+    }
+
+    private func usageObject(_ usage: OpenAIUsage) -> [String: Any] {
+        ["prompt_tokens": usage.promptTokens,
+         "completion_tokens": usage.completionTokens,
+         "total_tokens": usage.totalTokens,
+         "prompt_tokens_details": ["cached_tokens": usage.promptTokensDetails.cachedTokens]]
+    }
+}

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -132,6 +132,7 @@ public actor BatchRegistry {
         var completedAt: Int?
         var failedAt: Int?
         var expiresAt: Int?
+        let outputExpiresAfterSeconds: Int?
         var finalizingAt: Int?
         var expiredAt: Int?
         var cancellingAt: Int?
@@ -155,7 +156,8 @@ public actor BatchRegistry {
                        modelID: String,
                        inputFileID: String? = nil,
                        completionWindow: String? = nil,
-                       metadata: [String: String]? = nil) throws -> Snapshot {
+                       metadata: [String: String]? = nil,
+                       outputExpiresAfterSeconds: Int? = nil) throws -> Snapshot {
         let id = "batch_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
         try FileManager.default.createDirectory(at: outputDirectory,
                                                 withIntermediateDirectories: true)
@@ -169,7 +171,8 @@ public actor BatchRegistry {
                        metadata: metadata,
                        createdAt: created,
                        total: requests.count,
-                       expiresAt: completionWindow == "24h" ? created + 86_400 : nil)
+                       expiresAt: completionWindow == "24h" ? created + 86_400 : nil,
+                       outputExpiresAfterSeconds: outputExpiresAfterSeconds)
         let task = Task { [weak self] in
             guard let self else { return }
             await self.start(id)
@@ -253,6 +256,9 @@ public actor BatchRegistry {
             try Data().write(to: outputURL, options: .withoutOverwriting)
             job.outputFileID = outputFileID
             job.outputURL = outputURL
+            scheduleExpiry(of: outputURL,
+                           createdAt: job.createdAt,
+                           after: job.outputExpiresAfterSeconds)
         }
         try appendSuccess(to: job.outputURL!,
                           customID: customID,
@@ -274,6 +280,9 @@ public actor BatchRegistry {
                 try Data().write(to: errorURL, options: .withoutOverwriting)
                 job.errorFileID = errorFileID
                 job.errorURL = errorURL
+                scheduleExpiry(of: errorURL,
+                               createdAt: job.createdAt,
+                               after: job.outputExpiresAfterSeconds)
             }
             try appendFailure(to: job.errorURL!, customID: customID, error: error)
         } catch {
@@ -310,6 +319,15 @@ public actor BatchRegistry {
         job.status = .completed
         job.completedAt = Int(Date().timeIntervalSince1970)
         jobs[id] = job
+    }
+
+    private func scheduleExpiry(of url: URL, createdAt: Int, after seconds: Int?) {
+        guard let seconds else { return }
+        let delay = max(0, createdAt + seconds - Int(Date().timeIntervalSince1970))
+        Task.detached {
+            try? await Task.sleep(for: .seconds(delay))
+            try? FileManager.default.removeItem(at: url)
+        }
     }
 
     private func snapshot(_ id: String) -> Snapshot? {

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -20,15 +20,32 @@ public actor BatchRegistry {
         public let object = "batch"
         public let status: Status
         public let endpoint: String
+        public let inputFileID: String?
+        public let completionWindow: String?
         public let createdAt: Int
+        public let inProgressAt: Int?
+        public let completedAt: Int?
+        public let failedAt: Int?
+        public let cancellingAt: Int?
+        public let cancelledAt: Int?
         public let requestCounts: Counts
         public let outputFileID: String
+        public let errorFileID: String?
+        public let metadata: [String: String]?
 
         enum CodingKeys: String, CodingKey {
-            case id, object, status, endpoint
+            case id, object, status, endpoint, metadata
+            case inputFileID = "input_file_id"
+            case completionWindow = "completion_window"
             case createdAt = "created_at"
+            case inProgressAt = "in_progress_at"
+            case completedAt = "completed_at"
+            case failedAt = "failed_at"
+            case cancellingAt = "cancelling_at"
+            case cancelledAt = "cancelled_at"
             case requestCounts = "request_counts"
             case outputFileID = "output_file_id"
+            case errorFileID = "error_file_id"
         }
     }
 
@@ -56,6 +73,9 @@ public actor BatchRegistry {
     private struct Job {
         var status: Status
         let endpoint: String
+        let inputFileID: String?
+        let completionWindow: String?
+        let metadata: [String: String]?
         let createdAt: Int
         let total: Int
         let outputFileID: String
@@ -63,6 +83,11 @@ public actor BatchRegistry {
         var completed = 0
         var failed = 0
         var task: Task<Void, Never>?
+        var inProgressAt: Int?
+        var completedAt: Int?
+        var failedAt: Int?
+        var cancellingAt: Int?
+        var cancelledAt: Int?
     }
 
     private let outputDirectory: URL
@@ -76,7 +101,10 @@ public actor BatchRegistry {
     public func create(requests: [BatchRequest],
                        backend: any ServerInferenceBackend,
                        coordinator: ServerCoordinator,
-                       modelID: String) throws -> Snapshot {
+                       modelID: String,
+                       inputFileID: String? = nil,
+                       completionWindow: String? = nil,
+                       metadata: [String: String]? = nil) throws -> Snapshot {
         let id = "batch_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
         let outputFileID = "file_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
         let outputURL = outputDirectory.appendingPathComponent(outputFileID).appendingPathExtension("jsonl")
@@ -87,6 +115,9 @@ public actor BatchRegistry {
         let created = Int(Date().timeIntervalSince1970)
         jobs[id] = Job(status: .validating,
                        endpoint: "/v1/chat/completions",
+                       inputFileID: inputFileID,
+                       completionWindow: completionWindow,
+                       metadata: metadata,
                        createdAt: created,
                        total: requests.count,
                        outputFileID: outputFileID,
@@ -146,6 +177,7 @@ public actor BatchRegistry {
         guard var job = jobs[id] else { return nil }
         guard job.status == .validating || job.status == .inProgress else { return snapshot(id) }
         job.status = .cancelling
+        job.cancellingAt = Int(Date().timeIntervalSince1970)
         job.task?.cancel()
         jobs[id] = job
         return snapshot(id)
@@ -154,6 +186,7 @@ public actor BatchRegistry {
     private func start(_ id: String) {
         guard var job = jobs[id], job.status == .validating else { return }
         job.status = .inProgress
+        job.inProgressAt = Int(Date().timeIntervalSince1970)
         jobs[id] = job
     }
 
@@ -184,12 +217,14 @@ public actor BatchRegistry {
     private func cancelled(_ id: String) {
         guard var job = jobs[id] else { return }
         job.status = .cancelled
+        job.cancelledAt = Int(Date().timeIntervalSince1970)
         jobs[id] = job
     }
 
     private func finish(_ id: String) {
         guard var job = jobs[id], job.status != .cancelled else { return }
-        job.status = job.failed == 0 ? .completed : .failed
+        job.status = .completed
+        job.completedAt = Int(Date().timeIntervalSince1970)
         jobs[id] = job
     }
 
@@ -198,11 +233,20 @@ public actor BatchRegistry {
         return Snapshot(id: id,
                         status: job.status,
                         endpoint: job.endpoint,
+                        inputFileID: job.inputFileID,
+                        completionWindow: job.completionWindow,
                         createdAt: job.createdAt,
+                        inProgressAt: job.inProgressAt,
+                        completedAt: job.completedAt,
+                        failedAt: job.failedAt,
+                        cancellingAt: job.cancellingAt,
+                        cancelledAt: job.cancelledAt,
                         requestCounts: .init(total: job.total,
                                              completed: job.completed,
                                              failed: job.failed),
-                        outputFileID: job.outputFileID)
+                        outputFileID: job.outputFileID,
+                        errorFileID: nil,
+                        metadata: job.metadata)
     }
 
     private func appendSuccess(to url: URL,

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -20,6 +20,7 @@ public actor BatchRegistry {
         public let object = "batch"
         public let status: Status
         public let endpoint: String
+        public let errors: [BatchError]?
         public let inputFileID: String?
         public let completionWindow: String?
         public let createdAt: Int
@@ -37,7 +38,7 @@ public actor BatchRegistry {
         public let metadata: [String: String]?
 
         enum CodingKeys: String, CodingKey {
-            case id, object, status, endpoint, metadata
+            case id, object, status, endpoint, errors, metadata
             case inputFileID = "input_file_id"
             case completionWindow = "completion_window"
             case createdAt = "created_at"
@@ -53,6 +54,13 @@ public actor BatchRegistry {
             case outputFileID = "output_file_id"
             case errorFileID = "error_file_id"
         }
+    }
+
+    public struct BatchError: Codable, Sendable {
+        public let code: String
+        public let message: String
+        public let param: String?
+        public let line: Int?
     }
 
     public struct Counts: Codable, Sendable {
@@ -132,13 +140,18 @@ public actor BatchRegistry {
                        createdAt: created,
                        total: requests.count,
                        outputFileID: outputFileID,
-                       outputURL: outputURL)
+                       outputURL: outputURL,
+                       expiresAt: completionWindow == "24h" ? created + 86_400 : nil)
         let task = Task { [weak self] in
             guard let self else { return }
             await self.start(id)
             for item in requests {
                 if Task.isCancelled {
                     await self.cancelled(id)
+                    return
+                }
+                if await self.isExpired(id) {
+                    await self.expired(id)
                     return
                 }
                 do {
@@ -239,6 +252,18 @@ public actor BatchRegistry {
         jobs[id] = job
     }
 
+    private func isExpired(_ id: String) -> Bool {
+        guard let expiresAt = jobs[id]?.expiresAt else { return false }
+        return Int(Date().timeIntervalSince1970) >= expiresAt
+    }
+
+    private func expired(_ id: String) {
+        guard var job = jobs[id] else { return }
+        job.status = .expired
+        job.expiredAt = Int(Date().timeIntervalSince1970)
+        jobs[id] = job
+    }
+
     private func finish(_ id: String) {
         guard var job = jobs[id], job.status != .cancelled else { return }
         job.status = .finalizing
@@ -254,6 +279,7 @@ public actor BatchRegistry {
         return Snapshot(id: id,
                         status: job.status,
                         endpoint: job.endpoint,
+                        errors: nil,
                         inputFileID: job.inputFileID,
                         completionWindow: job.completionWindow,
                         createdAt: job.createdAt,

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -258,6 +258,7 @@ public actor BatchRegistry {
                         metadata: job.metadata)
     }
 
+
     private func appendSuccess(to url: URL,
                                customID: String,
                                completion: ServerCompletion,

--- a/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
+++ b/Sources/TurboFieldfareServer/Core/BatchRegistry.swift
@@ -21,7 +21,7 @@ public actor BatchRegistry {
         public let status: Status
         public let endpoint: String
         public let model: String
-        public let errors: [BatchError]?
+        public let errors: Errors?
         public let inputFileID: String?
         public let completionWindow: String?
         public let createdAt: Int
@@ -91,6 +91,16 @@ public actor BatchRegistry {
         public let line: Int?
     }
 
+    public struct Errors: Codable, Sendable {
+        public let object: String
+        public let data: [BatchError]
+
+        public init(data: [BatchError]) {
+            self.object = "list"
+            self.data = data
+        }
+    }
+
     public struct Counts: Codable, Sendable {
         public let total: Int
         public let completed: Int
@@ -140,6 +150,7 @@ public actor BatchRegistry {
         var inputTokens = 0
         var cachedTokens = 0
         var outputTokens = 0
+        let batchErrors: [BatchError]?
     }
 
     private let outputDirectory: URL
@@ -175,7 +186,8 @@ public actor BatchRegistry {
                        createdAt: created,
                        total: requests.count,
                        expiresAt: completionWindow == "24h" ? created + 86_400 : nil,
-                       outputExpiresAfterSeconds: outputExpiresAfterSeconds)
+                       outputExpiresAfterSeconds: outputExpiresAfterSeconds,
+                       batchErrors: nil)
         let task = Task { [weak self] in
             guard let self else { return }
             await self.start(id)
@@ -206,6 +218,28 @@ public actor BatchRegistry {
             await self.finish(id)
         }
         jobs[id]?.task = task
+        return snapshot(id)!
+    }
+
+    public func createFailed(modelID: String,
+                             inputFileID: String,
+                             completionWindow: String,
+                             metadata: [String: String]?,
+                             error: BatchError) -> Snapshot {
+        let id = "batch_" + UUID().uuidString.lowercased().replacingOccurrences(of: "-", with: "")
+        let created = Int(Date().timeIntervalSince1970)
+        jobs[id] = Job(status: .failed,
+                       endpoint: "/v1/chat/completions",
+                       model: modelID,
+                       inputFileID: inputFileID,
+                       completionWindow: completionWindow,
+                       metadata: metadata,
+                       createdAt: created,
+                       total: 0,
+                       failedAt: created,
+                       expiresAt: created + 86_400,
+                       outputExpiresAfterSeconds: nil,
+                       batchErrors: [error])
         return snapshot(id)!
     }
 
@@ -328,7 +362,7 @@ public actor BatchRegistry {
                         status: job.status,
                         endpoint: job.endpoint,
                         model: job.model,
-                        errors: nil,
+                        errors: job.batchErrors.map(Errors.init),
                         inputFileID: job.inputFileID,
                         completionWindow: job.completionWindow,
                         createdAt: job.createdAt,

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -224,10 +224,14 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
             handleBatchJob(body: body, context: context)
         case (.POST, "/v1/files"):
             handleFileUpload(head: head, body: body, context: context)
+        case (.GET, "/v1/files"):
+            handleFileList(context: context)
         case (.GET, let uri) where uri.hasPrefix("/v1/files/") && uri.hasSuffix("/content"):
             handleFileContent(id: String(uri.dropFirst("/v1/files/".count).dropLast("/content".count)), context: context)
         case (.GET, let uri) where uri.hasPrefix("/v1/files/"):
             handleFileStatus(id: String(uri.dropFirst("/v1/files/".count)), context: context)
+        case (.DELETE, let uri) where uri.hasPrefix("/v1/files/"):
+            handleFileDelete(id: String(uri.dropFirst("/v1/files/".count)), context: context)
         case (.GET, "/v1/batches"):
             handleBatchList(uri: head.uri, context: context)
         case (.GET, let uri) where uri.hasPrefix("/v1/batches/"):
@@ -370,6 +374,20 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
     private func handleFileStatus(id: String, context: ChannelHandlerContext) {
         let box = SendableContext(context)
         activeTask = childChannels.startTask { guard let file = await self.files.get(id) else { self.writeError(box.value, status: .notFound, OpenAIErrorEnvelope(message: "file not found", code: "not_found")); return }; self.writeCodable(box.value, status: .ok, file) }
+    }
+
+    private func handleFileList(context: ChannelHandlerContext) {
+        struct List: Encodable { let object = "list"; let data: [BatchFileStore.File] }
+        let box = SendableContext(context)
+        activeTask = childChannels.startTask { self.writeCodable(box.value, status: .ok, List(data: await self.files.list())) }
+    }
+
+    private func handleFileDelete(id: String, context: ChannelHandlerContext) {
+        let box = SendableContext(context)
+        activeTask = childChannels.startTask { do {
+            guard try await self.files.delete(id) else { self.writeError(box.value, status: .notFound, OpenAIErrorEnvelope(message: "file not found", code: "not_found")); return }
+            self.writeJSON(box.value, status: .ok, object: ["id": id, "object": "file", "deleted": true])
+        } catch { self.writeError(box.value, status: .internalServerError, OpenAIErrorEnvelope(message: "could not delete file", code: "internal_error")) } }
     }
 
     private func handleFileContent(id: String, context: ChannelHandlerContext) {

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -235,6 +235,13 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
             }
             handleBatchJob(body: body, context: context)
         case (.POST, "/v1/files"):
+            guard head.headers.first(name: "content-type")?
+                .lowercased().hasPrefix("multipart/form-data") == true else {
+                writeError(context, status: .unsupportedMediaType,
+                           OpenAIErrorEnvelope(message: "content-type must be multipart/form-data",
+                                               code: "unsupported_media_type"))
+                return
+            }
             handleFileUpload(head: head, body: body, context: context)
         case (.GET, "/v1/files"):
             handleFileList(uri: head.uri, context: context)

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -124,6 +124,11 @@ public actor TurboFieldfareHTTPServer {
     }
 }
 
+private struct BatchInputValidationError: Error {
+    let error: ServerRequestError
+    let line: Int?
+}
+
 private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
@@ -286,16 +291,16 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                         }
                         do {
                             requests = try self.decodeBatchInput(input)
-                        } catch let error as ServerRequestError {
+                        } catch let error as BatchInputValidationError {
                             let snapshot = await self.batches.createFailed(
                                 modelID: self.modelID,
                                 inputFileID: create.inputFileID,
                                 completionWindow: create.completionWindow,
                                 metadata: create.metadata,
-                                error: .init(code: error.envelope.error.code,
-                                             message: error.envelope.error.message,
-                                             param: error.envelope.error.param,
-                                             line: nil))
+                                error: .init(code: error.error.envelope.error.code,
+                                             message: error.error.envelope.error.message,
+                                             param: error.error.envelope.error.param,
+                                             line: error.line))
                             self.writeCodable(box.value, status: .ok, snapshot)
                             return
                         }
@@ -333,22 +338,26 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
             enum CodingKeys: String, CodingKey { case customID = "custom_id", method, url, body } }
         let text = String(decoding: data, as: UTF8.self)
         let lines = text.split(whereSeparator: \.isNewline)
-        guard !lines.isEmpty else { throw ServerRequestError.invalid(message: "input file must contain JSONL requests", param: "input_file_id", code: "invalid_value") }
-        guard lines.count <= 50_000 else { throw ServerRequestError.invalid(message: "batch input may contain at most 50,000 requests", param: "input_file_id", code: "invalid_value") }
+        guard !lines.isEmpty else { throw BatchInputValidationError(error: .invalid(message: "input file must contain JSONL requests", param: "input_file_id", code: "invalid_value"), line: nil) }
+        guard lines.count <= 50_000 else { throw BatchInputValidationError(error: .invalid(message: "batch input may contain at most 50,000 requests", param: "input_file_id", code: "invalid_value"), line: nil) }
         var ids = Set<String>()
         return try lines.enumerated().map { index, line in
-            guard let lineData = String(line).data(using: .utf8) else { throw ServerRequestError.invalid(message: "invalid UTF-8 JSONL line", param: "input_file_id", code: "invalid_value") }
+            guard let lineData = String(line).data(using: .utf8) else { throw BatchInputValidationError(error: .invalid(message: "invalid UTF-8 JSONL line", param: "input_file_id", code: "invalid_value"), line: index + 1) }
             let item: Line
             do { item = try JSONDecoder().decode(Line.self, from: lineData) }
-            catch { throw ServerRequestError.invalid(message: "invalid JSONL request at line \(index + 1)", param: "input_file_id", code: "invalid_value") }
+            catch { throw BatchInputValidationError(error: .invalid(message: "invalid JSONL request at line \(index + 1)", param: "input_file_id", code: "invalid_value"), line: index + 1) }
             guard !item.customID.isEmpty, item.customID.utf8.count <= 512 else {
-                throw ServerRequestError.invalid(message: "custom_id must contain 1 through 512 UTF-8 bytes", param: "input_file_id", code: "invalid_value")
+                throw BatchInputValidationError(error: .invalid(message: "custom_id must contain 1 through 512 UTF-8 bytes", param: "input_file_id", code: "invalid_value"), line: index + 1)
             }
             guard item.method == "POST", item.url == "/v1/chat/completions", ids.insert(item.customID).inserted else {
-                throw ServerRequestError.invalid(message: "invalid Batch request at line \(index + 1)", param: "input_file_id", code: "invalid_value")
+                throw BatchInputValidationError(error: .invalid(message: "invalid Batch request at line \(index + 1)", param: "input_file_id", code: "invalid_value"), line: index + 1)
             }
-            guard item.body.stream != true else { throw ServerRequestError.invalid(message: "streaming is not supported for batch requests", param: "input_file_id", code: "unsupported_value") }
-            return BatchRequest(customID: item.customID, request: try OpenAIRequestValidator.validate(item.body, modelID: modelID))
+            guard item.body.stream != true else { throw BatchInputValidationError(error: .invalid(message: "streaming is not supported for batch requests", param: "input_file_id", code: "unsupported_value"), line: index + 1) }
+            do {
+                return BatchRequest(customID: item.customID, request: try OpenAIRequestValidator.validate(item.body, modelID: modelID))
+            } catch let error as ServerRequestError {
+                throw BatchInputValidationError(error: error, line: index + 1)
+            }
         }
     }
 

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -249,6 +249,9 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                 do {
                     let decoded = try? JSONDecoder().decode(OpenAIBatchCreateRequest.self, from: Data(bytes))
                     let requests: [BatchRequest]
+                    var inputFileID: String?
+                    var completionWindow: String?
+                    var metadata: [String: String]?
                     if let create = decoded {
                         guard create.endpoint == "/v1/chat/completions" else {
                             throw ServerRequestError.invalid(message: "only /v1/chat/completions batches are supported", param: "endpoint", code: "unsupported_value")
@@ -260,6 +263,9 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                             throw ServerRequestError.invalid(message: "input file not found", param: "input_file_id", code: "invalid_value")
                         }
                         requests = try self.decodeBatchInput(input)
+                        inputFileID = create.inputFileID
+                        completionWindow = create.completionWindow
+                        metadata = create.metadata
                     } else {
                         let legacy = try JSONDecoder().decode(LegacyOpenAIChatBatchRequest.self, from: Data(bytes))
                         guard !legacy.requests.isEmpty else { throw ServerRequestError.invalid(message: "requests must not be empty", param: "requests", code: "invalid_value") }
@@ -271,7 +277,10 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                     let snapshot = try await self.batches.create(requests: requests,
                                                                  backend: self.backend,
                                                                  coordinator: self.coordinator,
-                                                                 modelID: self.modelID)
+                                                                 modelID: self.modelID,
+                                                                 inputFileID: inputFileID,
+                                                                 completionWindow: completionWindow,
+                                                                 metadata: metadata)
                     _ = try await self.files.registerBatchOutput(snapshot.outputFileID)
                     self.writeCodable(box.value, status: .ok, snapshot)
                 } catch let error as ServerRequestError {

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -225,7 +225,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         case (.POST, "/v1/files"):
             handleFileUpload(head: head, body: body, context: context)
         case (.GET, "/v1/files"):
-            handleFileList(context: context)
+            handleFileList(uri: head.uri, context: context)
         case (.GET, let uri) where uri.hasPrefix("/v1/files/") && uri.hasSuffix("/content"):
             handleFileContent(id: String(uri.dropFirst("/v1/files/".count).dropLast("/content".count)), context: context)
         case (.GET, let uri) where uri.hasPrefix("/v1/files/"):
@@ -373,10 +373,42 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         activeTask = childChannels.startTask { guard let file = await self.files.get(id) else { self.writeError(box.value, status: .notFound, OpenAIErrorEnvelope(message: "file not found", code: "not_found")); return }; self.writeCodable(box.value, status: .ok, file) }
     }
 
-    private func handleFileList(context: ChannelHandlerContext) {
-        struct List: Encodable { let object = "list"; let data: [BatchFileStore.File] }
+    private func handleFileList(uri: String, context: ChannelHandlerContext) {
+        struct List: Encodable {
+            let object = "list"
+            let data: [BatchFileStore.File]
+            let firstID: String?
+            let lastID: String?
+            let hasMore: Bool
+            enum CodingKeys: String, CodingKey {
+                case object, data
+                case firstID = "first_id"
+                case lastID = "last_id"
+                case hasMore = "has_more"
+            }
+        }
+        guard let components = URLComponents(string: "http://localhost\(uri)") else {
+            writeError(context, status: .badRequest, OpenAIErrorEnvelope(message: "invalid query", code: "invalid_value"))
+            return
+        }
+        let query = components.queryItems ?? []
+        let limit = query.first(where: { $0.name == "limit" })?.value.flatMap(Int.init) ?? 10_000
+        let order = query.first(where: { $0.name == "order" })?.value ?? "desc"
+        guard (1...10_000).contains(limit), order == "asc" || order == "desc" else {
+            writeError(context, status: .badRequest, OpenAIErrorEnvelope(message: "invalid Files list query", code: "invalid_value"))
+            return
+        }
+        let after = query.first(where: { $0.name == "after" })?.value
+        let purpose = query.first(where: { $0.name == "purpose" })?.value
         let box = SendableContext(context)
-        activeTask = childChannels.startTask { self.writeCodable(box.value, status: .ok, List(data: await self.files.list())) }
+        activeTask = childChannels.startTask {
+            let all = await self.files.list(order: order, purpose: purpose)
+            let start = after.flatMap { id in all.firstIndex(where: { $0.id == id }).map { $0 + 1 } } ?? 0
+            let page = Array(all.dropFirst(start).prefix(limit))
+            self.writeCodable(box.value, status: .ok, List(data: page, firstID: page.first?.id,
+                                                            lastID: page.last?.id,
+                                                            hasMore: start + page.count < all.count))
+        }
     }
 
     private func handleFileDelete(id: String, context: ChannelHandlerContext) {

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -129,6 +129,10 @@ private struct BatchInputValidationError: Error {
     let line: Int?
 }
 
+private struct BatchInputErrors: Error {
+    let errors: [BatchRegistry.BatchError]
+}
+
 private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendable {
     typealias InboundIn = HTTPServerRequestPart
     typealias OutboundOut = HTTPServerResponsePart
@@ -289,18 +293,16 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                         guard let input = try await self.files.contents(create.inputFileID) else {
                             throw ServerRequestError.invalid(message: "input file not found", param: "input_file_id", code: "invalid_value")
                         }
-                        do {
-                            requests = try self.decodeBatchInput(input)
-                        } catch let error as BatchInputValidationError {
+                        switch self.decodeBatchInput(input) {
+                        case .success(let decoded):
+                            requests = decoded
+                        case .failure(let validation):
                             let snapshot = await self.batches.createFailed(
                                 modelID: self.modelID,
                                 inputFileID: create.inputFileID,
                                 completionWindow: create.completionWindow,
                                 metadata: create.metadata,
-                                error: .init(code: error.error.envelope.error.code,
-                                             message: error.error.envelope.error.message,
-                                             param: error.error.envelope.error.param,
-                                             line: error.line))
+                                errors: validation.errors)
                             self.writeCodable(box.value, status: .ok, snapshot)
                             return
                         }
@@ -333,36 +335,54 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         }
     }
 
-    private func decodeBatchInput(_ data: Data) throws -> [BatchRequest] {
+    private func decodeBatchInput(_ data: Data) -> Result<[BatchRequest], BatchInputErrors> {
         struct Line: Decodable { let customID: String; let method: String; let url: String; let body: OpenAIChatRequest
             enum CodingKeys: String, CodingKey { case customID = "custom_id", method, url, body } }
         let text = String(decoding: data, as: UTF8.self)
         var lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
         if lines.last?.isEmpty == true { lines.removeLast() }
-        guard !lines.isEmpty else { throw BatchInputValidationError(error: .invalid(message: "input file must contain JSONL requests", param: "input_file_id", code: "invalid_value"), line: nil) }
-        guard lines.count <= 50_000 else { throw BatchInputValidationError(error: .invalid(message: "batch input may contain at most 50,000 requests", param: "input_file_id", code: "invalid_value"), line: nil) }
+        guard !lines.isEmpty else { return .failure(.init(errors: [batchError(.init(error: .invalid(message: "input file must contain JSONL requests", param: "input_file_id", code: "invalid_value"), line: nil))])) }
+        guard lines.count <= 50_000 else { return .failure(.init(errors: [batchError(.init(error: .invalid(message: "batch input may contain at most 50,000 requests", param: "input_file_id", code: "invalid_value"), line: nil))])) }
         var ids = Set<String>()
-        return try lines.enumerated().map { index, line in
-            guard !line.isEmpty else {
-                throw BatchInputValidationError(error: .invalid(message: "JSONL request line must not be empty", param: "input_file_id", code: "invalid_value"), line: index + 1)
-            }
-            guard let lineData = String(line).data(using: .utf8) else { throw BatchInputValidationError(error: .invalid(message: "invalid UTF-8 JSONL line", param: "input_file_id", code: "invalid_value"), line: index + 1) }
-            let item: Line
-            do { item = try JSONDecoder().decode(Line.self, from: lineData) }
-            catch { throw BatchInputValidationError(error: .invalid(message: "invalid JSONL request at line \(index + 1)", param: "input_file_id", code: "invalid_value"), line: index + 1) }
-            guard !item.customID.isEmpty, item.customID.utf8.count <= 512 else {
-                throw BatchInputValidationError(error: .invalid(message: "custom_id must contain 1 through 512 UTF-8 bytes", param: "input_file_id", code: "invalid_value"), line: index + 1)
-            }
-            guard item.method == "POST", item.url == "/v1/chat/completions", ids.insert(item.customID).inserted else {
-                throw BatchInputValidationError(error: .invalid(message: "invalid Batch request at line \(index + 1)", param: "input_file_id", code: "invalid_value"), line: index + 1)
-            }
-            guard item.body.stream != true else { throw BatchInputValidationError(error: .invalid(message: "streaming is not supported for batch requests", param: "input_file_id", code: "unsupported_value"), line: index + 1) }
+        var requests: [BatchRequest] = []
+        var errors: [BatchRegistry.BatchError] = []
+        for (index, line) in lines.enumerated() {
             do {
-                return BatchRequest(customID: item.customID, request: try OpenAIRequestValidator.validate(item.body, modelID: modelID))
-            } catch let error as ServerRequestError {
-                throw BatchInputValidationError(error: error, line: index + 1)
+                guard !line.isEmpty else {
+                    throw BatchInputValidationError(error: .invalid(message: "JSONL request line must not be empty", param: "input_file_id", code: "invalid_value"), line: index + 1)
+                }
+                guard let lineData = String(line).data(using: .utf8) else { throw BatchInputValidationError(error: .invalid(message: "invalid UTF-8 JSONL line", param: "input_file_id", code: "invalid_value"), line: index + 1) }
+                let item: Line
+                do { item = try JSONDecoder().decode(Line.self, from: lineData) }
+                catch { throw BatchInputValidationError(error: .invalid(message: "invalid JSONL request at line \(index + 1)", param: "input_file_id", code: "invalid_value"), line: index + 1) }
+                guard !item.customID.isEmpty, item.customID.utf8.count <= 512 else {
+                    throw BatchInputValidationError(error: .invalid(message: "custom_id must contain 1 through 512 UTF-8 bytes", param: "input_file_id", code: "invalid_value"), line: index + 1)
+                }
+                guard item.method == "POST", item.url == "/v1/chat/completions", ids.insert(item.customID).inserted else {
+                    throw BatchInputValidationError(error: .invalid(message: "invalid Batch request at line \(index + 1)", param: "input_file_id", code: "invalid_value"), line: index + 1)
+                }
+                guard item.body.stream != true else { throw BatchInputValidationError(error: .invalid(message: "streaming is not supported for batch requests", param: "input_file_id", code: "unsupported_value"), line: index + 1) }
+                do {
+                    requests.append(BatchRequest(customID: item.customID, request: try OpenAIRequestValidator.validate(item.body, modelID: modelID)))
+                } catch let error as ServerRequestError {
+                    throw BatchInputValidationError(error: error, line: index + 1)
+                } catch {
+                    throw BatchInputValidationError(error: .invalid(message: "invalid Batch request at line \(index + 1)", param: "input_file_id", code: "invalid_value"), line: index + 1)
+                }
+            } catch let error as BatchInputValidationError {
+                errors.append(batchError(error))
+            } catch {
+                errors.append(batchError(.init(error: .invalid(message: "invalid Batch request at line \(index + 1)", param: "input_file_id", code: "invalid_value"), line: index + 1)))
             }
         }
+        return errors.isEmpty ? .success(requests) : .failure(.init(errors: errors))
+    }
+
+    private func batchError(_ error: BatchInputValidationError) -> BatchRegistry.BatchError {
+        .init(code: error.error.envelope.error.code,
+              message: error.error.envelope.error.message,
+              param: error.error.envelope.error.param,
+              line: error.line)
     }
 
     private func handleFileUpload(head: HTTPRequestHead, body: ByteBuffer, context: ChannelHandlerContext) {

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -7,6 +7,7 @@ import TurboFieldfare
 
 public actor TurboFieldfareHTTPServer {
     public static let maximumBodyBytes = 1_048_576
+    public static let maximumBatchFileBytes = 200 * 1_024 * 1_024
 
     private let group: MultiThreadedEventLoopGroup
     private let modelID: String
@@ -159,7 +160,10 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
             body.clear()
             oversized = false
         case .body(var part):
-            if body.readableBytes + part.readableBytes > TurboFieldfareHTTPServer.maximumBodyBytes {
+            let limit = head?.uri.split(separator: "?", maxSplits: 1).first == "/v1/files"
+                ? TurboFieldfareHTTPServer.maximumBatchFileBytes
+                : TurboFieldfareHTTPServer.maximumBodyBytes
+            if body.readableBytes + part.readableBytes > limit {
                 oversized = true
             } else {
                 body.writeBuffer(&part)
@@ -253,6 +257,10 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                     var completionWindow: String?
                     var metadata: [String: String]?
                     if let create = decoded {
+                        guard (create.metadata?.count ?? 0) <= 16,
+                              create.metadata?.allSatisfy({ $0.key.utf8.count <= 64 && $0.value.utf8.count <= 512 }) ?? true else {
+                            throw ServerRequestError.invalid(message: "metadata supports at most 16 entries with keys up to 64 and values up to 512 UTF-8 bytes", param: "metadata", code: "invalid_value")
+                        }
                         guard create.endpoint == "/v1/chat/completions" else {
                             throw ServerRequestError.invalid(message: "only /v1/chat/completions batches are supported", param: "endpoint", code: "unsupported_value")
                         }
@@ -299,12 +307,16 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         let text = String(decoding: data, as: UTF8.self)
         let lines = text.split(whereSeparator: \.isNewline)
         guard !lines.isEmpty else { throw ServerRequestError.invalid(message: "input file must contain JSONL requests", param: "input_file_id", code: "invalid_value") }
+        guard lines.count <= 50_000 else { throw ServerRequestError.invalid(message: "batch input may contain at most 50,000 requests", param: "input_file_id", code: "invalid_value") }
         var ids = Set<String>()
         return try lines.enumerated().map { index, line in
             guard let lineData = String(line).data(using: .utf8) else { throw ServerRequestError.invalid(message: "invalid UTF-8 JSONL line", param: "input_file_id", code: "invalid_value") }
             let item: Line
             do { item = try JSONDecoder().decode(Line.self, from: lineData) }
             catch { throw ServerRequestError.invalid(message: "invalid JSONL request at line \(index + 1)", param: "input_file_id", code: "invalid_value") }
+            guard !item.customID.isEmpty, item.customID.utf8.count <= 512 else {
+                throw ServerRequestError.invalid(message: "custom_id must contain 1 through 512 UTF-8 bytes", param: "input_file_id", code: "invalid_value")
+            }
             guard item.method == "POST", item.url == "/v1/chat/completions", ids.insert(item.customID).inserted else {
                 throw ServerRequestError.invalid(message: "invalid Batch request at line \(index + 1)", param: "input_file_id", code: "invalid_value")
             }

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -13,6 +13,7 @@ public actor TurboFieldfareHTTPServer {
     private let backend: any ServerInferenceBackend
     private let coordinator: ServerCoordinator
     private let batches: BatchRegistry
+    private let files: BatchFileStore
     private let heartbeatInterval: TimeAmount
     private let childChannels = ChildChannelRegistry()
     private var channel: Channel?
@@ -28,7 +29,10 @@ public actor TurboFieldfareHTTPServer {
         self.modelID = modelID
         self.backend = backend
         self.coordinator = ServerCoordinator(queueLimit: queueLimit)
-        self.batches = batchOutputDirectory.map(BatchRegistry.init(outputDirectory:)) ?? BatchRegistry()
+        let batchDirectory = batchOutputDirectory ?? FileManager.default.temporaryDirectory
+            .appendingPathComponent("TurboFieldfare/batches", isDirectory: true)
+        self.batches = BatchRegistry(outputDirectory: batchDirectory)
+        self.files = BatchFileStore(directory: batchDirectory)
         self.heartbeatInterval = heartbeatInterval
     }
 
@@ -37,6 +41,7 @@ public actor TurboFieldfareHTTPServer {
         let backend = self.backend
         let coordinator = self.coordinator
         let batches = self.batches
+        let files = self.files
         let heartbeatInterval = self.heartbeatInterval
         let childChannels = self.childChannels
         let bootstrap = ServerBootstrap(group: group)
@@ -53,6 +58,7 @@ public actor TurboFieldfareHTTPServer {
                         backend: backend,
                         coordinator: coordinator,
                         batches: batches,
+                        files: files,
                         heartbeatInterval: heartbeatInterval,
                         childChannels: childChannels))
                 }
@@ -122,6 +128,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
     private let backend: any ServerInferenceBackend
     private let coordinator: ServerCoordinator
     private let batches: BatchRegistry
+    private let files: BatchFileStore
     private let heartbeatInterval: TimeAmount
     private let childChannels: ChildChannelRegistry
     private var head: HTTPRequestHead?
@@ -133,12 +140,14 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
          backend: any ServerInferenceBackend,
          coordinator: ServerCoordinator,
          batches: BatchRegistry,
+         files: BatchFileStore,
          heartbeatInterval: TimeAmount,
          childChannels: ChildChannelRegistry) {
         self.modelID = modelID
         self.backend = backend
         self.coordinator = coordinator
         self.batches = batches
+        self.files = files
         self.heartbeatInterval = heartbeatInterval
         self.childChannels = childChannels
     }
@@ -209,13 +218,19 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                 return
             }
             handleBatchJob(body: body, context: context)
+        case (.POST, "/v1/files"):
+            handleFileUpload(head: head, body: body, context: context)
+        case (.GET, let uri) where uri.hasPrefix("/v1/files/") && uri.hasSuffix("/content"):
+            handleFileContent(id: String(uri.dropFirst("/v1/files/".count).dropLast("/content".count)), context: context)
+        case (.GET, let uri) where uri.hasPrefix("/v1/files/"):
+            handleFileStatus(id: String(uri.dropFirst("/v1/files/".count)), context: context)
         case (.GET, "/v1/batches"):
             handleBatchList(uri: head.uri, context: context)
         case (.GET, let uri) where uri.hasPrefix("/v1/batches/"):
             handleBatchStatus(uri: uri, context: context)
         case (.POST, let uri) where uri.hasPrefix("/v1/batches/") && uri.hasSuffix("/cancel"):
             handleBatchCancel(uri: uri, context: context)
-        case (_, "/health"), (_, "/v1/models"), (_, "/v1/chat/completions"), (_, "/v1/batches"):
+        case (_, "/health"), (_, "/v1/models"), (_, "/v1/chat/completions"), (_, "/v1/batches"), (_, "/v1/files"):
             writeError(context, status: .methodNotAllowed,
                        OpenAIErrorEnvelope(message: "method not allowed",
                                            code: "method_not_allowed"))
@@ -229,21 +244,38 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
     private func handleBatchJob(body: ByteBuffer, context: ChannelHandlerContext) {
         do {
             let bytes = body.getBytes(at: body.readerIndex, length: body.readableBytes) ?? []
-            let envelope = try JSONDecoder().decode(OpenAIChatBatchRequest.self, from: Data(bytes))
-            guard !envelope.requests.isEmpty else { throw ServerRequestError.invalid(message: "requests must not be empty", param: "requests", code: "invalid_value") }
-            let requests = try envelope.requests.enumerated().map { index, item -> BatchRequest in
-                guard item.stream != true else { throw ServerRequestError.invalid(message: "streaming is not supported for batch requests", param: "requests.stream", code: "unsupported_value") }
-                return BatchRequest(customID: item.customID ?? "request-\(index)",
-                                    request: try OpenAIRequestValidator.validate(item, modelID: modelID))
-            }
             let box = SendableContext(context)
             activeTask = childChannels.startTask {
                 do {
+                    let decoded = try? JSONDecoder().decode(OpenAIBatchCreateRequest.self, from: Data(bytes))
+                    let requests: [BatchRequest]
+                    if let create = decoded {
+                        guard create.endpoint == "/v1/chat/completions" else {
+                            throw ServerRequestError.invalid(message: "only /v1/chat/completions batches are supported", param: "endpoint", code: "unsupported_value")
+                        }
+                        guard create.completionWindow == "24h" else {
+                            throw ServerRequestError.invalid(message: "only completion_window=24h is supported", param: "completion_window", code: "unsupported_value")
+                        }
+                        guard let input = try await self.files.contents(create.inputFileID) else {
+                            throw ServerRequestError.invalid(message: "input file not found", param: "input_file_id", code: "invalid_value")
+                        }
+                        requests = try self.decodeBatchInput(input)
+                    } else {
+                        let legacy = try JSONDecoder().decode(LegacyOpenAIChatBatchRequest.self, from: Data(bytes))
+                        guard !legacy.requests.isEmpty else { throw ServerRequestError.invalid(message: "requests must not be empty", param: "requests", code: "invalid_value") }
+                        requests = try legacy.requests.enumerated().map { index, item in
+                            guard item.stream != true else { throw ServerRequestError.invalid(message: "streaming is not supported for batch requests", param: "requests.stream", code: "unsupported_value") }
+                            return BatchRequest(customID: item.customID ?? "request-\(index)", request: try OpenAIRequestValidator.validate(item, modelID: self.modelID))
+                        }
+                    }
                     let snapshot = try await self.batches.create(requests: requests,
                                                                  backend: self.backend,
                                                                  coordinator: self.coordinator,
                                                                  modelID: self.modelID)
+                    _ = try await self.files.registerBatchOutput(snapshot.outputFileID)
                     self.writeCodable(box.value, status: .ok, snapshot)
+                } catch let error as ServerRequestError {
+                    self.writeError(box.value, status: error == .unknownModel ? .notFound : .badRequest, error.envelope)
                 } catch {
                     self.handleAsyncError(
                         error,
@@ -255,6 +287,78 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
             }
         } catch let error as ServerRequestError { writeError(context, status: error == .unknownModel ? .notFound : .badRequest, error.envelope) }
         catch { writeError(context, status: .badRequest, OpenAIErrorEnvelope(message: "malformed JSON request", code: "invalid_json")) }
+    }
+
+    private func decodeBatchInput(_ data: Data) throws -> [BatchRequest] {
+        struct Line: Decodable { let customID: String; let method: String; let url: String; let body: OpenAIChatRequest
+            enum CodingKeys: String, CodingKey { case customID = "custom_id", method, url, body } }
+        let text = String(decoding: data, as: UTF8.self)
+        let lines = text.split(whereSeparator: \.isNewline)
+        guard !lines.isEmpty else { throw ServerRequestError.invalid(message: "input file must contain JSONL requests", param: "input_file_id", code: "invalid_value") }
+        var ids = Set<String>()
+        return try lines.enumerated().map { index, line in
+            guard let lineData = String(line).data(using: .utf8) else { throw ServerRequestError.invalid(message: "invalid UTF-8 JSONL line", param: "input_file_id", code: "invalid_value") }
+            let item: Line
+            do { item = try JSONDecoder().decode(Line.self, from: lineData) }
+            catch { throw ServerRequestError.invalid(message: "invalid JSONL request at line \(index + 1)", param: "input_file_id", code: "invalid_value") }
+            guard item.method == "POST", item.url == "/v1/chat/completions", ids.insert(item.customID).inserted else {
+                throw ServerRequestError.invalid(message: "invalid Batch request at line \(index + 1)", param: "input_file_id", code: "invalid_value")
+            }
+            guard item.body.stream != true else { throw ServerRequestError.invalid(message: "streaming is not supported for batch requests", param: "input_file_id", code: "unsupported_value") }
+            return BatchRequest(customID: item.customID, request: try OpenAIRequestValidator.validate(item.body, modelID: modelID))
+        }
+    }
+
+    private func handleFileUpload(head: HTTPRequestHead, body: ByteBuffer, context: ChannelHandlerContext) {
+        do {
+            guard let contentType = head.headers.first(name: "content-type"),
+                  let boundary = contentType.split(separator: ";").map({ $0.trimmingCharacters(in: .whitespaces) }).first(where: { $0.hasPrefix("boundary=") })?.dropFirst("boundary=".count) else {
+                throw ServerRequestError.invalid(message: "content-type must be multipart/form-data", param: nil, code: "unsupported_media_type")
+            }
+            let bytes = body.getBytes(at: body.readerIndex, length: body.readableBytes) ?? []
+            let parsed = try parseMultipart(Data(bytes), boundary: String(boundary).trimmingCharacters(in: CharacterSet(charactersIn: "\"")))
+            let box = SendableContext(context)
+            activeTask = childChannels.startTask { do {
+                let file = try await self.files.create(filename: parsed.filename, purpose: parsed.purpose, contents: parsed.contents)
+                self.writeCodable(box.value, status: .ok, file)
+            } catch let error as ServerRequestError { self.writeError(box.value, status: .badRequest, error.envelope) }
+              catch { self.writeError(box.value, status: .internalServerError, OpenAIErrorEnvelope(message: "could not store file", code: "internal_error")) } }
+        } catch let error as ServerRequestError { writeError(context, status: .badRequest, error.envelope) }
+          catch { writeError(context, status: .badRequest, OpenAIErrorEnvelope(message: "malformed multipart request", code: "invalid_request_error")) }
+    }
+
+    private func parseMultipart(_ data: Data, boundary: String) throws -> (filename: String, purpose: String, contents: Data) {
+        let text = String(decoding: data, as: UTF8.self)
+        let parts = text.components(separatedBy: "--\(boundary)")
+        var purpose: String?
+        var filename: String?
+        var contents: Data?
+        for rawPart in parts {
+            let part = rawPart.trimmingCharacters(in: CharacterSet(charactersIn: "\r\n-"))
+            guard let range = part.range(of: "\r\n\r\n") else { continue }
+            let headers = String(part[..<range.lowerBound])
+            var value = String(part[range.upperBound...])
+            if value.hasSuffix("\r\n") { value.removeLast(2) }
+            if headers.contains("name=\"purpose\"") { purpose = value }
+            if headers.contains("name=\"file\"") {
+                filename = headers.components(separatedBy: "filename=\"").dropFirst().first?.components(separatedBy: "\"").first
+                contents = Data(value.utf8)
+            }
+        }
+        guard let purpose, let filename, let contents else {
+            throw ServerRequestError.invalid(message: "multipart request requires file and purpose", param: nil, code: "invalid_value")
+        }
+        return (filename, purpose, contents)
+    }
+
+    private func handleFileStatus(id: String, context: ChannelHandlerContext) {
+        let box = SendableContext(context)
+        activeTask = childChannels.startTask { guard let file = await self.files.get(id) else { self.writeError(box.value, status: .notFound, OpenAIErrorEnvelope(message: "file not found", code: "not_found")); return }; self.writeCodable(box.value, status: .ok, file) }
+    }
+
+    private func handleFileContent(id: String, context: ChannelHandlerContext) {
+        let box = SendableContext(context)
+        activeTask = childChannels.startTask { do { guard let data = try await self.files.contents(id) else { self.writeError(box.value, status: .notFound, OpenAIErrorEnvelope(message: "file not found", code: "not_found")); return }; self.writeRaw(box.value, status: .ok, contentType: "application/jsonl", data: data) } catch { self.writeError(box.value, status: .internalServerError, OpenAIErrorEnvelope(message: "could not read file", code: "internal_error")) } }
     }
 
     private func handleBatchList(uri: String, context: ChannelHandlerContext) {
@@ -628,6 +732,21 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
             contextBox.value.write(self.wrapOutboundOut(.head(
                 HTTPResponseHead(version: .http1_1, status: status, headers: headers))),
                 promise: nil)
+            var buffer = contextBox.value.channel.allocator.buffer(capacity: data.count)
+            buffer.writeBytes(data)
+            contextBox.value.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)
+            contextBox.value.writeAndFlush(self.wrapOutboundOut(.end(nil)), promise: nil)
+        }
+    }
+
+    private func writeRaw(_ context: ChannelHandlerContext, status: HTTPResponseStatus,
+                          contentType: String, data: Data) {
+        let contextBox = SendableContext(context)
+        context.eventLoop.execute {
+            var headers = HTTPHeaders()
+            headers.add(name: "content-type", value: contentType)
+            headers.add(name: "content-length", value: "\(data.count)")
+            contextBox.value.write(self.wrapOutboundOut(.head(HTTPResponseHead(version: .http1_1, status: status, headers: headers))), promise: nil)
             var buffer = contextBox.value.channel.allocator.buffer(capacity: data.count)
             buffer.writeBytes(data)
             contextBox.value.write(self.wrapOutboundOut(.body(.byteBuffer(buffer))), promise: nil)

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -281,17 +281,12 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                                                                  inputFileID: inputFileID,
                                                                  completionWindow: completionWindow,
                                                                  metadata: metadata)
-                    _ = try await self.files.registerBatchOutput(snapshot.outputFileID)
                     self.writeCodable(box.value, status: .ok, snapshot)
                 } catch let error as ServerRequestError {
                     self.writeError(box.value, status: error == .unknownModel ? .notFound : .badRequest, error.envelope)
                 } catch {
-                    self.handleAsyncError(
-                        error,
-                        context: box.value,
-                        id: "batch-" + UUID().uuidString.lowercased(),
-                        phase: "creating batch",
-                        stream: false)
+                    self.writeError(box.value, status: .badRequest,
+                                    OpenAIErrorEnvelope(message: "malformed JSON request", code: "invalid_json"))
                 }
             }
         } catch let error as ServerRequestError { writeError(context, status: error == .unknownModel ? .notFound : .badRequest, error.envelope) }

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -337,11 +337,15 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         struct Line: Decodable { let customID: String; let method: String; let url: String; let body: OpenAIChatRequest
             enum CodingKeys: String, CodingKey { case customID = "custom_id", method, url, body } }
         let text = String(decoding: data, as: UTF8.self)
-        let lines = text.split(whereSeparator: \.isNewline)
+        var lines = text.split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+        if lines.last?.isEmpty == true { lines.removeLast() }
         guard !lines.isEmpty else { throw BatchInputValidationError(error: .invalid(message: "input file must contain JSONL requests", param: "input_file_id", code: "invalid_value"), line: nil) }
         guard lines.count <= 50_000 else { throw BatchInputValidationError(error: .invalid(message: "batch input may contain at most 50,000 requests", param: "input_file_id", code: "invalid_value"), line: nil) }
         var ids = Set<String>()
         return try lines.enumerated().map { index, line in
+            guard !line.isEmpty else {
+                throw BatchInputValidationError(error: .invalid(message: "JSONL request line must not be empty", param: "input_file_id", code: "invalid_value"), line: index + 1)
+            }
             guard let lineData = String(line).data(using: .utf8) else { throw BatchInputValidationError(error: .invalid(message: "invalid UTF-8 JSONL line", param: "input_file_id", code: "invalid_value"), line: index + 1) }
             let item: Line
             do { item = try JSONDecoder().decode(Line.self, from: lineData) }

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -259,6 +259,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                     var inputFileID: String?
                     var completionWindow: String?
                     var metadata: [String: String]?
+                    var outputExpiresAfterSeconds: Int?
                     if let create = decoded {
                         guard (create.metadata?.count ?? 0) <= 16,
                               create.metadata?.allSatisfy({ $0.key.utf8.count <= 64 && $0.value.utf8.count <= 512 }) ?? true else {
@@ -269,6 +270,13 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                         }
                         guard create.completionWindow == "24h" else {
                             throw ServerRequestError.invalid(message: "only completion_window=24h is supported", param: "completion_window", code: "unsupported_value")
+                        }
+                        if let outputExpiresAfter = create.outputExpiresAfter {
+                            guard outputExpiresAfter.anchor == "created_at",
+                                  (3_600...2_592_000).contains(outputExpiresAfter.seconds) else {
+                                throw ServerRequestError.invalid(message: "output_expires_after requires anchor=created_at and seconds between 3600 and 2592000", param: "output_expires_after", code: "invalid_value")
+                            }
+                            outputExpiresAfterSeconds = outputExpiresAfter.seconds
                         }
                         guard let input = try await self.files.contents(create.inputFileID) else {
                             throw ServerRequestError.invalid(message: "input file not found", param: "input_file_id", code: "invalid_value")
@@ -291,7 +299,8 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                                                                  modelID: self.modelID,
                                                                  inputFileID: inputFileID,
                                                                  completionWindow: completionWindow,
-                                                                 metadata: metadata)
+                                                                 metadata: metadata,
+                                                                 outputExpiresAfterSeconds: outputExpiresAfterSeconds)
                     self.writeCodable(box.value, status: .ok, snapshot)
             } catch let error as ServerRequestError {
                 self.writeError(box.value, status: error == .unknownModel ? .notFound : .badRequest, error.envelope)

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -284,7 +284,21 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                         guard let input = try await self.files.contents(create.inputFileID) else {
                             throw ServerRequestError.invalid(message: "input file not found", param: "input_file_id", code: "invalid_value")
                         }
-                        requests = try self.decodeBatchInput(input)
+                        do {
+                            requests = try self.decodeBatchInput(input)
+                        } catch let error as ServerRequestError {
+                            let snapshot = await self.batches.createFailed(
+                                modelID: self.modelID,
+                                inputFileID: create.inputFileID,
+                                completionWindow: create.completionWindow,
+                                metadata: create.metadata,
+                                error: .init(code: error.envelope.error.code,
+                                             message: error.envelope.error.message,
+                                             param: error.envelope.error.param,
+                                             line: nil))
+                            self.writeCodable(box.value, status: .ok, snapshot)
+                            return
+                        }
                         inputFileID = create.inputFileID
                         completionWindow = create.completionWindow
                         metadata = create.metadata

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -290,8 +290,10 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                             }
                             outputExpiresAfterSeconds = outputExpiresAfter.seconds
                         }
-                        guard let input = try await self.files.contents(create.inputFileID) else {
-                            throw ServerRequestError.invalid(message: "input file not found", param: "input_file_id", code: "invalid_value")
+                        guard let inputFile = await self.files.get(create.inputFileID),
+                              inputFile.purpose == "batch",
+                              let input = try await self.files.contents(create.inputFileID) else {
+                            throw ServerRequestError.invalid(message: "input_file_id must reference a file with purpose=batch", param: "input_file_id", code: "invalid_value")
                         }
                         switch self.decodeBatchInput(input) {
                         case .success(let decoded):

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -32,8 +32,11 @@ public actor TurboFieldfareHTTPServer {
         self.coordinator = ServerCoordinator(queueLimit: queueLimit)
         let batchDirectory = batchOutputDirectory ?? FileManager.default.temporaryDirectory
             .appendingPathComponent("TurboFieldfare/batches", isDirectory: true)
-        self.batches = BatchRegistry(outputDirectory: batchDirectory)
-        self.files = BatchFileStore(directory: batchDirectory)
+        let files = BatchFileStore(directory: batchDirectory)
+        self.files = files
+        self.batches = BatchRegistry(outputDirectory: batchDirectory) { id, expiresAt in
+            _ = try? await files.registerBatchOutput(id, expiresAt: expiresAt)
+        }
         self.heartbeatInterval = heartbeatInterval
     }
 

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -250,11 +250,10 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
     }
 
     private func handleBatchJob(body: ByteBuffer, context: ChannelHandlerContext) {
-        do {
-            let bytes = body.getBytes(at: body.readerIndex, length: body.readableBytes) ?? []
-            let box = SendableContext(context)
-            activeTask = childChannels.startTask {
-                do {
+        let bytes = body.getBytes(at: body.readerIndex, length: body.readableBytes) ?? []
+        let box = SendableContext(context)
+        activeTask = childChannels.startTask {
+            do {
                     let decoded = try? JSONDecoder().decode(OpenAIBatchCreateRequest.self, from: Data(bytes))
                     let requests: [BatchRequest]
                     var inputFileID: String?
@@ -294,15 +293,13 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                                                                  completionWindow: completionWindow,
                                                                  metadata: metadata)
                     self.writeCodable(box.value, status: .ok, snapshot)
-                } catch let error as ServerRequestError {
-                    self.writeError(box.value, status: error == .unknownModel ? .notFound : .badRequest, error.envelope)
-                } catch {
-                    self.writeError(box.value, status: .badRequest,
-                                    OpenAIErrorEnvelope(message: "malformed JSON request", code: "invalid_json"))
-                }
+            } catch let error as ServerRequestError {
+                self.writeError(box.value, status: error == .unknownModel ? .notFound : .badRequest, error.envelope)
+            } catch {
+                self.writeError(box.value, status: .badRequest,
+                                OpenAIErrorEnvelope(message: "malformed JSON request", code: "invalid_json"))
             }
-        } catch let error as ServerRequestError { writeError(context, status: error == .unknownModel ? .notFound : .badRequest, error.envelope) }
-        catch { writeError(context, status: .badRequest, OpenAIErrorEnvelope(message: "malformed JSON request", code: "invalid_json")) }
+        }
     }
 
     private func decodeBatchInput(_ data: Data) throws -> [BatchRequest] {

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -12,6 +12,7 @@ public actor TurboFieldfareHTTPServer {
     private let modelID: String
     private let backend: any ServerInferenceBackend
     private let coordinator: ServerCoordinator
+    private let batches: BatchRegistry
     private let heartbeatInterval: TimeAmount
     private let childChannels = ChildChannelRegistry()
     private var channel: Channel?
@@ -21,11 +22,13 @@ public actor TurboFieldfareHTTPServer {
                 queueLimit: Int,
                 backend: any ServerInferenceBackend,
                 heartbeatInterval: TimeAmount = .seconds(5),
+                batchOutputDirectory: URL? = nil,
                 group: MultiThreadedEventLoopGroup = .init(numberOfThreads: 1)) {
         self.group = group
         self.modelID = modelID
         self.backend = backend
         self.coordinator = ServerCoordinator(queueLimit: queueLimit)
+        self.batches = batchOutputDirectory.map(BatchRegistry.init(outputDirectory:)) ?? BatchRegistry()
         self.heartbeatInterval = heartbeatInterval
     }
 
@@ -33,6 +36,7 @@ public actor TurboFieldfareHTTPServer {
         let modelID = self.modelID
         let backend = self.backend
         let coordinator = self.coordinator
+        let batches = self.batches
         let heartbeatInterval = self.heartbeatInterval
         let childChannels = self.childChannels
         let bootstrap = ServerBootstrap(group: group)
@@ -48,6 +52,7 @@ public actor TurboFieldfareHTTPServer {
                         modelID: modelID,
                         backend: backend,
                         coordinator: coordinator,
+                        batches: batches,
                         heartbeatInterval: heartbeatInterval,
                         childChannels: childChannels))
                 }
@@ -116,6 +121,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
     private let modelID: String
     private let backend: any ServerInferenceBackend
     private let coordinator: ServerCoordinator
+    private let batches: BatchRegistry
     private let heartbeatInterval: TimeAmount
     private let childChannels: ChildChannelRegistry
     private var head: HTTPRequestHead?
@@ -126,11 +132,13 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
     init(modelID: String,
          backend: any ServerInferenceBackend,
          coordinator: ServerCoordinator,
+         batches: BatchRegistry,
          heartbeatInterval: TimeAmount,
          childChannels: ChildChannelRegistry) {
         self.modelID = modelID
         self.backend = backend
         self.coordinator = coordinator
+        self.batches = batches
         self.heartbeatInterval = heartbeatInterval
         self.childChannels = childChannels
     }
@@ -192,7 +200,22 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                 return
             }
             handleCompletion(body: body, context: context)
-        case (_, "/health"), (_, "/v1/models"), (_, "/v1/chat/completions"):
+        case (.POST, "/v1/batches"):
+            guard head.headers.first(name: "content-type")?
+                .lowercased().hasPrefix("application/json") == true else {
+                writeError(context, status: .unsupportedMediaType,
+                           OpenAIErrorEnvelope(message: "content-type must be application/json",
+                                               code: "unsupported_media_type"))
+                return
+            }
+            handleBatchJob(body: body, context: context)
+        case (.GET, "/v1/batches"):
+            handleBatchList(uri: head.uri, context: context)
+        case (.GET, let uri) where uri.hasPrefix("/v1/batches/"):
+            handleBatchStatus(uri: uri, context: context)
+        case (.POST, let uri) where uri.hasPrefix("/v1/batches/") && uri.hasSuffix("/cancel"):
+            handleBatchCancel(uri: uri, context: context)
+        case (_, "/health"), (_, "/v1/models"), (_, "/v1/chat/completions"), (_, "/v1/batches"):
             writeError(context, status: .methodNotAllowed,
                        OpenAIErrorEnvelope(message: "method not allowed",
                                            code: "method_not_allowed"))
@@ -201,6 +224,69 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                        OpenAIErrorEnvelope(message: "route not found",
                                            code: "not_found"))
         }
+    }
+
+    private func handleBatchJob(body: ByteBuffer, context: ChannelHandlerContext) {
+        do {
+            let bytes = body.getBytes(at: body.readerIndex, length: body.readableBytes) ?? []
+            let envelope = try JSONDecoder().decode(OpenAIChatBatchRequest.self, from: Data(bytes))
+            guard !envelope.requests.isEmpty else { throw ServerRequestError.invalid(message: "requests must not be empty", param: "requests", code: "invalid_value") }
+            let requests = try envelope.requests.enumerated().map { index, item -> BatchRequest in
+                guard item.stream != true else { throw ServerRequestError.invalid(message: "streaming is not supported for batch requests", param: "requests.stream", code: "unsupported_value") }
+                return BatchRequest(customID: item.customID ?? "request-\(index)",
+                                    request: try OpenAIRequestValidator.validate(item, modelID: modelID))
+            }
+            let box = SendableContext(context)
+            activeTask = childChannels.startTask {
+                do {
+                    let snapshot = try await self.batches.create(requests: requests,
+                                                                 backend: self.backend,
+                                                                 coordinator: self.coordinator,
+                                                                 modelID: self.modelID)
+                    self.writeCodable(box.value, status: .ok, snapshot)
+                } catch {
+                    self.handleAsyncError(
+                        error,
+                        context: box.value,
+                        id: "batch-" + UUID().uuidString.lowercased(),
+                        phase: "creating batch",
+                        stream: false)
+                }
+            }
+        } catch let error as ServerRequestError { writeError(context, status: error == .unknownModel ? .notFound : .badRequest, error.envelope) }
+        catch { writeError(context, status: .badRequest, OpenAIErrorEnvelope(message: "malformed JSON request", code: "invalid_json")) }
+    }
+
+    private func handleBatchList(uri: String, context: ChannelHandlerContext) {
+        guard let components = URLComponents(string: "http://localhost\(uri)") else {
+            writeError(context, status: .badRequest, OpenAIErrorEnvelope(message: "invalid query", code: "invalid_value"))
+            return
+        }
+        let limit = components.queryItems?.first(where: { $0.name == "limit" })?.value
+            .flatMap { Int($0) } ?? 20
+        guard (1...100).contains(limit) else {
+            writeError(context, status: .badRequest, OpenAIErrorEnvelope(message: "limit must be between 1 and 100", param: "limit", code: "invalid_value"))
+            return
+        }
+        let box = SendableContext(context)
+        activeTask = childChannels.startTask {
+            self.writeCodable(box.value, status: .ok,
+                              await self.batches.list(
+                                limit: limit,
+                                after: components.queryItems?.first(where: { $0.name == "after" })?.value))
+        }
+    }
+
+    private func handleBatchStatus(uri: String, context: ChannelHandlerContext) {
+        let id = String(uri.dropFirst("/v1/batches/".count))
+        let box = SendableContext(context)
+        activeTask = childChannels.startTask { guard let batch = await self.batches.get(id) else { self.writeError(box.value, status: .notFound, OpenAIErrorEnvelope(message: "batch not found", code: "not_found")); return }; self.writeCodable(box.value, status: .ok, batch) }
+    }
+
+    private func handleBatchCancel(uri: String, context: ChannelHandlerContext) {
+        let id = String(uri.dropFirst("/v1/batches/".count).dropLast("/cancel".count))
+        let box = SendableContext(context)
+        activeTask = childChannels.startTask { guard let batch = await self.batches.cancel(id) else { self.writeError(box.value, status: .notFound, OpenAIErrorEnvelope(message: "batch not found", code: "not_found")); return }; self.writeCodable(box.value, status: .ok, batch) }
     }
 
     private func handleCompletion(body: ByteBuffer,
@@ -312,6 +398,13 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                                  id: String,
                                  created: Int,
                                  completion: ServerCompletion) {
+        writeJSON(context, status: .ok,
+                  object: completionObject(id: id, created: created, completion: completion))
+    }
+
+    private func completionObject(id: String,
+                                  created: Int,
+                                  completion: ServerCompletion) -> [String: Any] {
         let encodedContent: Any =
             completion.content.isEmpty && !completion.toolCalls.isEmpty
                 ? NSNull()
@@ -335,7 +428,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
             ]],
             "usage": usageObject(completion.usage),
         ]
-        writeJSON(context, status: .ok, object: object)
+        return object
     }
 
     private func beginStream(

--- a/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
@@ -173,11 +173,23 @@ public struct OpenAIChatRequest: Codable, Equatable, Sendable {
     }
 }
 
-/// A small, local-only batch envelope. Requests are deliberately executed in
-/// order by the single model-owning server; this endpoint is not the hosted
-/// OpenAI Batch API.
-public struct OpenAIChatBatchRequest: Codable, Equatable, Sendable {
-    public let requests: [OpenAIChatRequest]
+public struct OpenAIBatchCreateRequest: Codable, Equatable, Sendable {
+    public let inputFileID: String
+    public let endpoint: String
+    public let completionWindow: String
+    public let metadata: [String: String]?
+
+    enum CodingKeys: String, CodingKey {
+        case inputFileID = "input_file_id"
+        case endpoint
+        case completionWindow = "completion_window"
+        case metadata
+    }
+}
+
+/// Deprecated local convenience envelope retained during migration to Files + Batch JSONL.
+struct LegacyOpenAIChatBatchRequest: Codable, Sendable {
+    let requests: [OpenAIChatRequest]
 }
 
 public struct OpenAIUsage: Codable, Equatable, Sendable {

--- a/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
@@ -174,16 +174,23 @@ public struct OpenAIChatRequest: Codable, Equatable, Sendable {
 }
 
 public struct OpenAIBatchCreateRequest: Codable, Equatable, Sendable {
+    public struct OutputExpiresAfter: Codable, Equatable, Sendable {
+        public let anchor: String
+        public let seconds: Int
+    }
+
     public let inputFileID: String
     public let endpoint: String
     public let completionWindow: String
     public let metadata: [String: String]?
+    public let outputExpiresAfter: OutputExpiresAfter?
 
     enum CodingKeys: String, CodingKey {
         case inputFileID = "input_file_id"
         case endpoint
         case completionWindow = "completion_window"
         case metadata
+        case outputExpiresAfter = "output_expires_after"
     }
 }
 

--- a/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
@@ -136,6 +136,7 @@ public struct OpenAIStreamOptions: Codable, Equatable, Sendable {
 }
 
 public struct OpenAIChatRequest: Codable, Equatable, Sendable {
+    public let customID: String?
     public let model: String
     public let messages: [OpenAIChatMessage]
     public let stream: Bool?
@@ -158,6 +159,7 @@ public struct OpenAIChatRequest: Codable, Equatable, Sendable {
 
     enum CodingKeys: String, CodingKey {
         case model, messages, stream, temperature, stop, seed, tools, n, logprobs
+        case customID = "custom_id"
         case streamOptions = "stream_options"
         case topP = "top_p"
         case maxTokens = "max_tokens"
@@ -169,6 +171,13 @@ public struct OpenAIChatRequest: Codable, Equatable, Sendable {
         case presencePenalty = "presence_penalty"
         case frequencyPenalty = "frequency_penalty"
     }
+}
+
+/// A small, local-only batch envelope. Requests are deliberately executed in
+/// order by the single model-owning server; this endpoint is not the hosted
+/// OpenAI Batch API.
+public struct OpenAIChatBatchRequest: Codable, Equatable, Sendable {
+    public let requests: [OpenAIChatRequest]
 }
 
 public struct OpenAIUsage: Codable, Equatable, Sendable {

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -539,6 +539,11 @@ struct HTTPServerTests {
         let outputData = try await URLSession.shared.data(
             from: URL(string: "http://127.0.0.1:\(port)/v1/files/\(try #require(outputFileID))/content")!).0
         let output = String(decoding: outputData, as: UTF8.self)
+        let filesData = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/files")!).0
+        let filesObject = try #require(JSONSerialization.jsonObject(with: filesData) as? [String: Any])
+        let files = try #require(filesObject["data"] as? [[String: Any]])
+        #expect(files.contains { $0["id"] as? String == outputFileID })
         let lines = output.split(separator: "\n")
         #expect(lines.count == 2)
         #expect(lines[0].contains("\"custom_id\":\"first\""))

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -543,11 +543,12 @@ struct HTTPServerTests {
             from: URL(string: "http://127.0.0.1:\(port)/v1/files/\(try #require(outputFileID))/content")!).0
         let output = String(decoding: outputData, as: UTF8.self)
         let filesData = try await URLSession.shared.data(
-            from: URL(string: "http://127.0.0.1:\(port)/v1/files")!).0
+            from: URL(string: "http://127.0.0.1:\(port)/v1/files?purpose=batch_output&limit=1&order=desc")!).0
         let filesObject = try #require(JSONSerialization.jsonObject(with: filesData) as? [String: Any])
         let files = try #require(filesObject["data"] as? [[String: Any]])
         let listedOutput = try #require(files.first { $0["id"] as? String == outputFileID })
         #expect(listedOutput["purpose"] as? String == "batch_output")
+        #expect(filesObject["has_more"] as? Bool == false)
         let lines = output.split(separator: "\n")
         #expect(lines.count == 2)
         #expect(lines[0].contains("\"custom_id\":\"first\""))

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -697,7 +697,6 @@ struct HTTPServerTests {
         let batchData = try await URLSession.shared.data(for: request).0
         let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
         let id = try #require(batch["id"] as? String)
-        let outputFileID = try #require(batch["output_file_id"] as? String)
         var status = ""
         for _ in 0..<100 {
             let data = try await URLSession.shared.data(
@@ -707,7 +706,11 @@ struct HTTPServerTests {
             try await Task.sleep(for: .milliseconds(5))
         }
         #expect(status == "completed")
-        let output = try String(contentsOf: outputDirectory.appendingPathComponent(outputFileID)
+        let final = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(id)")!).0
+        let finalObject = try #require(JSONSerialization.jsonObject(with: final) as? [String: Any])
+        let errorFileID = try #require(finalObject["error_file_id"] as? String)
+        let output = try String(contentsOf: outputDirectory.appendingPathComponent(errorFileID)
             .appendingPathExtension("jsonl"), encoding: .utf8)
         #expect(output.contains("\"custom_id\":\"will-fail\""))
         #expect(output.contains("\"response\":null"))

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -267,6 +267,17 @@ private actor FailingServerBackend: ServerInferenceBackend {
     }
 }
 
+private actor BatchFailingServerBackend: ServerInferenceBackend {
+    func generate(
+        _ request: ValidatedChatRequest,
+        onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
+    ) async throws -> ServerCompletion {
+        throw ServerRequestError.invalid(message: "synthetic failure",
+                                         param: nil,
+                                         code: "synthetic_failure")
+    }
+}
+
 @Suite("OpenAI HTTP server", .serialized)
 struct HTTPServerTests {
     @Test func healthModelsAndNonStreamingCompletion() async throws {
@@ -471,6 +482,205 @@ struct HTTPServerTests {
         #expect(text.contains(#""code":"internal_error""#))
         #expect(!text.contains("sensitiveFailure"))
         #expect(text.hasSuffix("data: [DONE]\n\n"))
+
+        try await server.shutdown()
+    }
+
+    @Test func batchRunsNonStreamingRequestsInOrder() async throws {
+        let outputDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TurboFieldfareBatchTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: ScriptedServerBackend(),
+            batchOutputDirectory: outputDirectory)
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"""
+        {"requests":[
+          {"custom_id":"first","model":"test-model","messages":[{"role":"user","content":"first"}]},
+          {"model":"test-model","messages":[{"role":"user","content":"second"}]}
+        ]}
+        """#.utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        #expect(object["object"] as? String == "batch")
+        let batchID = try #require(object["id"] as? String)
+        let outputFileID = try #require(object["output_file_id"] as? String)
+        #expect((object["request_counts"] as? [String: Any])?["total"] as? Int == 2)
+
+        let listData = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/batches?limit=1")!).0
+        let list = try #require(JSONSerialization.jsonObject(with: listData) as? [String: Any])
+        #expect(list["object"] as? String == "list")
+        #expect((list["data"] as? [[String: Any]])?.first?["id"] as? String == batchID)
+        #expect(list["has_more"] as? Bool == false)
+
+        var status = ""
+        for _ in 0..<100 {
+            let statusData = try await URLSession.shared.data(
+                from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(batchID)")!).0
+            let snapshot = try #require(JSONSerialization.jsonObject(with: statusData) as? [String: Any])
+            status = try #require(snapshot["status"] as? String)
+            if status == "completed" { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(status == "completed")
+        let output = try String(contentsOf: outputDirectory
+            .appendingPathComponent(outputFileID)
+            .appendingPathExtension("jsonl"), encoding: .utf8)
+        let lines = output.split(separator: "\n")
+        #expect(lines.count == 2)
+        #expect(lines[0].contains("\"custom_id\":\"first\""))
+        #expect(lines.allSatisfy { $0.contains("\"status_code\":200") })
+
+        try await server.shutdown()
+    }
+
+    @Test func batchRejectsStreamingItems() async throws {
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: ScriptedServerBackend())
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"""
+        {"requests":[{"model":"test-model","messages":[{"role":"user","content":"hi"}],"stream":true}]}
+        """#.utf8)
+
+        let (data, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 400)
+        #expect(String(decoding: data, as: UTF8.self).contains("unsupported_value"))
+
+        try await server.shutdown()
+    }
+
+    @Test func batchListPaginatesWithAfterCursor() async throws {
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 3,
+            backend: ScriptedServerBackend(delayNanoseconds: 20_000_000))
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var createdIDs: [String] = []
+        for index in 0..<3 {
+            var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "content-type")
+            request.httpBody = Data(#"""
+            {"requests":[{"model":"test-model","messages":[{"role":"user","content":"\#(index)"}]}]}
+            """#.utf8)
+            let data = try await URLSession.shared.data(for: request).0
+            let batch = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+            createdIDs.append(try #require(batch["id"] as? String))
+        }
+
+        let firstPage = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/batches?limit=2")!).0
+        let firstObject = try #require(JSONSerialization.jsonObject(with: firstPage) as? [String: Any])
+        let firstData = try #require(firstObject["data"] as? [[String: Any]])
+        #expect(firstData.count == 2)
+        #expect(firstObject["has_more"] as? Bool == true)
+        let after = try #require(firstObject["last_id"] as? String)
+
+        let secondPage = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/batches?limit=2&after=\(after)")!).0
+        let secondObject = try #require(JSONSerialization.jsonObject(with: secondPage) as? [String: Any])
+        #expect((secondObject["data"] as? [[String: Any]])?.count == 1)
+        #expect(secondObject["has_more"] as? Bool == false)
+        #expect(Set(createdIDs).count == 3)
+
+        try await server.shutdown()
+    }
+
+    @Test func batchCancellationReachesCancelledWithoutFailure() async throws {
+        let backend = CancellableServerBackend()
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1, backend: backend)
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"""
+        {"requests":[
+          {"model":"test-model","messages":[{"role":"user","content":"one"}]},
+          {"model":"test-model","messages":[{"role":"user","content":"two"}]}
+        ]}
+        """#.utf8)
+        let batchData = try await URLSession.shared.data(for: request).0
+        let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
+        let id = try #require(batch["id"] as? String)
+        for _ in 0..<100 where await backend.startedCount == 0 {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(await backend.startedCount == 1)
+
+        var cancellation = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(id)/cancel")!)
+        cancellation.httpMethod = "POST"
+        let cancellationData = try await URLSession.shared.data(for: cancellation).0
+        #expect(String(decoding: cancellationData, as: UTF8.self).contains("cancelling"))
+
+        var status = ""
+        var counts: [String: Any] = [:]
+        for _ in 0..<100 {
+            let statusData = try await URLSession.shared.data(
+                from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(id)")!).0
+            let snapshot = try #require(JSONSerialization.jsonObject(with: statusData) as? [String: Any])
+            status = try #require(snapshot["status"] as? String)
+            counts = try #require(snapshot["request_counts"] as? [String: Any])
+            if status == "cancelled" { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(status == "cancelled")
+        #expect(counts["failed"] as? Int == 0)
+        #expect(await backend.cancellationCount == 1)
+
+        try await server.shutdown()
+    }
+
+    @Test func batchFailureWritesJSONLErrorRecord() async throws {
+        let outputDirectory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("TurboFieldfareBatchFailureTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: outputDirectory) }
+        let server = TurboFieldfareHTTPServer(modelID: "test-model",
+                                              queueLimit: 1,
+                                              backend: BatchFailingServerBackend(),
+                                              batchOutputDirectory: outputDirectory)
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"""
+        {"requests":[{"custom_id":"will-fail","model":"test-model","messages":[{"role":"user","content":"fail"}]}]}
+        """#.utf8)
+        let batchData = try await URLSession.shared.data(for: request).0
+        let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
+        let id = try #require(batch["id"] as? String)
+        let outputFileID = try #require(batch["output_file_id"] as? String)
+        var status = ""
+        for _ in 0..<100 {
+            let data = try await URLSession.shared.data(
+                from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(id)")!).0
+            status = try #require((JSONSerialization.jsonObject(with: data) as? [String: Any])?["status"] as? String)
+            if status == "failed" { break }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(status == "failed")
+        let output = try String(contentsOf: outputDirectory.appendingPathComponent(outputFileID)
+            .appendingPathExtension("jsonl"), encoding: .utf8)
+        #expect(output.contains("\"custom_id\":\"will-fail\""))
+        #expect(output.contains("\"response\":null"))
+        #expect(output.contains("\"synthetic_failure\""))
 
         try await server.shutdown()
     }

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -538,6 +538,7 @@ struct HTTPServerTests {
             try await Task.sleep(for: .milliseconds(5))
         }
         #expect(status == "completed")
+        #expect(outputFileID?.hasPrefix("file-") == true)
         #expect((usage?["output_tokens_details"] as? [String: Any])?["reasoning_tokens"] as? Int == 0)
         let outputData = try await URLSession.shared.data(
             from: URL(string: "http://127.0.0.1:\(port)/v1/files/\(try #require(outputFileID))/content")!).0

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -636,6 +636,7 @@ struct HTTPServerTests {
         #expect((batchResponse as? HTTPURLResponse)?.statusCode == 200)
         let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
         #expect(batch["object"] as? String == "batch")
+        #expect(batch["model"] as? String == "test-model")
         #expect(batch["input_file_id"] as? String == fileID)
         #expect(batch["completion_window"] as? String == "24h")
         #expect(batch["errors"] is NSNull || batch["errors"] == nil)

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -566,6 +566,21 @@ struct HTTPServerTests {
         try await server.shutdown()
     }
 
+    @Test func fileUploadRequiresMultipartContentType() async throws {
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend())
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/files")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data("{}".utf8)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 415)
+        #expect(String(decoding: data, as: UTF8.self).contains("unsupported_media_type"))
+        try await server.shutdown()
+    }
+
     @Test func batchRejectsStreamingItems() async throws {
         let server = TurboFieldfareHTTPServer(
             modelID: "test-model",

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -524,6 +524,7 @@ struct HTTPServerTests {
 
         var status = ""
         var outputFileID: String?
+        var usage: [String: Any]?
         for _ in 0..<100 {
             let statusData = try await URLSession.shared.data(
                 from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(batchID)")!).0
@@ -531,11 +532,13 @@ struct HTTPServerTests {
             status = try #require(snapshot["status"] as? String)
             if status == "completed" {
                 outputFileID = try #require(snapshot["output_file_id"] as? String)
+                usage = try #require(snapshot["usage"] as? [String: Any])
                 break
             }
             try await Task.sleep(for: .milliseconds(5))
         }
         #expect(status == "completed")
+        #expect((usage?["output_tokens_details"] as? [String: Any])?["reasoning_tokens"] as? Int == 0)
         let outputData = try await URLSession.shared.data(
             from: URL(string: "http://127.0.0.1:\(port)/v1/files/\(try #require(outputFileID))/content")!).0
         let output = String(decoding: outputData, as: UTF8.self)

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -819,6 +819,19 @@ struct HTTPServerTests {
         #expect(!FileManager.default.fileExists(atPath: output.path))
     }
 
+    @Test func batchFileSizeLimitReturnsOpenAIError() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareBatchFileSizeTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = BatchFileStore(directory: directory, maximumInputBytes: 3)
+        do {
+            _ = try await store.create(filename: "input.jsonl", purpose: "batch", contents: Data("1234".utf8))
+            Issue.record("expected batch file size rejection")
+        } catch let error as ServerRequestError {
+            #expect(error.envelope.error.code == "invalid_value")
+            #expect(error.envelope.error.param == "file")
+        }
+    }
+
     @Test func batchRejectsMoreThanFiftyThousandJSONLRequests() async throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareBatchLimitTest-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -536,9 +536,9 @@ struct HTTPServerTests {
             try await Task.sleep(for: .milliseconds(5))
         }
         #expect(status == "completed")
-        let output = try String(contentsOf: outputDirectory
-            .appendingPathComponent(try #require(outputFileID))
-            .appendingPathExtension("jsonl"), encoding: .utf8)
+        let outputData = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/files/\(try #require(outputFileID))/content")!).0
+        let output = String(decoding: outputData, as: UTF8.self)
         let lines = output.split(separator: "\n")
         #expect(lines.count == 2)
         #expect(lines[0].contains("\"custom_id\":\"first\""))
@@ -604,6 +604,9 @@ struct HTTPServerTests {
         #expect((fileResponse as? HTTPURLResponse)?.statusCode == 200)
         let file = try #require(JSONSerialization.jsonObject(with: fileData) as? [String: Any])
         let fileID = try #require(file["id"] as? String)
+        let files = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/files")!).0
+        #expect((try #require(JSONSerialization.jsonObject(with: files) as? [String: Any]))["data"] as? [[String: Any]] != nil)
         var create = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
         create.httpMethod = "POST"
         create.setValue("application/json", forHTTPHeaderField: "content-type")

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -592,6 +592,21 @@ struct HTTPServerTests {
         try await server.shutdown()
     }
 
+    @Test func malformedBatchJSONUsesInvalidJSONError() async throws {
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend())
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data("{".utf8)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 400)
+        #expect(String(decoding: data, as: UTF8.self).contains("invalid_json"))
+        try await server.shutdown()
+    }
+
     @Test func batchAcceptsOpenAIFileAndJSONLContract() async throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareBatchFileTest-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -754,6 +754,35 @@ struct HTTPServerTests {
         try await server.shutdown()
     }
 
+    @Test func batchFilesAreDiscardedOnServerRestart() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareRestartBatchTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let first = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                             backend: ScriptedServerBackend(), batchOutputDirectory: directory)
+        let firstChannel = try await first.start(port: 0)
+        let firstPort = try #require(firstChannel.localAddress?.port)
+        let boundary = "restart-batch-boundary"
+        let jsonl = #"{"custom_id":"row-1","method":"POST","url":"/v1/chat/completions","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}]}}"# + "\n"
+        let multipart = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"input.jsonl\"\r\nContent-Type: application/jsonl\r\n\r\n\(jsonl)\r\n--\(boundary)--\r\n"
+        var upload = URLRequest(url: URL(string: "http://127.0.0.1:\(firstPort)/v1/files")!)
+        upload.httpMethod = "POST"
+        upload.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "content-type")
+        upload.httpBody = Data(multipart.utf8)
+        let (fileData, _) = try await URLSession.shared.data(for: upload)
+        let file = try #require(JSONSerialization.jsonObject(with: fileData) as? [String: Any])
+        let fileID = try #require(file["id"] as? String)
+        try await first.shutdown()
+
+        let second = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend(), batchOutputDirectory: directory)
+        let secondChannel = try await second.start(port: 0)
+        let secondPort = try #require(secondChannel.localAddress?.port)
+        let (_, response) = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(secondPort)/v1/files/\(fileID)")!)
+        #expect((response as? HTTPURLResponse)?.statusCode == 404)
+        try await second.shutdown()
+    }
+
     @Test func batchListPaginatesWithAfterCursor() async throws {
         let server = TurboFieldfareHTTPServer(
             modelID: "test-model",

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -588,7 +588,10 @@ struct HTTPServerTests {
         create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h"}"#.utf8)
         let (batchData, batchResponse) = try await URLSession.shared.data(for: create)
         #expect((batchResponse as? HTTPURLResponse)?.statusCode == 200)
-        #expect((try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any]))["object"] as? String == "batch")
+        let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
+        #expect(batch["object"] as? String == "batch")
+        #expect(batch["input_file_id"] as? String == fileID)
+        #expect(batch["completion_window"] as? String == "24h")
         try await server.shutdown()
     }
 
@@ -700,10 +703,10 @@ struct HTTPServerTests {
             let data = try await URLSession.shared.data(
                 from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(id)")!).0
             status = try #require((JSONSerialization.jsonObject(with: data) as? [String: Any])?["status"] as? String)
-            if status == "failed" { break }
+            if status == "completed" { break }
             try await Task.sleep(for: .milliseconds(5))
         }
-        #expect(status == "failed")
+        #expect(status == "completed")
         let output = try String(contentsOf: outputDirectory.appendingPathComponent(outputFileID)
             .appendingPathExtension("jsonl"), encoding: .utf8)
         #expect(output.contains("\"custom_id\":\"will-fail\""))

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -543,7 +543,8 @@ struct HTTPServerTests {
             from: URL(string: "http://127.0.0.1:\(port)/v1/files")!).0
         let filesObject = try #require(JSONSerialization.jsonObject(with: filesData) as? [String: Any])
         let files = try #require(filesObject["data"] as? [[String: Any]])
-        #expect(files.contains { $0["id"] as? String == outputFileID })
+        let listedOutput = try #require(files.first { $0["id"] as? String == outputFileID })
+        #expect(listedOutput["purpose"] as? String == "batch_output")
         let lines = output.split(separator: "\n")
         #expect(lines.count == 2)
         #expect(lines[0].contains("\"custom_id\":\"first\""))

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -628,7 +628,8 @@ struct HTTPServerTests {
         let channel = try await server.start(port: 0)
         let port = try #require(channel.localAddress?.port)
         let boundary = "batch-test-boundary"
-        let jsonl = #"{"custom_id":"row-1","method":"POST","url":"/v1/chat/completions","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}]}}"# + "\n"
+        let jsonl = #"{"custom_id":"row-1","method":"POST","url":"/v1/chat/completions","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}]}}"# + "\n" +
+            #"{"custom_id":"row-2","method":"POST","url":"/v1/chat/completions","body":{"model":"test-model","messages":[{"role":"user","content":"again"}]}}"# + "\n"
         let multipart = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"input.jsonl\"\r\nContent-Type: application/jsonl\r\n\r\n\(jsonl)\r\n--\(boundary)--\r\n"
         var upload = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/files")!)
         upload.httpMethod = "POST"
@@ -652,6 +653,7 @@ struct HTTPServerTests {
         #expect(batch["model"] as? String == "test-model")
         #expect(batch["input_file_id"] as? String == fileID)
         #expect(batch["completion_window"] as? String == "24h")
+        #expect((batch["request_counts"] as? [String: Any])?["total"] as? Int == 2)
         #expect(batch["errors"] is NSNull || batch["errors"] == nil)
         #expect((batch["expires_at"] as? Int ?? 0) > (batch["created_at"] as? Int ?? 0))
         let batchID = try #require(batch["id"] as? String)
@@ -671,6 +673,9 @@ struct HTTPServerTests {
             from: URL(string: "http://127.0.0.1:\(port)/v1/files/\(output)")!).0
         let outputObject = try #require(JSONSerialization.jsonObject(with: outputFile) as? [String: Any])
         #expect((outputObject["expires_at"] as? Int ?? 0) > (outputObject["created_at"] as? Int ?? 0))
+        let outputLines = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/files/\(output)/content")!).0
+        #expect(String(decoding: outputLines, as: UTF8.self).split(separator: "\n").count == 2)
         try await server.shutdown()
     }
 

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -554,6 +554,14 @@ struct HTTPServerTests {
         #expect(lines[0].contains("\"custom_id\":\"first\""))
         #expect(lines.allSatisfy { $0.contains("\"status_code\":200") })
 
+        var reuseOutput = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        reuseOutput.httpMethod = "POST"
+        reuseOutput.setValue("application/json", forHTTPHeaderField: "content-type")
+        reuseOutput.httpBody = Data(#"{"input_file_id":"\#(try #require(outputFileID))","endpoint":"/v1/chat/completions","completion_window":"24h"}"#.utf8)
+        let (reuseData, reuseResponse) = try await URLSession.shared.data(for: reuseOutput)
+        #expect((reuseResponse as? HTTPURLResponse)?.statusCode == 400)
+        #expect(String(decoding: reuseData, as: UTF8.self).contains("input_file_id"))
+
         try await server.shutdown()
     }
 

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -804,6 +804,21 @@ struct HTTPServerTests {
         try await second.shutdown()
     }
 
+    @Test func expiredBatchOutputFileIsRemoved() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareExpiredOutputTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let store = BatchFileStore(directory: directory)
+        let id = "file-expired-output"
+        let output = directory.appendingPathComponent(id).appendingPathExtension("jsonl")
+        try Data("{}\n".utf8).write(to: output)
+        _ = try await store.registerBatchOutput(id, expiresAt: Int(Date().timeIntervalSince1970) - 1)
+        #expect((await store.get(id))?.id == nil)
+        for _ in 0..<20 where FileManager.default.fileExists(atPath: output.path) {
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        #expect(!FileManager.default.fileExists(atPath: output.path))
+    }
+
     @Test func batchListPaginatesWithAfterCursor() async throws {
         let server = TurboFieldfareHTTPServer(
             modelID: "test-model",

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -768,6 +768,7 @@ struct HTTPServerTests {
         #expect(output.contains("\"custom_id\":\"will-fail\""))
         #expect(output.contains("\"response\":null"))
         #expect(output.contains("\"synthetic_failure\""))
+        #expect(output.contains("\"type\":\"invalid_request_error\""))
 
         try await server.shutdown()
     }

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -660,7 +660,7 @@ struct HTTPServerTests {
         var create = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
         create.httpMethod = "POST"
         create.setValue("application/json", forHTTPHeaderField: "content-type")
-        create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h","output_expires_after":{"anchor":"created_at","seconds":3600}}"#.utf8)
+        create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h","metadata":{"source":"http-test"},"output_expires_after":{"anchor":"created_at","seconds":3600}}"#.utf8)
         let (batchData, batchResponse) = try await URLSession.shared.data(for: create)
         #expect((batchResponse as? HTTPURLResponse)?.statusCode == 200)
         let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
@@ -668,6 +668,7 @@ struct HTTPServerTests {
         #expect(batch["model"] as? String == "test-model")
         #expect(batch["input_file_id"] as? String == fileID)
         #expect(batch["completion_window"] as? String == "24h")
+        #expect((batch["metadata"] as? [String: Any])?["source"] as? String == "http-test")
         #expect((batch["request_counts"] as? [String: Any])?["total"] as? Int == 2)
         #expect(batch["errors"] is NSNull || batch["errors"] == nil)
         #expect((batch["expires_at"] as? Int ?? 0) > (batch["created_at"] as? Int ?? 0))

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -715,6 +715,35 @@ struct HTTPServerTests {
         try await server.shutdown()
     }
 
+    @Test func blankBatchJSONLLineReturnsItsLineNumber() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareBlankBatchTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend(), batchOutputDirectory: directory)
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        let boundary = "blank-batch-boundary"
+        let requestLine = #"{"custom_id":"row-1","method":"POST","url":"/v1/chat/completions","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}]}}"#
+        let multipart = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"input.jsonl\"\r\nContent-Type: application/jsonl\r\n\r\n\(requestLine)\n\n\(requestLine)\n\r\n--\(boundary)--\r\n"
+        var upload = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/files")!)
+        upload.httpMethod = "POST"
+        upload.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "content-type")
+        upload.httpBody = Data(multipart.utf8)
+        let (fileData, _) = try await URLSession.shared.data(for: upload)
+        let file = try #require(JSONSerialization.jsonObject(with: fileData) as? [String: Any])
+        let fileID = try #require(file["id"] as? String)
+        var create = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        create.httpMethod = "POST"
+        create.setValue("application/json", forHTTPHeaderField: "content-type")
+        create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h"}"#.utf8)
+        let (batchData, _) = try await URLSession.shared.data(for: create)
+        let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
+        let errors = try #require(batch["errors"] as? [String: Any])
+        let data = try #require(errors["data"] as? [[String: Any]])
+        #expect(data[0]["line"] as? Int == 2)
+        try await server.shutdown()
+    }
+
     @Test func batchListPaginatesWithAfterCursor() async throws {
         let server = TurboFieldfareHTTPServer(
             modelID: "test-model",

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -568,6 +568,24 @@ struct HTTPServerTests {
         try await server.shutdown()
     }
 
+    @Test func batchRejectsOversizedMetadataBeforeReadingInputFile() async throws {
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend())
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        let metadata = Dictionary(uniqueKeysWithValues: (0..<17).map { ("key\($0)", "value") })
+        let body: [String: Any] = ["input_file_id": "file-missing", "endpoint": "/v1/chat/completions",
+                                   "completion_window": "24h", "metadata": metadata]
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 400)
+        #expect(String(decoding: data, as: UTF8.self).contains("metadata"))
+        try await server.shutdown()
+    }
+
     @Test func batchAcceptsOpenAIFileAndJSONLContract() async throws {
         let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareBatchFileTest-\(UUID().uuidString)", isDirectory: true)
         defer { try? FileManager.default.removeItem(at: directory) }

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -512,7 +512,7 @@ struct HTTPServerTests {
         let object = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
         #expect(object["object"] as? String == "batch")
         let batchID = try #require(object["id"] as? String)
-        let outputFileID = try #require(object["output_file_id"] as? String)
+        #expect(object["output_file_id"] is NSNull || object["output_file_id"] == nil)
         #expect((object["request_counts"] as? [String: Any])?["total"] as? Int == 2)
 
         let listData = try await URLSession.shared.data(
@@ -523,17 +523,21 @@ struct HTTPServerTests {
         #expect(list["has_more"] as? Bool == false)
 
         var status = ""
+        var outputFileID: String?
         for _ in 0..<100 {
             let statusData = try await URLSession.shared.data(
                 from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(batchID)")!).0
             let snapshot = try #require(JSONSerialization.jsonObject(with: statusData) as? [String: Any])
             status = try #require(snapshot["status"] as? String)
-            if status == "completed" { break }
+            if status == "completed" {
+                outputFileID = try #require(snapshot["output_file_id"] as? String)
+                break
+            }
             try await Task.sleep(for: .milliseconds(5))
         }
         #expect(status == "completed")
         let output = try String(contentsOf: outputDirectory
-            .appendingPathComponent(outputFileID)
+            .appendingPathComponent(try #require(outputFileID))
             .appendingPathExtension("jsonl"), encoding: .utf8)
         let lines = output.split(separator: "\n")
         #expect(lines.count == 2)

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -819,6 +819,38 @@ struct HTTPServerTests {
         #expect(!FileManager.default.fileExists(atPath: output.path))
     }
 
+    @Test func batchRejectsMoreThanFiftyThousandJSONLRequests() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareBatchLimitTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend(), batchOutputDirectory: directory)
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        let boundary = "batch-limit-boundary"
+        let line = #"{"custom_id":"row","method":"POST","url":"/v1/chat/completions","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}]}}"# + "\n"
+        let jsonl = String(repeating: line, count: 50_001)
+        let multipart = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"input.jsonl\"\r\nContent-Type: application/jsonl\r\n\r\n\(jsonl)\r\n--\(boundary)--\r\n"
+        var upload = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/files")!)
+        upload.httpMethod = "POST"
+        upload.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "content-type")
+        upload.httpBody = Data(multipart.utf8)
+        let (fileData, uploadResponse) = try await URLSession.shared.data(for: upload)
+        #expect((uploadResponse as? HTTPURLResponse)?.statusCode == 200)
+        let file = try #require(JSONSerialization.jsonObject(with: fileData) as? [String: Any])
+        let fileID = try #require(file["id"] as? String)
+        var create = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        create.httpMethod = "POST"
+        create.setValue("application/json", forHTTPHeaderField: "content-type")
+        create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h"}"#.utf8)
+        let (batchData, response) = try await URLSession.shared.data(for: create)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
+        let errors = try #require(batch["errors"] as? [String: Any])
+        let errorsData = try #require(errors["data"] as? [[String: Any]])
+        #expect(errorsData[0]["message"] as? String == "batch input may contain at most 50,000 requests")
+        try await server.shutdown()
+    }
+
     @Test func batchListPaginatesWithAfterCursor() async throws {
         let server = TurboFieldfareHTTPServer(
             modelID: "test-model",

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -709,7 +709,9 @@ struct HTTPServerTests {
         #expect(batch["status"] as? String == "failed")
         let errors = try #require(batch["errors"] as? [String: Any])
         #expect(errors["object"] as? String == "list")
-        #expect(!(try #require(errors["data"] as? [[String: Any]])).isEmpty)
+        let data = try #require(errors["data"] as? [[String: Any]])
+        #expect(!(data).isEmpty)
+        #expect(data[0]["line"] as? Int == 1)
         try await server.shutdown()
     }
 

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -645,6 +645,23 @@ struct HTTPServerTests {
         #expect(batch["completion_window"] as? String == "24h")
         #expect(batch["errors"] is NSNull || batch["errors"] == nil)
         #expect((batch["expires_at"] as? Int ?? 0) > (batch["created_at"] as? Int ?? 0))
+        let batchID = try #require(batch["id"] as? String)
+        var outputFileID: String?
+        for _ in 0..<20 {
+            let statusData = try await URLSession.shared.data(
+                from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(batchID)")!).0
+            let status = try #require(JSONSerialization.jsonObject(with: statusData) as? [String: Any])
+            if status["status"] as? String == "completed" {
+                outputFileID = try #require(status["output_file_id"] as? String)
+                break
+            }
+            try await Task.sleep(for: .milliseconds(5))
+        }
+        let output = try #require(outputFileID)
+        let outputFile = try await URLSession.shared.data(
+            from: URL(string: "http://127.0.0.1:\(port)/v1/files/\(output)")!).0
+        let outputObject = try #require(JSONSerialization.jsonObject(with: outputFile) as? [String: Any])
+        #expect((outputObject["expires_at"] as? Int ?? 0) > (outputObject["created_at"] as? Int ?? 0))
         try await server.shutdown()
     }
 

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -622,6 +622,8 @@ struct HTTPServerTests {
         #expect(batch["object"] as? String == "batch")
         #expect(batch["input_file_id"] as? String == fileID)
         #expect(batch["completion_window"] as? String == "24h")
+        #expect(batch["errors"] is NSNull || batch["errors"] == nil)
+        #expect((batch["expires_at"] as? Int ?? 0) > (batch["created_at"] as? Int ?? 0))
         try await server.shutdown()
     }
 

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -683,6 +683,36 @@ struct HTTPServerTests {
         try await server.shutdown()
     }
 
+    @Test func invalidBatchJSONLReturnsFailedBatchWithErrors() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareInvalidBatchTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend(), batchOutputDirectory: directory)
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        let boundary = "invalid-batch-boundary"
+        let multipart = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"input.jsonl\"\r\nContent-Type: application/jsonl\r\n\r\nnot-json\n\r\n--\(boundary)--\r\n"
+        var upload = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/files")!)
+        upload.httpMethod = "POST"
+        upload.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "content-type")
+        upload.httpBody = Data(multipart.utf8)
+        let (fileData, _) = try await URLSession.shared.data(for: upload)
+        let file = try #require(JSONSerialization.jsonObject(with: fileData) as? [String: Any])
+        let fileID = try #require(file["id"] as? String)
+        var create = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        create.httpMethod = "POST"
+        create.setValue("application/json", forHTTPHeaderField: "content-type")
+        create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h"}"#.utf8)
+        let (batchData, response) = try await URLSession.shared.data(for: create)
+        #expect((response as? HTTPURLResponse)?.statusCode == 200)
+        let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
+        #expect(batch["status"] as? String == "failed")
+        let errors = try #require(batch["errors"] as? [String: Any])
+        #expect(errors["object"] as? String == "list")
+        #expect(!(try #require(errors["data"] as? [[String: Any]])).isEmpty)
+        try await server.shutdown()
+    }
+
     @Test func batchListPaginatesWithAfterCursor() async throws {
         let server = TurboFieldfareHTTPServer(
             modelID: "test-model",

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -635,7 +635,7 @@ struct HTTPServerTests {
         var create = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
         create.httpMethod = "POST"
         create.setValue("application/json", forHTTPHeaderField: "content-type")
-        create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h"}"#.utf8)
+        create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h","output_expires_after":{"anchor":"created_at","seconds":3600}}"#.utf8)
         let (batchData, batchResponse) = try await URLSession.shared.data(for: create)
         #expect((batchResponse as? HTTPURLResponse)?.statusCode == 200)
         let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
@@ -645,6 +645,24 @@ struct HTTPServerTests {
         #expect(batch["completion_window"] as? String == "24h")
         #expect(batch["errors"] is NSNull || batch["errors"] == nil)
         #expect((batch["expires_at"] as? Int ?? 0) > (batch["created_at"] as? Int ?? 0))
+        try await server.shutdown()
+    }
+
+    @Test func batchRejectsInvalidOutputExpiryPolicy() async throws {
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend())
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        let body: [String: Any] = ["input_file_id": "file-missing", "endpoint": "/v1/chat/completions",
+                                   "completion_window": "24h",
+                                   "output_expires_after": ["anchor": "created_at", "seconds": 1]]
+        var request = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = try JSONSerialization.data(withJSONObject: body)
+        let (data, response) = try await URLSession.shared.data(for: request)
+        #expect((response as? HTTPURLResponse)?.statusCode == 400)
+        #expect(String(decoding: data, as: UTF8.self).contains("output_expires_after"))
         try await server.shutdown()
     }
 

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -743,6 +743,7 @@ struct HTTPServerTests {
             from: URL(string: "http://127.0.0.1:\(port)/v1/batches/\(id)")!).0
         let finalObject = try #require(JSONSerialization.jsonObject(with: final) as? [String: Any])
         let errorFileID = try #require(finalObject["error_file_id"] as? String)
+        #expect(finalObject["output_file_id"] is NSNull || finalObject["output_file_id"] == nil)
         let output = try String(contentsOf: outputDirectory.appendingPathComponent(errorFileID)
             .appendingPathExtension("jsonl"), encoding: .utf8)
         #expect(output.contains("\"custom_id\":\"will-fail\""))

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -724,7 +724,8 @@ struct HTTPServerTests {
         let port = try #require(channel.localAddress?.port)
         let boundary = "blank-batch-boundary"
         let requestLine = #"{"custom_id":"row-1","method":"POST","url":"/v1/chat/completions","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}]}}"#
-        let multipart = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"input.jsonl\"\r\nContent-Type: application/jsonl\r\n\r\n\(requestLine)\n\n\(requestLine)\n\r\n--\(boundary)--\r\n"
+        let secondRequestLine = requestLine.replacingOccurrences(of: "row-1", with: "row-2")
+        let multipart = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"input.jsonl\"\r\nContent-Type: application/jsonl\r\n\r\nnot-json\n\n\(requestLine)\n\(secondRequestLine)\n\r\n--\(boundary)--\r\n"
         var upload = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/files")!)
         upload.httpMethod = "POST"
         upload.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "content-type")
@@ -740,7 +741,7 @@ struct HTTPServerTests {
         let batch = try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any])
         let errors = try #require(batch["errors"] as? [String: Any])
         let data = try #require(errors["data"] as? [[String: Any]])
-        #expect(data[0]["line"] as? Int == 2)
+        #expect(data.map { $0["line"] as? Int } == [1, 2])
         try await server.shutdown()
     }
 

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -564,6 +564,34 @@ struct HTTPServerTests {
         try await server.shutdown()
     }
 
+    @Test func batchAcceptsOpenAIFileAndJSONLContract() async throws {
+        let directory = FileManager.default.temporaryDirectory.appendingPathComponent("TurboFieldfareBatchFileTest-\(UUID().uuidString)", isDirectory: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let server = TurboFieldfareHTTPServer(modelID: "test-model", queueLimit: 1,
+                                              backend: ScriptedServerBackend(), batchOutputDirectory: directory)
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+        let boundary = "batch-test-boundary"
+        let jsonl = #"{"custom_id":"row-1","method":"POST","url":"/v1/chat/completions","body":{"model":"test-model","messages":[{"role":"user","content":"hi"}]}}"# + "\n"
+        let multipart = "--\(boundary)\r\nContent-Disposition: form-data; name=\"purpose\"\r\n\r\nbatch\r\n--\(boundary)\r\nContent-Disposition: form-data; name=\"file\"; filename=\"input.jsonl\"\r\nContent-Type: application/jsonl\r\n\r\n\(jsonl)\r\n--\(boundary)--\r\n"
+        var upload = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/files")!)
+        upload.httpMethod = "POST"
+        upload.setValue("multipart/form-data; boundary=\(boundary)", forHTTPHeaderField: "content-type")
+        upload.httpBody = Data(multipart.utf8)
+        let (fileData, fileResponse) = try await URLSession.shared.data(for: upload)
+        #expect((fileResponse as? HTTPURLResponse)?.statusCode == 200)
+        let file = try #require(JSONSerialization.jsonObject(with: fileData) as? [String: Any])
+        let fileID = try #require(file["id"] as? String)
+        var create = URLRequest(url: URL(string: "http://127.0.0.1:\(port)/v1/batches")!)
+        create.httpMethod = "POST"
+        create.setValue("application/json", forHTTPHeaderField: "content-type")
+        create.httpBody = Data(#"{"input_file_id":"\#(fileID)","endpoint":"/v1/chat/completions","completion_window":"24h"}"#.utf8)
+        let (batchData, batchResponse) = try await URLSession.shared.data(for: create)
+        #expect((batchResponse as? HTTPURLResponse)?.statusCode == 200)
+        #expect((try #require(JSONSerialization.jsonObject(with: batchData) as? [String: Any]))["object"] as? String == "batch")
+        try await server.shutdown()
+    }
+
     @Test func batchListPaginatesWithAfterCursor() async throws {
         let server = TurboFieldfareHTTPServer(
             modelID: "test-model",

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -168,6 +168,9 @@ Endpoints:
 - `GET /health`
 - `GET /v1/models`
 - `POST /v1/chat/completions`
+- `POST /v1/files`, `GET /v1/files/{id}`, `GET /v1/files/{id}/content`
+- `POST /v1/batches`, `GET /v1/batches`, `GET /v1/batches/{id}`,
+  `POST /v1/batches/{id}/cancel`
 
 Chat Completions supports JSON and Server-Sent Events responses. Set
 `"stream": true` for streaming. Set
@@ -178,9 +181,11 @@ Supported options include `temperature`, `top_p`, `top_k`,
 `repetition_penalty`, `seed`, `stop`, `max_tokens`,
 `max_completion_tokens`, and function-tool fields.
 
-The server supports one model and one choice. It does not support the Responses
-API, legacy Completions, embeddings, multimodal input, structured output,
-batching, log probabilities, or remote model switching.
+The server supports one model and one choice. Batch accepts OpenAI-format JSONL
+input files for non-streaming `/v1/chat/completions` with `completion_window`
+set to `"24h"`. It does not support the Responses API, legacy Completions,
+embeddings, multimodal input, structured output, log probabilities, or remote
+model switching.
 
 Context length can be 4K, 8K, 16K, 32K, or 64K. The default is 16K. Larger FP16
 KV contexts use more memory. On an 8 GB Mac, run one model process at a time and

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -184,7 +184,9 @@ Supported options include `temperature`, `top_p`, `top_k`,
 
 The server supports one model and one choice. Batch accepts OpenAI-format JSONL
 input files for non-streaming `/v1/chat/completions` with `completion_window`
-set to `"24h"`. It does not support the Responses API, legacy Completions,
+set to `"24h"`. `output_expires_after` is supported with `anchor` set to
+`"created_at"` and `seconds` from 3,600 through 2,592,000; it removes generated
+output and error JSONL files after that interval. It does not support the Responses API, legacy Completions,
 embeddings, multimodal input, structured output, log probabilities, or remote
 model switching. Batch and Files data is discarded on server restart.
 

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -186,7 +186,8 @@ The server supports one model and one choice. Batch accepts OpenAI-format JSONL
 input files for non-streaming `/v1/chat/completions` with `completion_window`
 set to `"24h"`. `output_expires_after` is supported with `anchor` set to
 `"created_at"` and `seconds` from 3,600 through 2,592,000; it removes generated
-output and error JSONL files after that interval. It does not support the Responses API, legacy Completions,
+output and error JSONL files after that interval, and their File objects expose
+`expires_at`. It does not support the Responses API, legacy Completions,
 embeddings, multimodal input, structured output, log probabilities, or remote
 model switching. Batch and Files data is discarded on server restart.
 

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -185,7 +185,7 @@ The server supports one model and one choice. Batch accepts OpenAI-format JSONL
 input files for non-streaming `/v1/chat/completions` with `completion_window`
 set to `"24h"`. It does not support the Responses API, legacy Completions,
 embeddings, multimodal input, structured output, log probabilities, or remote
-model switching.
+model switching. Batch and Files data is discarded on server restart.
 
 Context length can be 4K, 8K, 16K, 32K, or 64K. The default is 16K. Larger FP16
 KV contexts use more memory. On an 8 GB Mac, run one model process at a time and

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -168,7 +168,8 @@ Endpoints:
 - `GET /health`
 - `GET /v1/models`
 - `POST /v1/chat/completions`
-- `POST /v1/files`, `GET /v1/files/{id}`, `GET /v1/files/{id}/content`
+- `POST /v1/files`, `GET /v1/files`, `GET /v1/files/{id}`,
+  `GET /v1/files/{id}/content`, `DELETE /v1/files/{id}`
 - `POST /v1/batches`, `GET /v1/batches`, `GET /v1/batches/{id}`,
   `POST /v1/batches/{id}/cancel`
 

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -191,6 +191,10 @@ output and error JSONL files after that interval, and their File objects expose
 embeddings, multimodal input, structured output, log probabilities, or remote
 model switching. Batch and Files data is discarded on server restart.
 
+An invalid JSONL input file produces a Batch with status `failed` and a
+structured `errors` list. Invalid `POST /v1/batches` parameters still return an
+HTTP error envelope.
+
 Context length can be 4K, 8K, 16K, 32K, or 64K. The default is 16K. Larger FP16
 KV contexts use more memory. On an 8 GB Mac, run one model process at a time and
 watch memory pressure.


### PR DESCRIPTION
## Motivation

TurboFieldfare already exposes a local OpenAI-compatible chat-completions endpoint, but callers had to submit and wait for each request individually. That makes offline automation awkward: a local worker, evaluation job, document-processing pipeline, or developer tool cannot hand the local LLM a collection of independent tasks and track it as one unit of work.

This PR adds a small asynchronous batch lifecycle for local use. Clients can submit a set of non-streaming chat-completion requests, poll one batch rather than every request, cancel remaining work, and associate result records with their own `custom_id` values. The design keeps the model local and does not allow concurrent access to the single model session.

## Architecture

### HTTP surface

- `POST /v1/batches` creates a batch from `{ "requests": [...] }`.
- `GET /v1/batches/{id}` retrieves lifecycle status and request counts.
- `POST /v1/batches/{id}/cancel` cancels work that has not completed.
- `GET /v1/batches?limit=&after=` lists in-memory batch metadata with cursor pagination.

Each item is validated as a regular chat-completions request. Streaming items are rejected, because batch output is recorded as completed JSONL records. An optional `custom_id` is propagated to that item’s result; a deterministic `request-{index}` fallback is used when it is absent.

### Execution and lifecycle

`BatchRegistry` is an actor that owns batch metadata, status transitions, counters, result-file metadata, and the task performing the batch. A batch moves from `validating` to `in_progress`, then to `completed`, `failed`, or `cancelled`; cancellation first reports `cancelling`.

Requests inside a batch are executed in order. Crucially, every item enters the existing `ServerCoordinator`, so batch jobs and ordinary `/v1/chat/completions` calls share the same single-model queue rather than racing the model session.

### Local JSONL output

At creation the registry allocates an `output_file_id` and a local JSONL file. Each completed item appends exactly one OpenAI-style record:

- success: `custom_id`, `response.status_code`, and a chat completion in `response.body`;
- failure: `custom_id`, `response: null`, and structured `error.code` / `error.message`.

The file is intentionally local-only in this iteration. `output_file_id` is included in batch metadata, but `/v1/files`, input JSONL upload, persistence across server restarts, and `/v1/files/{id}/content` are deliberately out of scope.

## User impact

Local tools can now queue many independent LLM tasks—such as labeling, extraction, evaluation, or batch summarization—without managing a separate request loop or accidentally issuing concurrent inference calls. They can poll aggregate progress, stop outstanding work, and correlate generated JSONL records with source jobs through `custom_id`.

## Validation

- `Scripts/test.sh --filter HTTPServerTests` — 14 tests passed.
- `swift build -c release --product TurboFieldfareServer`.
- HTTP tests cover create/retrieve/list pagination/cancel, successful JSONL records, failure JSONL records, and streaming-item rejection.
