### PR TITLE
fix: propagate Metal command-buffer errors instead of swallowing them

### DIFF
--- a/Sources/TurboFieldfare/Runtime/Inference/RealForwardRunner.swift
+++ b/Sources/TurboFieldfare/Runtime/Inference/RealForwardRunner.swift
@@ -940,7 +940,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                         hiddenStrideElements: UInt32(D))
 
                     cb.commit()
-                    waitForCompletion(cb)
+                    try waitForCompletion(cb)
                     if let error = cb.error {
                         throw error
                     }
@@ -1008,7 +1008,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                            d: UInt32(D),
                                            eps: eps)
                     sharedCB.commit()
-                    waitForCompletion(sharedCB)
+                    try waitForCompletion(sharedCB)
                     if let error = sharedCB.error {
                         throw error
                     }
@@ -1028,9 +1028,15 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                     func drainOldestPendingTile() throws {
                         guard !pendingTiles.isEmpty else { return }
                         let pending = pendingTiles.removeFirst()
+                        var drainWaitError: (any Error)?
                         withExtendedLifetime((pending.fetch, pending.argumentBuffer)) {
-                            waitForCompletion(pending.commandBuffer)
+                            do {
+                                try waitForCompletion(pending.commandBuffer)
+                            } catch {
+                                drainWaitError = error
+                            }
                         }
+                        if let drainWaitError { throw drainWaitError }
                         if let error = pending.commandBuffer.error {
                             throw error
                         }
@@ -1182,9 +1188,15 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                             eps: eps,
                                             layerScalar: Quantization.bf16ToFloat(scalarBits))
                     tailCB.commit()
+                    var tailWaitError: (any Error)?
                     withExtendedLifetime(metadata) {
-                        waitForCompletion(tailCB)
+                        do {
+                            try waitForCompletion(tailCB)
+                        } catch {
+                            tailWaitError = error
+                        }
                     }
+                    if let tailWaitError { throw tailWaitError }
                     if let error = tailCB.error {
                         throw error
                     }
@@ -1239,7 +1251,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
                                                  rmsEps: eps)
             }
             finalCB.commit()
-            waitForCompletion(finalCB)
+            try waitForCompletion(finalCB)
             if let error = finalCB.error {
                 throw error
             }
@@ -1279,29 +1291,29 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         var pendingRoutedCommand: PendingRoutedCommand?
 
         func finishPendingRoutedCommand(_ pending: PendingRoutedCommand,
-                                        waitIfNeeded: Bool) {
+                                        waitIfNeeded: Bool) throws {
             if waitIfNeeded {
-                func wait(_ cb: MTLCommandBuffer) {
-                    waitForCompletion(cb)
+                func wait(_ cb: MTLCommandBuffer) throws {
+                    try waitForCompletion(cb)
                 }
                 if let sharedCB = pending.sharedCB {
-                    wait(sharedCB)
+                    try wait(sharedCB)
                 }
                 if let phase1HitCB = pending.phase1HitCB {
-                    wait(phase1HitCB)
+                    try wait(phase1HitCB)
                 }
-                wait(pending.cb)
+                try wait(pending.cb)
             } else if let err = pending.cb.error {
-                print("CB error: \(err)")
+                throw err
             }
             if let sharedCB = pending.sharedCB {
                 if let err = sharedCB.error {
-                    print("CB error: \(err)")
+                    throw err
                 }
             }
             if let phase1HitCB = pending.phase1HitCB,
                let err = phase1HitCB.error {
-                print("CB error: \(err)")
+                throw err
             }
             totalCb2Nanos &+= pending.encodeAndCommitNanos
         }
@@ -1314,7 +1326,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         // Embed lookup + sqrt(H) fused.
         let emb = model.embedding
         do {
-            runSync { cb in
+            try runSync { cb in
                 embedInt4.encode(commandBuffer: cb,
                                  table:  emb.buffer, tableOffset:  Int(emb.offset),
                                  scales: emb.buffer, scalesOffset: Int(emb.scaleOffset),
@@ -1491,10 +1503,10 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             gRouter(cb)
             cb.commit()
             let tWait = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
-            waitForCompletion(cb)
+            try waitForCompletion(cb)
             let waitNanos = clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tWait
             if let pending = pendingRoutedCommand {
-                finishPendingRoutedCommand(pending, waitIfNeeded: false)
+                try finishPendingRoutedCommand(pending, waitIfNeeded: false)
                 pendingRoutedCommand = nil
             }
             totalCb1Nanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tCb1Start - waitNanos
@@ -1714,7 +1726,7 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             continue
         }
         if let pending = pendingRoutedCommand {
-            finishPendingRoutedCommand(pending, waitIfNeeded: true)
+            try finishPendingRoutedCommand(pending, waitIfNeeded: true)
             pendingRoutedCommand = nil
         }
 
@@ -1750,11 +1762,11 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
             let useFusedHeadForThisToken = useFusedGreedyHead && outputMode == .greedyIfAvailable
             let tHead = clock_gettime_nsec_np(CLOCK_UPTIME_RAW)
             if useFusedHeadForThisToken {
-                runSync(gFusionHead)
+                try runSync(gFusionHead)
                 totalHeadFusedNanos &+= clock_gettime_nsec_np(CLOCK_UPTIME_RAW) - tHead
                 lastGreedyToken = greedyTokenBuf.contents().load(as: UInt32.self)
             } else {
-                runSync { cb in
+                try runSync { cb in
                     gFinalNorm(cb)
                     gLmHead(cb)
                 }
@@ -1765,20 +1777,20 @@ public final class RealForwardRunner: ChunkedPrefillRunner, ContextWindowReporti
         kv?.advance()
     }
 
-    private func runSync(_ body: (MTLCommandBuffer) -> Void) {
+    private func runSync(_ body: (MTLCommandBuffer) -> Void) throws {
         let cb = ctx.queue.makeCommandBuffer()!
         body(cb)
         cb.commit()
         cb.waitUntilCompleted()
         if let err = cb.error {
-            print("CB error: \(err)")
+            throw err
         }
     }
 
-    private nonisolated func waitForCompletion(_ cb: MTLCommandBuffer) {
+    private nonisolated func waitForCompletion(_ cb: MTLCommandBuffer) throws {
         cb.waitUntilCompleted()
         if let err = cb.error {
-            print("CB error: \(err)")
+            throw err
         }
     }
 


### PR DESCRIPTION
## What

`RealForwardRunner.runSync` and `waitForCompletion` printed `CB error: ...` and returned instead of surfacing the failure. After a Metal command-buffer error, the decode path kept running on corrupt state — the server ground at ~100% CPU for minutes or emitted garbage, and streaming clients got a bare EOF with no SSE error frame and no `data: [DONE]`.

This makes both functions `throws`, and threads the error up through `produceToken`/`prefillChunked` (both already `async throws`), `finishPendingRoutedCommand`, and the two `withExtendedLifetime` wait closures. Combined with the existing `handleAsyncError` → `finishStreamWithError` path (#43), a GPU failure now ends the stream cleanly instead of hanging.

## Why it matters

Reproduced on Apple Silicon (M2 Pro, 16 GB) streaming Gemma 4 via the OpenAI-compatible endpoint: a large cold prefill produced a 263-byte response containing only a role-delta chunk and keepalives, then the server wedged. The direct cause was a swallowed `MTLCommandBufferError`; with the error propagated, the request now completes normally or terminates with a proper SSE error + `[DONE]`.

## Verification

- `swift build -c release --product TurboFieldfareServer` passes.
- The identical change was also verified end-to-end in a local run: a ~70 KB cold prompt that previously truncated now streams to completion with `[DONE]`; a multi-turn continuation still hits the single-prefix prompt cache (8,206/8,258 tokens cached, ~4 s vs ~4:36 cold).

## Notes

No behavior change on the success path — only error handling changes. All call sites were already in throwing contexts, so no new API surface is exposed to callers outside the runner.