### PR TITLE
Render Markdown in the Mac chat transcript

### DIFF
--- a/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
@@ -273,6 +273,10 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
         var timer: Timer?
         var prefillAnimationTimer: Timer?
         let documentController = InstructionTranscriptDocumentController()
+        /// Whether new output should keep the viewport pinned to the bottom.
+        /// Driven by the reader's own scrolling: true while they are at the
+        /// bottom, false the moment they scroll up to read earlier output.
+        private var autoFollow = true
 
         func attach(scrollView: NSScrollView, textView: NSTextView) {
             self.scrollView = scrollView
@@ -284,6 +288,17 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
             timer.tolerance = 0.02
             RunLoop.main.add(timer, forMode: .common)
             self.timer = timer
+
+            let clipView = scrollView.contentView
+            clipView.postsBoundsChangedNotifications = true
+            NotificationCenter.default.addObserver(
+                self, selector: #selector(clipViewDidScroll),
+                name: NSView.boundsDidChangeNotification, object: clipView)
+        }
+
+        @objc private func clipViewDidScroll() {
+            guard let scrollView else { return }
+            autoFollow = isAtBottom(scrollView)
         }
 
         func synchronize(
@@ -343,6 +358,7 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
         }
 
         func invalidate() {
+            NotificationCenter.default.removeObserver(self)
             timer?.invalidate()
             timer = nil
             stopPrefillAnimationTimer()
@@ -377,8 +393,7 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
             isTerminal: Bool,
             showsPrefillPlaceholder: Bool
         ) {
-            guard let scrollView, let textView, let storage = textView.textStorage else { return }
-            let wasAtBottom = isAtBottom(scrollView)
+            guard let textView, let storage = textView.textStorage else { return }
             let selection = textView.selectedRanges.map(\.rangeValue)
 
             storage.beginEditing()
@@ -392,6 +407,9 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
             updatePrefillAnimationTimer()
 
             guard update.mutation != .none else { return }
+            // A fresh prompt/response starts pinned to the bottom again.
+            if update.mutation == .rebuilt { autoFollow = true }
+
             let restored = InstructionTranscriptDocumentController.clampedRanges(
                 selection,
                 toLength: storage.length)
@@ -400,15 +418,15 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
             } else {
                 textView.selectedRanges = restored.map(NSValue.init(range:))
             }
-            if InstructionTranscriptDocumentController.shouldScrollToBottom(
-                wasAtBottom: wasAtBottom,
-                mutation: update.mutation
-            ) {
-                if let textContainer = textView.textContainer {
-                    textView.layoutManager?.ensureLayout(for: textContainer)
-                }
-                textView.scrollToEndOfDocument(nil)
+
+            // Only the changed suffix was mutated, so content the reader scrolled
+            // up to is undisturbed. Follow the bottom solely when they are already
+            // there; never move their viewport otherwise.
+            guard autoFollow else { return }
+            if let textContainer = textView.textContainer {
+                textView.layoutManager?.ensureLayout(for: textContainer)
             }
+            textView.scrollToEndOfDocument(nil)
         }
 
         private func isAtBottom(_ scrollView: NSScrollView) -> Bool {
@@ -426,7 +444,18 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
         scrollView.autohidesScrollers = true
         scrollView.drawsBackground = false
 
-        let textView = NSTextView()
+        // Build an explicit TextKit 1 stack so the transcript can draw rounded
+        // containers behind fenced code blocks via TranscriptLayoutManager.
+        let textStorage = NSTextStorage()
+        let layoutManager = TranscriptLayoutManager()
+        textStorage.addLayoutManager(layoutManager)
+        let textContainer = NSTextContainer(
+            size: NSSize(width: 0, height: CGFloat.greatestFiniteMagnitude))
+        textContainer.widthTracksTextView = true
+        textContainer.lineFragmentPadding = 0
+        layoutManager.addTextContainer(textContainer)
+
+        let textView = NSTextView(frame: .zero, textContainer: textContainer)
         textView.isEditable = false
         textView.isSelectable = true
         textView.isRichText = true
@@ -435,8 +464,14 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
         textView.isVerticallyResizable = true
         textView.isHorizontallyResizable = false
         textView.autoresizingMask = [.width]
-        textView.textContainer?.widthTracksTextView = true
-        textView.textContainer?.lineFragmentPadding = 0
+        // A manually built text view (unlike `NSTextView()`) does not get a
+        // growable maxSize, so without this it stays capped at the viewport
+        // height and the transcript cannot scroll once content overflows.
+        textView.minSize = NSSize(width: 0, height: 0)
+        textView.maxSize = NSSize(
+            width: CGFloat.greatestFiniteMagnitude,
+            height: CGFloat.greatestFiniteMagnitude)
+        textContainer.heightTracksTextView = false
         textView.isAutomaticLinkDetectionEnabled = false
         textView.isAutomaticDataDetectionEnabled = false
         textView.setAccessibilityLabel("Conversation transcript")

--- a/Sources/TurboFieldfareApp/MacPresentation/CodeHighlighting.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/CodeHighlighting.swift
@@ -1,0 +1,136 @@
+import AppKit
+import Foundation
+
+/// Colors and attribute keys shared by the Markdown renderer and the transcript
+/// layout manager. Every color resolves per light/dark appearance so the
+/// transcript reads correctly in both.
+public enum TranscriptCodeStyle {
+    /// Marks the character range of a fenced code block so the layout manager can
+    /// draw a single rounded container behind it. The value is the language hint.
+    public nonisolated static let codeBlockAttribute = NSAttributedString.Key("TurboFieldfareCodeBlock")
+
+    nonisolated static func dynamic(light: NSColor, dark: NSColor) -> NSColor {
+        NSColor(name: nil) { appearance in
+            appearance.bestMatch(from: [.aqua, .darkAqua]) == .darkAqua ? dark : light
+        }
+    }
+
+    public nonisolated static let codeBackground = dynamic(
+        light: NSColor(srgbRed: 0.96, green: 0.96, blue: 0.97, alpha: 1),
+        dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.055))
+    public nonisolated static let codeBorder = dynamic(
+        light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.08),
+        dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.10))
+    public nonisolated static let inlineCodeBackground = dynamic(
+        light: NSColor(srgbRed: 0.5, green: 0.5, blue: 0.55, alpha: 0.14),
+        dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.11))
+    public nonisolated static let tableBorder = dynamic(
+        light: NSColor(srgbRed: 0, green: 0, blue: 0, alpha: 0.14),
+        dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.16))
+    public nonisolated static let tableHeaderBackground = dynamic(
+        light: NSColor(srgbRed: 0.5, green: 0.5, blue: 0.55, alpha: 0.10),
+        dark: NSColor(srgbRed: 1, green: 1, blue: 1, alpha: 0.07))
+
+    nonisolated static let codeText = dynamic(
+        light: NSColor(srgbRed: 0.13, green: 0.14, blue: 0.16, alpha: 1),
+        dark: NSColor(srgbRed: 0.90, green: 0.91, blue: 0.94, alpha: 1))
+    nonisolated static let keyword = dynamic(
+        light: NSColor(srgbRed: 0.68, green: 0.14, blue: 0.55, alpha: 1),
+        dark: NSColor(srgbRed: 1.00, green: 0.48, blue: 0.70, alpha: 1))
+    nonisolated static let string = dynamic(
+        light: NSColor(srgbRed: 0.77, green: 0.10, blue: 0.09, alpha: 1),
+        dark: NSColor(srgbRed: 0.99, green: 0.42, blue: 0.36, alpha: 1))
+    nonisolated static let comment = dynamic(
+        light: NSColor(srgbRed: 0.42, green: 0.47, blue: 0.53, alpha: 1),
+        dark: NSColor(srgbRed: 0.50, green: 0.55, blue: 0.60, alpha: 1))
+    nonisolated static let number = dynamic(
+        light: NSColor(srgbRed: 0.11, green: 0.00, blue: 0.81, alpha: 1),
+        dark: NSColor(srgbRed: 0.82, green: 0.75, blue: 0.41, alpha: 1))
+    nonisolated static let type = dynamic(
+        light: NSColor(srgbRed: 0.04, green: 0.31, blue: 0.48, alpha: 1),
+        dark: NSColor(srgbRed: 0.42, green: 0.87, blue: 1.00, alpha: 1))
+}
+
+/// Lightweight, language-aware syntax highlighter. It is intentionally
+/// approximate: LLM code answers span many languages, so it colors the features
+/// that read the same almost everywhere — comments, strings, numbers, a broad
+/// keyword union, and capitalized type names — rather than parsing any single
+/// grammar precisely.
+public struct CodeSyntaxHighlighter {
+    public init() {}
+
+    private static let keywords: Set<String> = [
+        "func", "function", "fn", "def", "lambda", "return", "yield",
+        "if", "else", "elif", "elseif", "then", "for", "while", "do", "loop",
+        "switch", "case", "default", "match", "when", "break", "continue", "goto",
+        "let", "var", "const", "val", "mut", "static", "final", "readonly",
+        "class", "struct", "enum", "interface", "protocol", "extension", "trait",
+        "impl", "namespace", "module", "package", "type", "typedef", "typealias",
+        "public", "private", "protected", "internal", "export", "import", "from",
+        "using", "include", "require", "use", "pub", "open", "override", "virtual",
+        "self", "this", "super", "new", "delete", "nil", "null", "none", "undefined",
+        "true", "false", "void", "async", "await", "throw", "throws", "try", "catch",
+        "finally", "defer", "guard", "where", "in", "is", "as", "and", "or", "not",
+        "with", "begin", "end", "unsafe", "extern", "inline", "operator", "sizeof",
+    ]
+
+    private static let cLike = "(?<comment>//[^\\n]*|/\\*[\\s\\S]*?\\*/)"
+    private static let hashLike = "(?<comment>#[^\\n]*)"
+    private static let dashLike = "(?<comment>--[^\\n]*)"
+
+    private func commentPattern(for language: String) -> String {
+        switch language.lowercased() {
+        case "python", "py", "ruby", "rb", "bash", "sh", "shell", "zsh", "yaml",
+             "yml", "toml", "r", "perl", "makefile", "make", "dockerfile", "conf",
+             "ini", "elixir", "ex", "julia", "jl", "coffee":
+            return Self.hashLike
+        case "sql", "lua", "haskell", "hs", "ada", "vhdl":
+            return Self.dashLike
+        default:
+            return Self.cLike
+        }
+    }
+
+    /// Apply syntax colors in place over `range` of `storage`. Named capture
+    /// groups keep the token categories stable even though the comment pattern
+    /// (and therefore its group count) varies by language.
+    public func highlight(
+        _ storage: NSMutableAttributedString,
+        range: NSRange,
+        language: String
+    ) {
+        let text = storage.string as NSString
+        let comment = commentPattern(for: language)
+        let string = "(?<str>\"\"\"[\\s\\S]*?\"\"\"|\"(?:\\\\.|[^\"\\\\\\n])*\"|'(?:\\\\.|[^'\\\\\\n])*')"
+        let number = "(?<num>\\b(?:0[xX][0-9A-Fa-f_]+|\\d[\\d_]*\\.?[\\d_]*(?:[eE][+-]?\\d+)?)\\b)"
+        let ident = "(?<ident>\\b[A-Za-z_][A-Za-z0-9_]*\\b)"
+        let pattern = "\(comment)|\(string)|\(number)|\(ident)"
+        guard let regex = try? NSRegularExpression(pattern: pattern) else { return }
+
+        func matched(_ match: NSTextCheckingResult, _ name: String) -> Bool {
+            match.range(withName: name).location != NSNotFound
+        }
+
+        regex.enumerateMatches(in: storage.string, range: range) { match, _, _ in
+            guard let match else { return }
+            let color: NSColor
+            if matched(match, "comment") {
+                color = TranscriptCodeStyle.comment
+            } else if matched(match, "str") {
+                color = TranscriptCodeStyle.string
+            } else if matched(match, "num") {
+                color = TranscriptCodeStyle.number
+            } else {
+                let word = text.substring(with: match.range)
+                if Self.keywords.contains(word) {
+                    color = TranscriptCodeStyle.keyword
+                } else if let first = word.first, first.isUppercase {
+                    color = TranscriptCodeStyle.type
+                } else {
+                    return
+                }
+            }
+            storage.addAttribute(.foregroundColor, value: color, range: match.range)
+        }
+    }
+}

--- a/Sources/TurboFieldfareApp/MacPresentation/InstructionTranscriptDocumentController.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/InstructionTranscriptDocumentController.swift
@@ -45,13 +45,6 @@ public final class InstructionTranscriptDocumentController {
         }
     }
 
-    public static func shouldScrollToBottom(
-        wasAtBottom: Bool,
-        mutation: Mutation
-    ) -> Bool {
-        wasAtBottom || mutation == .finalized
-    }
-
     public static func shouldRunPrefillAnimation(
         response: String,
         isTerminal: Bool,
@@ -88,12 +81,12 @@ public final class InstructionTranscriptDocumentController {
                 response: response,
                 showsPrefillPlaceholder: displaysPrefillPlaceholder)
             mutation = .rebuilt
-        } else if response.count > self.response.count {
-            let delta = String(response.dropFirst(self.response.count))
-            storage.append(NSAttributedString(
-                string: delta,
-                attributes: Self.responseAttributes()))
-            assistantRange.length += (delta as NSString).length
+        } else if responseChanged && !isTerminal {
+            // Live-render the whole assistant block as it streams. Markdown block
+            // structure can change anywhere as tokens arrive (a newline turns a
+            // line into a list; a closing fence turns text into a code block), so
+            // re-render the response rather than append a plain-text delta.
+            renderAssistant(storage: storage, response: response, streaming: true)
             mutation = .appended
         }
 
@@ -102,9 +95,10 @@ public final class InstructionTranscriptDocumentController {
         self.showsPrefillPlaceholder = displaysPrefillPlaceholder
 
         if isTerminal && (!isFinalized || responseChanged) {
-            let rendered = renderer.render(response).attributedString
-            storage.replaceCharacters(in: assistantRange, with: rendered)
-            assistantRange.length = rendered.length
+            // Render tolerantly (not strict) so a response that ends inside a code
+            // fence stays a rendered code block instead of reverting to raw text
+            // at end of turn.
+            renderAssistant(storage: storage, response: response, streaming: true)
             isFinalized = true
             mutation = .finalized
         } else if !isTerminal {
@@ -131,6 +125,59 @@ public final class InstructionTranscriptDocumentController {
         return true
     }
 
+    private func renderAssistant(
+        storage: NSMutableAttributedString,
+        response: String,
+        streaming: Bool
+    ) {
+        let rendered = renderer.render(response, streaming: streaming).attributedString
+        let existing = storage.attributedSubstring(from: assistantRange)
+        // Streaming appends at the end, so the freshly rendered block usually
+        // shares a long prefix with what is already on screen. Replace only the
+        // differing suffix so already-laid-out content (everything the reader may
+        // have scrolled up to) is left untouched — a full replace each tick makes
+        // the transcript impossible to scroll while generating.
+        let shared = Self.commonPrefixLength(existing, rendered)
+        let staleRange = NSRange(
+            location: assistantRange.location + shared,
+            length: assistantRange.length - shared)
+        let freshTail = rendered.attributedSubstring(
+            from: NSRange(location: shared, length: rendered.length - shared))
+        storage.replaceCharacters(in: staleRange, with: freshTail)
+        assistantRange.length = rendered.length
+    }
+
+    /// Longest prefix over which `existing` and `replacement` agree on both
+    /// characters and attributes.
+    static func commonPrefixLength(
+        _ existing: NSAttributedString,
+        _ replacement: NSAttributedString
+    ) -> Int {
+        let a = existing.string as NSString
+        let b = replacement.string as NSString
+        let limit = min(a.length, b.length)
+        guard limit > 0 else { return 0 }
+
+        var charCommon = 0
+        while charCommon < limit, a.character(at: charCommon) == b.character(at: charCommon) {
+            charCommon += 1
+        }
+        guard charCommon > 0 else { return 0 }
+
+        var location = 0
+        var common = 0
+        while location < charCommon {
+            var aRange = NSRange(location: 0, length: 0)
+            var bRange = NSRange(location: 0, length: 0)
+            let aAttrs = existing.attributes(at: location, effectiveRange: &aRange)
+            let bAttrs = replacement.attributes(at: location, effectiveRange: &bRange)
+            guard NSDictionary(dictionary: aAttrs).isEqual(to: bAttrs) else { break }
+            location = min(min(NSMaxRange(aRange), NSMaxRange(bRange)), charCommon)
+            common = location
+        }
+        return common
+    }
+
     private func rebuild(
         storage: NSMutableAttributedString,
         prompt: String,
@@ -153,10 +200,9 @@ public final class InstructionTranscriptDocumentController {
             string: "Answer\n",
             attributes: Self.assistantLabelAttributes()))
         assistantRange = NSRange(location: document.length, length: 0)
-        document.append(NSAttributedString(
-            string: response,
-            attributes: Self.responseAttributes()))
-        assistantRange.length = (response as NSString).length
+        let renderedResponse = renderer.render(response, streaming: true).attributedString
+        document.append(renderedResponse)
+        assistantRange.length = renderedResponse.length
         prefillDotCount = 0
         prefillPlaceholderRange = nil
         if showsPrefillPlaceholder {

--- a/Sources/TurboFieldfareApp/MacPresentation/ResponseMarkdownRenderer.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/ResponseMarkdownRenderer.swift
@@ -16,7 +16,7 @@ public struct ResponseMarkdownRenderer {
     private enum BlockKind: Equatable {
         case paragraph
         case heading(Int)
-        case code
+        case code(language: String?)
         case quote
         case unorderedList(indent: Int)
         case orderedList(ordinal: Int, indent: Int)
@@ -28,6 +28,10 @@ public struct ResponseMarkdownRenderer {
             default: false
             }
         }
+
+        var isCode: Bool {
+            if case .code = self { true } else { false }
+        }
     }
 
     private struct Block: Equatable {
@@ -37,12 +41,21 @@ public struct ResponseMarkdownRenderer {
 
     public init() {}
 
-    public func render(_ source: String) -> Result {
+    /// Render Markdown to an attributed string.
+    ///
+    /// Pass `streaming: true` while a response is still arriving. In that mode an
+    /// unterminated trailing code fence is treated as closed for display, so an
+    /// in-progress code block renders as a code block instead of dragging the
+    /// whole message into the raw-text fallback on every token. On the final,
+    /// terminal render use the default strict mode so a genuinely unclosed
+    /// fence stays readable as exact raw text.
+    public func render(_ source: String, streaming: Bool = false) -> Result {
         guard !source.isEmpty else {
             return Result(attributedString: NSAttributedString(), usedFallback: false)
         }
-        guard !requiresRawFallback(source) else { return fallback(source) }
-        let presentationSource = source.replacingOccurrences(
+        let normalized = streaming ? closingOpenCodeFence(source) : source
+        guard !requiresRawFallback(normalized) else { return fallback(source) }
+        let presentationSource = normalized.replacingOccurrences(
             of: #"(?m)^([ \t]*\*\*[^*\n]+\*\*[ \t]*)\n(?=\S)"#,
             with: "$1\n\n",
             options: .regularExpression)
@@ -53,12 +66,25 @@ public struct ResponseMarkdownRenderer {
                 options: .init(
                     interpretedSyntax: .full,
                     failurePolicy: .returnPartiallyParsedIfPossible))
-            guard !containsUnsupportedBlock(in: parsed) else { return fallback(source) }
 
             let output = NSMutableAttributedString()
             var previousBlock: Block?
+            let runs = Array(parsed.runs)
+            var index = 0
 
-            for run in parsed.runs {
+            while index < runs.count {
+                // A table is a group of consecutive cell runs sharing one table
+                // identity; render the whole group as an NSTextTable at once.
+                if let info = tableCellInfo(for: runs[index].presentationIntent) {
+                    let next = appendTable(
+                        from: runs, at: index, parsed: parsed, info: info,
+                        previous: previousBlock, to: output)
+                    previousBlock = Block(identity: info.identity, kind: .paragraph)
+                    index = next
+                    continue
+                }
+
+                let run = runs[index]
                 let block = block(for: run.presentationIntent)
                 if block != previousBlock {
                     appendSeparator(to: output, previous: previousBlock, next: block)
@@ -74,6 +100,7 @@ public struct ResponseMarkdownRenderer {
                     previousBlock = block
                 }
 
+                index += 1
                 guard block.kind != .thematicBreak else { continue }
                 let text = String(parsed[run.range].characters)
                 guard !text.isEmpty else { continue }
@@ -86,9 +113,24 @@ public struct ResponseMarkdownRenderer {
             }
 
             guard output.length > 0 else { return fallback(source) }
+            applySyntaxHighlighting(to: output)
             return Result(attributedString: output, usedFallback: false)
         } catch {
             return fallback(source)
+        }
+    }
+
+    /// Color the token ranges of every fenced code block. The block's language
+    /// hint is stored as the value of `codeBlockAttribute` by `attributes(...)`.
+    private func applySyntaxHighlighting(to output: NSMutableAttributedString) {
+        let highlighter = CodeSyntaxHighlighter()
+        output.enumerateAttribute(
+            TranscriptCodeStyle.codeBlockAttribute,
+            in: NSRange(location: 0, length: output.length),
+            options: []
+        ) { value, range, _ in
+            guard let language = value as? String else { return }
+            highlighter.highlight(output, range: range, language: language)
         }
     }
 
@@ -96,30 +138,200 @@ public struct ResponseMarkdownRenderer {
         render(source).attributedString.string
     }
 
+    /// When a response ends inside an open ``` fence, append a synthetic closing
+    /// fence so the in-progress block parses as a code block. Leaves already
+    /// balanced sources untouched. Used only for streaming renders.
+    private func closingOpenCodeFence(_ source: String) -> String {
+        let fenceCount = source.components(separatedBy: "```").count - 1
+        guard !fenceCount.isMultiple(of: 2) else { return source }
+        let separator = source.hasSuffix("\n") ? "" : "\n"
+        return source + separator + "```"
+    }
+
     private func requiresRawFallback(_ source: String) -> Bool {
         let fenceCount = source.components(separatedBy: "```").count - 1
         if !fenceCount.isMultiple(of: 2) { return true }
-        if source.range(
+        // Check for raw HTML / images only in prose. Code routinely contains
+        // angle brackets (generics like `Array<Int>`, `#include <stdio.h>`,
+        // `2..<n`) that would otherwise look like HTML tags and drag the whole
+        // message into the raw-text fallback.
+        let prose = strippingCodeRegions(source)
+        if prose.range(
             of: #"</?[A-Za-z][^>]*>"#,
             options: .regularExpression) != nil {
             return true
         }
-        return source.range(
+        return prose.range(
             of: #"!\[[^\]]*\]\([^\)]*\)"#,
             options: .regularExpression) != nil
     }
 
-    private func containsUnsupportedBlock(in parsed: AttributedString) -> Bool {
-        parsed.runs.contains { run in
-            run.presentationIntent?.components.contains { component in
-                switch component.kind {
-                case .table, .tableHeaderRow, .tableRow, .tableCell:
-                    return true
-                default:
-                    return false
+    /// Replace fenced code blocks and inline code spans with spaces so the raw
+    /// HTML / image heuristics never inspect code content.
+    private func strippingCodeRegions(_ source: String) -> String {
+        source
+            .replacingOccurrences(
+                of: #"(?s)```.*?```"#, with: " ", options: .regularExpression)
+            .replacingOccurrences(
+                of: #"`[^`\n]*`"#, with: " ", options: .regularExpression)
+    }
+
+    private struct TableCellInfo {
+        let column: Int
+        let row: Int
+        let isHeader: Bool
+        let columns: Int
+        let identity: Int
+        let alignments: [NSTextAlignment]
+    }
+
+    /// Table geometry for a cell run, or nil if the run is not part of a table.
+    /// Header cells map to row 0; body cells keep their `tableRow` index (which
+    /// the parser starts at 1), so a header + two rows becomes grid rows 0, 1, 2.
+    private func tableCellInfo(for intent: PresentationIntent?) -> TableCellInfo? {
+        guard let components = intent?.components else { return nil }
+        var column: Int?
+        var row = 0
+        var isHeader = false
+        var columns = 0
+        var identity = 0
+        var alignments: [NSTextAlignment] = []
+        for component in components {
+            switch component.kind {
+            case .tableCell(let columnIndex): column = columnIndex
+            case .tableHeaderRow: isHeader = true
+            case .tableRow(let rowIndex): row = rowIndex
+            case .table(let tableColumns):
+                columns = tableColumns.count
+                identity = component.identity
+                alignments = tableColumns.map { column in
+                    switch column.alignment {
+                    case .left: .left
+                    case .center: .center
+                    case .right: .right
+                    @unknown default: .left
+                    }
                 }
-            } == true
+            default: break
+            }
         }
+        guard let column else { return nil }
+        return TableCellInfo(
+            column: column, row: isHeader ? 0 : row, isHeader: isHeader,
+            columns: columns, identity: identity, alignments: alignments)
+    }
+
+    /// Consume every cell run of the table starting at `start` and append one
+    /// NSTextTable to `output`. Returns the index of the first run after it.
+    private func appendTable(
+        from runs: [AttributedString.Runs.Run],
+        at start: Int,
+        parsed: AttributedString,
+        info: TableCellInfo,
+        previous: Block?,
+        to output: NSMutableAttributedString
+    ) -> Int {
+        var cells: [Int: [Int: NSMutableAttributedString]] = [:]
+        var headerRows: Set<Int> = []
+        var columns = info.columns
+        var alignments = info.alignments
+
+        var index = start
+        while index < runs.count,
+              let cell = tableCellInfo(for: runs[index].presentationIntent),
+              cell.identity == info.identity {
+            let text = String(parsed[runs[index].range].characters)
+            let attributes = cellInlineAttributes(
+                inlineIntent: runs[index].inlinePresentationIntent,
+                link: runs[index].link,
+                isHeader: cell.isHeader)
+            if cells[cell.row]?[cell.column] == nil {
+                cells[cell.row, default: [:]][cell.column] = NSMutableAttributedString()
+            }
+            cells[cell.row]![cell.column]!.append(
+                NSAttributedString(string: text, attributes: attributes))
+            if cell.isHeader { headerRows.insert(cell.row) }
+            columns = max(columns, cell.column + 1)
+            if !cell.alignments.isEmpty { alignments = cell.alignments }
+            index += 1
+        }
+
+        appendSeparator(
+            to: output, previous: previous,
+            next: Block(identity: info.identity, kind: .paragraph))
+
+        let table = NSTextTable()
+        table.numberOfColumns = columns
+        table.setContentWidth(100, type: .percentageValueType)
+        let baseAttributes: [NSAttributedString.Key: Any] = [
+            .font: NSFont.systemFont(ofSize: NSFont.systemFontSize),
+            .foregroundColor: NSColor.labelColor,
+        ]
+
+        for (gridRow, rowKey) in cells.keys.sorted().enumerated() {
+            let isHeader = headerRows.contains(rowKey)
+            for column in 0..<columns {
+                let content = cells[rowKey]?[column].map {
+                    NSMutableAttributedString(attributedString: $0)
+                } ?? NSMutableAttributedString()
+                if content.length == 0 {
+                    content.append(NSAttributedString(string: " ", attributes: baseAttributes))
+                }
+
+                let block = NSTextTableBlock(
+                    table: table, startingRow: gridRow, rowSpan: 1,
+                    startingColumn: column, columnSpan: 1)
+                block.setWidth(1, type: .absoluteValueType, for: .border)
+                block.setWidth(7, type: .absoluteValueType, for: .padding)
+                block.setBorderColor(TranscriptCodeStyle.tableBorder)
+                if isHeader { block.backgroundColor = TranscriptCodeStyle.tableHeaderBackground }
+
+                let paragraph = NSMutableParagraphStyle()
+                paragraph.textBlocks = [block]
+                paragraph.alignment = column < alignments.count ? alignments[column] : .left
+
+                content.addAttribute(
+                    .paragraphStyle, value: paragraph,
+                    range: NSRange(location: 0, length: content.length))
+                output.append(content)
+                output.append(NSAttributedString(
+                    string: "\n",
+                    attributes: baseAttributes.merging(
+                        [.paragraphStyle: paragraph]) { _, new in new }))
+            }
+        }
+        return index
+    }
+
+    private func cellInlineAttributes(
+        inlineIntent: InlinePresentationIntent?,
+        link: URL?,
+        isHeader: Bool
+    ) -> [NSAttributedString.Key: Any] {
+        let size = NSFont.systemFontSize
+        var values: [NSAttributedString.Key: Any] = [.foregroundColor: NSColor.labelColor]
+        let bold = isHeader || inlineIntent?.contains(.stronglyEmphasized) == true
+
+        if inlineIntent?.contains(.code) == true {
+            values[.font] = NSFont.monospacedSystemFont(ofSize: size - 0.5, weight: .regular)
+            values[.foregroundColor] = TranscriptCodeStyle.codeText
+            values[.backgroundColor] = TranscriptCodeStyle.inlineCodeBackground
+        } else {
+            var font = NSFont.systemFont(ofSize: size, weight: bold ? .semibold : .regular)
+            if inlineIntent?.contains(.emphasized) == true {
+                let descriptor = font.fontDescriptor.withSymbolicTraits(.italic)
+                font = NSFont(descriptor: descriptor, size: size) ?? font
+            }
+            values[.font] = font
+        }
+        if inlineIntent?.contains(.strikethrough) == true {
+            values[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
+        }
+        if link != nil {
+            values[.foregroundColor] = NSColor.linkColor
+            values[.underlineStyle] = NSUnderlineStyle.single.rawValue
+        }
+        return values
     }
 
     private func block(for intent: PresentationIntent?) -> Block {
@@ -129,6 +341,7 @@ public struct ResponseMarkdownRenderer {
 
         var headingLevel: Int?
         var code = false
+        var codeLanguage: String?
         var quote = false
         var thematicBreak = false
         var ordinal: Int?
@@ -139,7 +352,9 @@ public struct ResponseMarkdownRenderer {
         for component in components {
             switch component.kind {
             case .header(let level): headingLevel = level
-            case .codeBlock: code = true
+            case .codeBlock(let languageHint):
+                code = true
+                codeLanguage = languageHint
             case .blockQuote: quote = true
             case .thematicBreak: thematicBreak = true
             case .listItem(let itemOrdinal): ordinal = itemOrdinal
@@ -159,7 +374,7 @@ public struct ResponseMarkdownRenderer {
         } else if let headingLevel {
             kind = .heading(headingLevel)
         } else if code {
-            kind = .code
+            kind = .code(language: codeLanguage)
         } else if ordered, let ordinal {
             kind = .orderedList(ordinal: ordinal, indent: max(0, listDepth - 1))
         } else if unordered {
@@ -178,8 +393,11 @@ public struct ResponseMarkdownRenderer {
         next: Block
     ) {
         guard let previous else { return }
-        let adjacentListItems = previous.kind.isList && next.kind.isList
-        let requiredNewlines = adjacentListItems ? 1 : 2
+        // Lines inside one code block, and adjacent list items, join with a
+        // single newline; every other block boundary gets a blank line.
+        let tight = (previous.kind.isList && next.kind.isList)
+            || (previous.kind.isCode && next.kind.isCode)
+        let requiredNewlines = tight ? 1 : 2
         let trailingNewlines = output.string.reversed().prefix { $0 == "\n" }.count
         guard trailingNewlines < requiredNewlines else { return }
         output.append(NSAttributedString(
@@ -213,11 +431,14 @@ public struct ResponseMarkdownRenderer {
         values[.paragraphStyle] = paragraphStyle(for: block)
         values[.font] = font(for: block, inlineIntent: inlineIntent)
 
-        if block == .quote {
+        if case .code(let language) = block {
+            values[.foregroundColor] = TranscriptCodeStyle.codeText
+            values[TranscriptCodeStyle.codeBlockAttribute] = language ?? ""
+        } else if block == .quote {
             values[.foregroundColor] = NSColor.secondaryLabelColor
-        }
-        if block == .code || inlineIntent?.contains(.code) == true {
-            values[.backgroundColor] = NSColor.controlBackgroundColor
+        } else if inlineIntent?.contains(.code) == true {
+            values[.foregroundColor] = TranscriptCodeStyle.codeText
+            values[.backgroundColor] = TranscriptCodeStyle.inlineCodeBackground
         }
         if inlineIntent?.contains(.strikethrough) == true {
             values[.strikethroughStyle] = NSUnderlineStyle.single.rawValue
@@ -241,7 +462,8 @@ public struct ResponseMarkdownRenderer {
         for block: BlockKind,
         inlineIntent: InlinePresentationIntent?
     ) -> NSFont {
-        if block == .code || inlineIntent?.contains(.code) == true {
+        let isCodeBlock: Bool = if case .code = block { true } else { false }
+        if isCodeBlock || inlineIntent?.contains(.code) == true {
             return NSFont.monospacedSystemFont(
                 ofSize: NSFont.systemFontSize - 0.5,
                 weight: .regular)
@@ -280,12 +502,12 @@ public struct ResponseMarkdownRenderer {
             style.paragraphSpacingBefore = 8
             style.paragraphSpacing = 4
         case .code:
-            style.firstLineHeadIndent = 10
-            style.headIndent = 10
-            style.tailIndent = -10
-            style.paragraphSpacingBefore = 6
-            style.paragraphSpacing = 6
-            style.lineSpacing = 2
+            style.firstLineHeadIndent = 12
+            style.headIndent = 12
+            style.tailIndent = -12
+            style.paragraphSpacingBefore = 0
+            style.paragraphSpacing = 2
+            style.lineSpacing = 3
         case .quote:
             style.firstLineHeadIndent = 4
             style.headIndent = 20

--- a/Sources/TurboFieldfareApp/MacPresentation/TranscriptLayoutManager.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/TranscriptLayoutManager.swift
@@ -1,0 +1,46 @@
+import AppKit
+import Foundation
+
+/// Draws a rounded, full-width container behind each fenced code block. Ranges
+/// are marked by the renderer with `TranscriptCodeStyle.codeBlockAttribute`;
+/// each maximal contiguous marked run becomes one rounded rect painted behind
+/// the text (and behind the per-glyph background of inline code, which
+/// `super` still handles).
+nonisolated public final class TranscriptLayoutManager: NSLayoutManager {
+    /// Extra padding painted around the code text inside the container.
+    private let verticalPadding: CGFloat = 8
+    private let horizontalInset: CGFloat = 2
+    private let cornerRadius: CGFloat = 6
+
+    public override func drawBackground(forGlyphRange glyphsToShow: NSRange, at origin: NSPoint) {
+        super.drawBackground(forGlyphRange: glyphsToShow, at: origin)
+        guard let storage = textStorage, let container = textContainer(forGlyphAt: glyphsToShow.location, effectiveRange: nil) else {
+            return
+        }
+        let charRange = characterRange(forGlyphRange: glyphsToShow, actualGlyphRange: nil)
+
+        storage.enumerateAttribute(
+            TranscriptCodeStyle.codeBlockAttribute,
+            in: charRange,
+            options: []
+        ) { value, blockCharRange, _ in
+            guard value != nil else { return }
+            let blockGlyphRange = glyphRange(forCharacterRange: blockCharRange, actualCharacterRange: nil)
+            var rect = boundingRect(forGlyphRange: blockGlyphRange, in: container)
+
+            // Grow to the container's full text width and add breathing room.
+            let fullWidth = container.size.width - container.lineFragmentPadding * 2
+            rect.origin.x = origin.x + horizontalInset
+            rect.size.width = fullWidth - horizontalInset * 2
+            rect.origin.y += origin.y - verticalPadding
+            rect.size.height += verticalPadding * 2
+
+            let path = NSBezierPath(roundedRect: rect, xRadius: cornerRadius, yRadius: cornerRadius)
+            TranscriptCodeStyle.codeBackground.setFill()
+            path.fill()
+            TranscriptCodeStyle.codeBorder.setStroke()
+            path.lineWidth = 1
+            path.stroke()
+        }
+    }
+}

--- a/Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift
+++ b/Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift
@@ -68,11 +68,10 @@ import Testing
         #expect(result.attributedString.string == source)
     }
 
-    @Test func unsupportedHTMLTableAndImageStayReadableAsRawText() {
+    @Test func unsupportedHTMLAndImagesStayReadableAsRawText() {
         let renderer = ResponseMarkdownRenderer()
         let samples = [
             "<div>Never execute this</div>",
-            "| A | B |\n|---|---|\n| 1 | 2 |",
             "![remote](https://example.com/image.png)",
         ]
 
@@ -81,6 +80,102 @@ import Testing
             #expect(result.usedFallback)
             #expect(result.attributedString.string == source)
         }
+    }
+
+    @Test func markdownTableRendersAsTableNotRawFallback() throws {
+        let source = """
+        | Action | Code |
+        | :--- | :--- |
+        | **Create** | `x = 1` |
+        | Remove | `del x` |
+        """
+        let result = ResponseMarkdownRenderer().render(source)
+        let attr = result.attributedString
+        let text = attr.string
+
+        #expect(!result.usedFallback)
+        #expect(text.contains("Action"))
+        #expect(text.contains("Create"))
+        #expect(text.contains("x = 1"))
+        #expect(!text.contains("|"))   // pipe delimiters consumed
+        #expect(!text.contains("**"))  // bold delimiters consumed
+
+        // Cells are laid out with NSTextTable blocks.
+        let cell = (text as NSString).range(of: "Create")
+        let paragraph = try #require(
+            attr.attribute(.paragraphStyle, at: cell.location, effectiveRange: nil) as? NSParagraphStyle)
+        #expect(paragraph.textBlocks.first is NSTextTableBlock)
+    }
+
+    @Test func streamingClosesOpenCodeFenceSoTheBlockRendersWhileArriving() {
+        let renderer = ResponseMarkdownRenderer()
+        let partial = "Here is code:\n\n```swift\nlet answer = 42"
+
+        let strict = renderer.render(partial)
+        #expect(strict.usedFallback)
+        #expect(strict.attributedString.string == partial)
+
+        let streamed = renderer.render(partial, streaming: true)
+        #expect(!streamed.usedFallback)
+        #expect(streamed.attributedString.string.contains("let answer = 42"))
+        #expect(!streamed.attributedString.string.contains("```"))
+    }
+
+    @Test func streamingLeavesBalancedMarkdownIdenticalToStrictRender() {
+        let renderer = ResponseMarkdownRenderer()
+        let source = "A **bold** point with `code` and a closed block:\n\n```\ndone\n```"
+
+        let strict = renderer.render(source)
+        let streamed = renderer.render(source, streaming: true)
+
+        #expect(!streamed.usedFallback)
+        #expect(streamed.attributedString.string == strict.attributedString.string)
+    }
+
+    @Test func codeWithAngleBracketsRendersInsteadOfRawFallback() {
+        let renderer = ResponseMarkdownRenderer()
+        let samples = [
+            "Use `Array<Int>` and check x > 0.",
+            "```swift\nfor i in 2..<n {}\n```\n\n> note",
+            "```cpp\n#include <stdio.h>\nint main() { return 0; }\n```",
+            "```ts\nfunction id<T>(x: T): T { return x }\n```",
+        ]
+        for source in samples {
+            #expect(!renderer.render(source).usedFallback, "\(source)")
+        }
+    }
+
+    @Test func codeBlockCarriesContainerMarkerMonoFontAndKeywordColor() throws {
+        let result = ResponseMarkdownRenderer().render("```swift\nfunc f() {}\n```")
+        let attr = result.attributedString
+        let text = attr.string as NSString
+        #expect(!result.usedFallback)
+
+        let codeStart = text.range(of: "func f()").location
+        #expect(attr.attribute(
+            TranscriptCodeStyle.codeBlockAttribute,
+            at: codeStart, effectiveRange: nil) != nil)
+
+        let font = try #require(attr.attribute(.font, at: codeStart, effectiveRange: nil) as? NSFont)
+        #expect(font.fontDescriptor.symbolicTraits.contains(.monoSpace))
+
+        let keywordColor = attr.attribute(
+            .foregroundColor, at: text.range(of: "func").location, effectiveRange: nil) as? NSColor
+        #expect(keywordColor?.isEqual(TranscriptCodeStyle.keyword) == true)
+    }
+
+    @Test func codeBlockLinesAreSingleSpaced() {
+        let result = ResponseMarkdownRenderer().render("```swift\nlet a = 1\nlet b = 2\n```")
+        #expect(result.attributedString.string.contains("let a = 1\nlet b = 2"))
+        #expect(!result.attributedString.string.contains("let a = 1\n\nlet b = 2"))
+    }
+
+    @Test func pythonHashCommentsAreColoredAsComments() {
+        let result = ResponseMarkdownRenderer().render("```python\nx = 1  # note\n```")
+        let text = result.attributedString.string as NSString
+        let color = result.attributedString.attribute(
+            .foregroundColor, at: text.range(of: "# note").location, effectiveRange: nil) as? NSColor
+        #expect(color?.isEqual(TranscriptCodeStyle.comment) == true)
     }
 
     @Test func latexRemainsReadableText() {
@@ -139,6 +234,47 @@ import Testing
             effectiveRange: nil) as? NSColor
         #expect(answerColor?.isEqual(TurboFieldfareMacTheme.accentNSColor) == true)
         #expect(controller.response == "Hello")
+    }
+
+    @Test func streamingRendersMarkdownLiveInsteadOfRawText() {
+        let storage = NSMutableAttributedString()
+        let controller = InstructionTranscriptDocumentController()
+
+        let first = controller.synchronize(
+            storage: storage,
+            prompt: "Explain",
+            response: "# Title",
+            isTerminal: false)
+        #expect(first.mutation == .rebuilt)
+        #expect(!controller.isFinalized)
+        #expect(storage.string == "You\nExplain\n\nAnswer\nTitle")
+
+        let second = controller.synchronize(
+            storage: storage,
+            prompt: "Explain",
+            response: "# Title\n\nA **bold** line",
+            isTerminal: false)
+        #expect(second.mutation == .appended)
+        #expect(!controller.isFinalized)
+        #expect(storage.string.contains("bold"))
+        #expect(!storage.string.contains("**"))
+        #expect(!storage.string.contains("# Title"))
+    }
+
+    @Test func streamingCodeBlockRendersBeforeClosingFenceArrives() {
+        let storage = NSMutableAttributedString()
+        let controller = InstructionTranscriptDocumentController()
+
+        let open = controller.synchronize(
+            storage: storage,
+            prompt: "Write code",
+            response: "```swift\nlet x = 1",
+            isTerminal: false)
+
+        #expect(open.mutation == .rebuilt)
+        #expect(!controller.isFinalized)
+        #expect(storage.string.contains("let x = 1"))
+        #expect(!storage.string.contains("```"))
     }
 
     @Test func animatedPrefillPlaceholderIsPresentationOnlyAndFirstResponseRemovesIt() {
@@ -240,7 +376,7 @@ import Testing
         #expect(storage.isEqual(to: unchanged))
     }
 
-    @Test func terminalPartialOutputIsReadableAndNextRunRestoresStreamingSource() {
+    @Test func returningToStreamingAfterFinalizeStillRendersMarkdown() {
         let storage = NSMutableAttributedString()
         let controller = InstructionTranscriptDocumentController()
         _ = controller.synchronize(
@@ -257,13 +393,16 @@ import Testing
             isTerminal: false)
         #expect(result.mutation == .rebuilt)
         #expect(!controller.isFinalized)
-        #expect(storage.string.hasSuffix("Partial **answer**"))
+        // Streaming renders Markdown live, so a reopened stream shows the
+        // formatted text rather than the raw ** delimiters.
+        #expect(storage.string.hasSuffix("Partial answer"))
+        #expect(!storage.string.contains("**"))
     }
 
-    @Test func terminalResponseRendersAgainWhenClosingFenceArrivesLate() {
+    @Test func truncatedCodeBlockRendersAtTerminalInsteadOfRevertingToRaw() {
         let storage = NSMutableAttributedString()
         let controller = InstructionTranscriptDocumentController()
-        let partial = "```cpp\nkernel void matmul() {}"
+        let partial = "```cpp\nkernel void matmul() {}"  // ends inside an open fence
         let complete = partial + "\n```"
 
         let first = controller.synchronize(
@@ -272,7 +411,10 @@ import Testing
             response: partial,
             isTerminal: true)
         #expect(first.mutation == .finalized)
-        #expect(storage.string.hasSuffix(partial))
+        // A response that ends inside a fence stays a rendered code block at end of
+        // turn rather than reverting to raw ``` text.
+        #expect(!storage.string.contains("```"))
+        #expect(storage.string.contains("kernel void matmul() {}"))
 
         let updated = controller.synchronize(
             storage: storage,
@@ -287,6 +429,24 @@ import Testing
         #expect(!storage.string.contains("```"))
     }
 
+    @Test func streamingThenTerminalKeepsUnterminatedCodeBlockFormatted() {
+        let storage = NSMutableAttributedString()
+        let controller = InstructionTranscriptDocumentController()
+        let text = "See:\n\n```swift\nlet x = 1"  // no closing fence
+
+        _ = controller.synchronize(
+            storage: storage, prompt: "Q", response: text, isTerminal: false)
+        #expect(!storage.string.contains("```"))  // rendered while streaming
+
+        _ = controller.synchronize(
+            storage: storage, prompt: "Q", response: text, isTerminal: true)
+        #expect(!storage.string.contains("```"))  // still rendered at terminal — no revert
+        let ns = storage.string as NSString
+        #expect(storage.attribute(
+            TranscriptCodeStyle.codeBlockAttribute,
+            at: ns.range(of: "let x").location, effectiveRange: nil) != nil)
+    }
+
     @Test func selectionRangesClampToCurrentStorage() {
         let ranges = InstructionTranscriptDocumentController.clampedRanges([
             NSRange(location: 3, length: 20),
@@ -299,15 +459,21 @@ import Testing
         ])
     }
 
-    @Test func terminalFormattingAlwaysScrollsToBottom() {
-        #expect(InstructionTranscriptDocumentController.shouldScrollToBottom(
-            wasAtBottom: false,
-            mutation: .finalized))
-        #expect(InstructionTranscriptDocumentController.shouldScrollToBottom(
-            wasAtBottom: true,
-            mutation: .appended))
-        #expect(!InstructionTranscriptDocumentController.shouldScrollToBottom(
-            wasAtBottom: false,
-            mutation: .appended))
+    @Test func commonPrefixStopsAtFirstCharacterOrAttributeDifference() {
+        let mono = [NSAttributedString.Key.font: NSFont.monospacedSystemFont(
+            ofSize: NSFont.systemFontSize, weight: .regular)]
+        let plain = [NSAttributedString.Key.font: NSFont.systemFont(ofSize: NSFont.systemFontSize)]
+
+        // Same text, attributes diverge at index 5 → common prefix is 5.
+        let a = NSMutableAttributedString(string: "abcde", attributes: plain)
+        a.append(NSAttributedString(string: "fgh", attributes: plain))
+        let b = NSMutableAttributedString(string: "abcde", attributes: plain)
+        b.append(NSAttributedString(string: "fgh", attributes: mono))
+        #expect(InstructionTranscriptDocumentController.commonPrefixLength(a, b) == 5)
+
+        // Pure append shares the whole shorter string.
+        let short = NSAttributedString(string: "let x = 1", attributes: mono)
+        let long = NSAttributedString(string: "let x = 1\nlet y = 2", attributes: mono)
+        #expect(InstructionTranscriptDocumentController.commonPrefixLength(short, long) == 9)
     }
 }


### PR DESCRIPTION
## Summary

The Mac app's transcript showed the model's answer as raw Markdown text. This
renders it as rich text — live while streaming and in both light and dark
appearances — so answers read the way they do in a modern chat client.

All work is in the Mac presentation layer (`TurboFieldfareMacPresentation` /
`TurboFieldfareApp/Mac`). Nothing touches inference, the decode protocol, or
runtime controls.

## Behavior changes

- **Live streaming render.** The answer formats as tokens arrive. Each tick
  re-renders only the changed suffix (`commonPrefixLength` diff), so already
  laid-out content is left untouched — the transcript stays scrollable and
  cheap to update mid-generation.
- **Syntax-highlighted code blocks.** Fenced blocks render in rounded,
  full-width containers drawn by a custom `NSLayoutManager`
  (`TranscriptLayoutManager`), with a small language-aware highlighter
  (`CodeSyntaxHighlighter`) for comments/strings/numbers/keywords/types.
  Inline code gets a chip background.
- **Tables.** GFM tables render as real `NSTextTable`s (bordered, shaded
  header row, inline cell formatting) instead of dropping the whole message
  to raw text.
- **Fewer spurious raw fallbacks.** The raw-text fallback no longer treats
  code angle brackets (`Array<Int>`, `#include <...>`, `2..<n`) as HTML — it
  inspects prose only. Genuine prose HTML and images still fall back to exact
  raw text on purpose.
- **No revert at end of turn.** A response that ends inside an open code
  fence stays a rendered code block rather than snapping back to raw text
  when generation finishes.
- **Transcript scrolling fix.** The transcript uses a manually built
  `NSTextView` (so the custom layout manager can draw code containers); that
  needs an explicit large `maxSize`, or the document view never grows past
  one screen and the transcript can't scroll once content overflows.

## Validation

- `swift build -c release` — passes (Swift 6.2.3, target macOS 26).
- `ruby Scripts/check_markdown_links.rb` — all 22 files, links/anchors resolve.
- `Scripts/test.sh` — **passes: 554 tests in 112 suites** (run serially against
  the Xcode Swift 6.3.3 toolchain via
  `DEVELOPER_DIR=/Applications/Xcode.app/Contents/Developer Scripts/test.sh`).
  Includes the new focused tests in `ResponseMarkdownRendererTests.swift`
  covering the renderer, syntax highlighting, tables, streaming/finalize
  behavior, and the incremental prefix-diff.

## Memory and performance

Presentation only — no complete checkpoint, shard, or model tensor is loaded.
Streaming keeps only the response text (already held by the transcript
mailbox) and re-renders the changed suffix, so per-tick work is bounded by the
current response length, not the number of tokens seen. No real-model run was
performed; this change does not exercise the model path.

## Remaining limitations

- Raw HTML and images are intentionally shown as exact raw text (unchanged).
- While a table is on screen and more text streams below it, the table is
  re-rendered each tick (`NSTextTableBlock` is reference-equal only). It is the
  same length/content each time, so there is no visible flicker or scroll
  shift, just a little extra layout work.

- [x] The change does not load a complete checkpoint, shard, or large model tensor into Swift heap memory.
- [x] Logs and artifacts contain no credentials, private paths, or model weights.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
