### PR TITLE
fix: Allow hyphens in OpenAI tool names and improve error info

### DIFF
--- a/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
@@ -334,8 +334,8 @@ public enum OpenAIRequestValidator {
             throw invalid("only function tools are supported", "tools", "unsupported_tool")
         }
         let name = tool.function.name
-        guard name.range(of: #"^[A-Za-z0-9_]{1,64}$"#, options: .regularExpression) != nil else {
-            throw invalid("tool name must match [A-Za-z0-9_]{1,64}",
+        guard name.range(of: #"^[A-Za-z0-9_-]{1,64}$"#, options: .regularExpression) != nil else {
+            throw invalid("tool name '\(name)' must match [A-Za-z0-9_-]{1,64}",
                           "tools", "invalid_tool_name")
         }
         guard tool.function.parameters.objectValue != nil else {

--- a/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
@@ -44,6 +44,33 @@ struct OpenAIValidationTests {
         }
     }
 
+    @Test func acceptsHyphenatedToolNames() throws {
+        let data = Data(#"""
+        {"model":"m","messages":[{"role":"user","content":"x"}],
+          "tools":[{"type":"function","function":{"name":"resolve-library-id",
+            "parameters":{"type":"object"}}}]
+        }
+        """#.utf8)
+        let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+        let validated = try OpenAIRequestValidator.validate(request, modelID: "m")
+        #expect(validated.tools.first?.function.name == "resolve-library-id")
+    }
+
+    @Test func rejectsToolNamesWithInvalidCharacters() throws {
+        for invalid in ["bad name", "bad.name", "bad@name"] {
+            let data = Data(#"""
+            {"model":"m","messages":[{"role":"user","content":"x"}],
+              "tools":[{"type":"function","function":{"name":"\#(invalid)",
+                "parameters":{"type":"object"}}}]
+            }
+            """#.utf8)
+            let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+            #expect(throws: ServerRequestError.self) {
+                try OpenAIRequestValidator.validate(request, modelID: "m")
+            }
+        }
+    }
+
     @Test func acceptsLeadingSystemAndDeveloperGuidance() throws {
         let data = Data(#"""
         {"model":"m","messages":[


### PR DESCRIPTION
## Summary

Updates the validation regex for OpenAI tool names to permit hyphens (`-`) in addition to letters, numbers, and underscores, matching common API usage. Also includes the invalid tool name directly in the validation error message for better debugging.

Initially, running this with pi coding agent, I got the following error:

```json
{
  "param": "tools",
  "type": "invalid_request_error",
  "code": "invalid_tool_name",
  "message": "tool name must match [A-Za-z0-9_]{1,64}"
}
```

which doesn't tell me much about which tool was causing the issue, so I updated the error message to indicate the tool name:

```json
{
  "param": "tools",
  "type": "invalid_request_error",
  "code": "invalid_tool_name",
  "message": "tool name 'resolve-library-id' must match [A-Za-z0-9_]{1,64}"
}
```

_(I guess its complaining about Context 7...)_

So next, I relaxed the regex to allow for hyphens

## Validation

Ran server with:

```
.build/release/TurboFieldfareServer   --model scratch/gemma4.gturbo  --max-context 65536
```

Pi transcript:

```
 pi v0.83.0                                                                                                                       
 escape interrupt · ctrl+c/ctrl+d clear/exit · / commands · ! bash · ctrl+o more                                                  
 Press ctrl+o to show full startup help and loaded resources.                                                                     
                                                                                                                                  
 Pi can explain its own features and look up its docs. Ask it how to use or extend Pi.                                            


[Context]                                                                                                                         
  AGENTS.md                                                                                                                       

[Skills]                                                                                                                          
  caveman, chakra-ui-builder, context7-docs, diagnose, find-skills, grill-me, grill-with-docs, improve-codebase-architecture,     
playwright-browser, tdd                                                                                                           

[Prompts]                                                                                                                         
  /c7-docs                                                                                                                        

[Extensions]                                                                                                                      
  @ollama/pi-web-search, @upstash/context7-pi:context7.ts, pi-gh-cli:gh-tools.ts, rg.ts, sg.ts                                    


 Model: gemma-4-26b-a4b-it                                                                                                        

> hello                                                                                                                            
                                                                                                                                  
 Error: 400: {"param":"tools","type":"invalid_request_error","code":"invalid_tool_name","message":"tool name must match           
 [A-Za-z0-9_]{1,64}"}                                                                                                                                                                                                      
                                                                                                                                  
> hello                                                                                                                            
                                                                                                                                  
 Error: 400: {"param":"tools","message":"tool name 'resolve-library-id' must match                                                
 [A-Za-z0-9_]{1,64}","type":"invalid_request_error","code":"invalid_tool_name"}                                                   

> hello again                                                                                                                      
                                                                                                                                  
 hello! How can I help you today?      
 ```

## Memory and performance

Not applicable

## Remaining limitations

Not applicable
