### PR TITLE
Add conversation history, document attachments, and safer server binding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,11 +40,17 @@ jobs:
       - name: Build debug (fast first signal)
         run: swift build
 
-      - name: Lint with swift-format (non-blocking)
+      - name: Lint changed Swift files with swift-format (non-blocking)
         continue-on-error: true
         run: |
           if xcrun --find swift-format >/dev/null 2>&1; then
-            xcrun swift-format lint --recursive Sources
+            BASE="${GITHUB_EVENT_PULL_REQUEST_BASE_SHA:-${GITHUB_SHA}}"
+            files="$(git diff --name-only "$BASE" HEAD -- '*.swift' || true)"
+            if [ -n "$files" ]; then
+              xcrun swift-format lint $files
+            else
+              echo "No Swift files changed; skipping"
+            fi
           else
             echo "swift-format not found in toolchain; skipping"
           fi

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,35 @@ jobs:
     runs-on: macos-26
     steps:
       - uses: actions/checkout@v4
+
+      - name: Cache SwiftPM
+        uses: actions/cache@v4
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/org.swift.swiftpm
+            .build
+          key: ${{ runner.os }}-swiftpm-${{ hashFiles('Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-swiftpm-
+
+      - name: Build debug (fast first signal)
+        run: swift build
+
+      - name: Lint with swift-format (non-blocking)
+        continue-on-error: true
+        run: |
+          if xcrun --find swift-format >/dev/null 2>&1; then
+            xcrun swift-format lint --recursive Sources
+          else
+            echo "swift-format not found in toolchain; skipping"
+          fi
+
       - name: Build release products
         run: swift build -c release
+
       - name: Run serial tests
         run: Scripts/test.sh
+
       - name: Check Markdown links
         run: ruby Scripts/check_markdown_links.rb

--- a/.gitignore
+++ b/.gitignore
@@ -44,6 +44,9 @@ benchmark-results/
 scratch/
 tmp/
 
+# Local app bundle builds
+TurboFieldfare.app/
+
 # Python
 __pycache__/
 *.pyc

--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fcd8c6c7b3bdc1b2987889f5525974610779e7fe094361a13b5cd2b27afa046b",
+  "originHash" : "fbdf91df66ad4f1f6bfbeca6ec74703245f2535ac654e46388a4cc97c966e011",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -15,8 +15,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-asn1.git",
       "state" : {
-        "revision" : "eb50cbd14606a9161cbc5d452f18797c90ef0bab",
-        "version" : "1.7.0"
+        "revision" : "a9a5efd40eaf558a2bcd48d64b1d1646be686008",
+        "version" : "1.7.1"
       }
     },
     {
@@ -24,8 +24,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-atomics.git",
       "state" : {
-        "revision" : "b601256eab081c0f92f059e12818ac1d4f178ff7",
-        "version" : "1.3.0"
+        "revision" : "0442cb5a3f98ab802acb777929fdb446bda11a34",
+        "version" : "1.3.1"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
-        "version" : "1.5.1"
+        "revision" : "a0cb0954ecb21e4e31b0070e6ed5674e8556685a",
+        "version" : "1.6.0"
       }
     },
     {
@@ -42,8 +42,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-crypto.git",
       "state" : {
-        "revision" : "1b6b2e274e85105bfa155183145a1dcfd63331f1",
-        "version" : "4.5.0"
+        "revision" : "47d3869a7291f085c1fb9fb1e6d3b97a793f45c6",
+        "version" : "4.5.1"
       }
     },
     {
@@ -60,8 +60,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/huggingface/swift-jinja.git",
       "state" : {
-        "revision" : "0b67ecb79139f6addef8699eff3622808aa6c7dc",
-        "version" : "2.3.6"
+        "revision" : "7d0b8880ef8e567dd4e0089f8b99fb354129017c",
+        "version" : "2.4.2"
       }
     },
     {
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
-        "version" : "2.99.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {
@@ -78,8 +78,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-system.git",
       "state" : {
-        "revision" : "7c6ad0fc39d0763e0b699210e4124afd5041c5df",
-        "version" : "1.6.4"
+        "revision" : "50688cacbd41d547e9eb9f7a213542340b7c442b",
+        "version" : "1.7.5"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", exact: "2.99.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.99.0"),
     ],
     targets: [
         .target(

--- a/README.md
+++ b/README.md
@@ -203,6 +203,15 @@ about the file's content.
 - Attached documents are stored with the conversation, so reloading a
   conversation from history restores its context.
 
+#### Cognitive mode
+
+The inspector's **Runtime** section offers a **Cognitive mode** toggle. When
+enabled, each generation runs four passes — plan, draft, critique, and final
+revision — and the model revises its own answer before it is stored in
+history. The output pane shows every pass under its own header. Each pass can
+generate up to the response limit, so cognitive runs are noticeably slower
+than single-pass generation.
+
 ### Command-line interface
 
 The CLI uses an existing `.gturbo` installation. If you installed the model

--- a/README.md
+++ b/README.md
@@ -165,6 +165,37 @@ right pane to configure sampling, context length, expert-cache slots, and
 runtime options. See [Runtime controls](docs/RUNTIME_CONTROLS.md) for details
 and defaults.
 
+#### Conversation history
+
+The sidebar on the left keeps a persistent history of past conversations. Each
+entry shows the title, a response preview, the relative update time, and the
+number of generated tokens. You can:
+
+- click an entry to reload its prompt and response,
+- search the history by title, prompt, or response,
+- delete entries individually or clear the whole history,
+- start a fresh conversation with the **New** button.
+
+History is stored as JSON in Application Support (`TurboFieldfare/
+conversations.json`) and survives app restarts. A conversation is saved when a
+generation finishes or is stopped; regenerating the same prompt updates the
+same conversation instead of creating duplicates.
+
+#### Document attachments
+
+You can attach PDF, Word (DOCX), TXT, Markdown, and RTF files to a prompt,
+either through the file picker or by dragging them onto the composer. The app
+extracts the text (PDFs via PDFKit, Word via `NSAttributedString`) and injects
+it into the prompt inside `[Document: …]` markers, so the model can answer
+about the file's content.
+
+- Files up to 50 MB are accepted; extracted text is limited to 500,000
+  characters and is marked as truncated when the limit is hit.
+- Attachments show their size, page count (PDFs), character count, and a text
+  preview popover, and can be removed individually or all at once.
+- Attached documents are stored with the conversation, so reloading a
+  conversation from history restores its context.
+
 ### Command-line interface
 
 The CLI uses an existing `.gturbo` installation. If you installed the model
@@ -266,7 +297,9 @@ swift build -c release --product TurboFieldfareServer
 It listens on `http://127.0.0.1:8080/v1` and supports Chat Completions,
 streaming, function tools, and single-prefix prompt reuse. The client must
 authorize and run every tool call. Keep the server on loopback; it has no
-remote authentication or TLS.
+remote authentication or TLS. `--host` selects the bind address and
+`--allow-remote` explicitly permits a non-loopback host (see the
+[server guide](docs/OPENAI_SERVER.md#bind-address) for the warning).
 
 See [Local server](docs/OPENAI_SERVER.md) for a test request, Python and
 OpenCode setup, prompt reuse, tool handling, and the supported API subset.
@@ -322,6 +355,9 @@ TurboFieldfare currently includes:
 - FP16 KV storage with bounded circular storage for 25 sliding-window layers
   and linear storage for 5 full-attention layers
 - Exact split-K/V decode attention with distinct normalized K and V paths
+- A persistent, searchable conversation history sidebar in the Mac app
+- PDF, DOCX, TXT, Markdown, and RTF document attachments whose text is
+  injected into the prompt
 - A Swift library, streaming installer, command-line interface, loopback
   OpenAI-compatible server, and native SwiftUI/AppKit Mac app with a one-shot
   local decode service

--- a/README.md
+++ b/README.md
@@ -187,8 +187,8 @@ The sidebar on the left keeps a persistent history of past conversations. Each
 entry shows the title, a response preview, the relative update time, and the
 number of generated tokens. You can:
 
-- click an entry to reload its prompt and response,
-- search the history by title, prompt, or response,
+- click an entry to reload its history and continue the dialogue,
+- search the history by title or any turn text,
 - pin entries so they stay at the top of the list,
 - rename entries by double-clicking the title,
 - export or import the whole history as JSON,
@@ -197,8 +197,10 @@ number of generated tokens. You can:
 
 History is stored as JSON in Application Support (`TurboFieldfare/
 conversations.json`) and survives app restarts. A conversation is saved when a
-generation finishes or is stopped; regenerating the same prompt updates the
-same conversation instead of creating duplicates.
+generation finishes or is stopped. Loading a conversation clears the composer
+so you can continue it: the next message is sent with the full turn history,
+and regenerating the same prompt replaces the previous answer instead of
+duplicating it.
 
 #### Document attachments
 

--- a/README.md
+++ b/README.md
@@ -135,6 +135,22 @@ Build the complete package so the app and its sibling decode service are both
 available. When launched from this checkout, the app stores the model in
 `scratch/gemma4.gturbo`.
 
+#### Packaging the Mac app
+
+To build a self-contained app bundle:
+
+```bash
+Scripts/build-app.sh            # → .build/release/TurboFieldfare.app
+Scripts/build-app.sh --codesign # also sign with an ad-hoc signature
+Scripts/install-app.sh          # install to /Applications (block if existing)
+Scripts/install-app.sh --force  # replace an existing install
+```
+
+The bundle version is taken from the latest git tag (`--version` overrides it),
+with the build number set to the number of commits on the current branch. The
+launchd-spawned decode service lives in `Contents/MacOS/` next to the main
+executable.
+
 #### Install the model
 
 On first launch, the app checks the available storage and shows the download

--- a/README.md
+++ b/README.md
@@ -173,6 +173,9 @@ number of generated tokens. You can:
 
 - click an entry to reload its prompt and response,
 - search the history by title, prompt, or response,
+- pin entries so they stay at the top of the list,
+- rename entries by double-clicking the title,
+- export or import the whole history as JSON,
 - delete entries individually or clear the whole history,
 - start a fresh conversation with the **New** button.
 
@@ -190,9 +193,13 @@ it into the prompt inside `[Document: …]` markers, so the model can answer
 about the file's content.
 
 - Files up to 50 MB are accepted; extracted text is limited to 500,000
-  characters and is marked as truncated when the limit is hit.
+  characters and is marked as truncated when the limit is hit. Both limits
+  are configurable in the **Attachments** pane of the inspector.
 - Attachments show their size, page count (PDFs), character count, and a text
   preview popover, and can be removed individually or all at once.
+- The composer shows an approximate token count for the full prompt
+  (documents included) and warns in orange when it exceeds the selected
+  context window.
 - Attached documents are stored with the conversation, so reloading a
   conversation from history restores its context.
 

--- a/Scripts/build-app.sh
+++ b/Scripts/build-app.sh
@@ -1,0 +1,136 @@
+#!/usr/bin/env bash
+# Build the complete TurboFieldfare Mac app bundle.
+#
+# - Builds all release products (app + decode service library)
+# - Packages them into .build/release/TurboFieldfare.app
+# - Optionally codesigns the bundle with an ad-hoc signature
+#
+# Usage:
+#   Scripts/build-app.sh [--version <shortVersion>] [--codesign]
+#
+# With no --version tag set, the version is derived from the most recent
+# git tag, falling back to a dev build (last commit short hash) when the
+# repository has no tags. Use `--version` to override both.
+
+set -euo pipefail
+
+script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+repo_root="$(cd -- "$script_directory/.." && pwd)"
+cd "$repo_root"
+
+version=""
+codesign_bundle=false
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --version)
+      if [[ $# -lt 2 ]]; then
+        echo "--version requires a value" >&2
+        exit 1
+      fi
+      version="$2"
+      shift 2
+      ;;
+    --codesign)
+      codesign_bundle=true
+      shift
+      ;;
+    --no-codesign)
+      codesign_bundle=false
+      shift
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# ---------------------------------------------------------------------------
+# Resolve version and build number from git, with dev fallbacks.
+# ---------------------------------------------------------------------------
+if [[ -z "$version" ]]; then
+  if git_tag=$(git describe --tags --abbrev=0 2>/dev/null); then
+    version="$git_tag"
+  else
+    version="dev-$(git rev-parse --short HEAD)"
+  fi
+fi
+build_number="$(git rev-list --count HEAD)"
+bundle_version="$version+$build_number"
+
+app_bundle=".build/release/TurboFieldfare.app"
+macos_dir="$app_bundle/Contents/MacOS"
+resources_dir="$app_bundle/Contents/Resources"
+
+# ---------------------------------------------------------------------------
+# Build
+# ---------------------------------------------------------------------------
+echo "▶ Building release products…"
+swift build -c release
+for product in TurboFieldfareMac TurboFieldfareDecodeService; do
+  if [[ ! -f ".build/release/$product" ]]; then
+    echo "Missing binary: .build/release/$product" >&2
+    exit 1
+  fi
+done
+
+# ---------------------------------------------------------------------------
+# Assemble the bundle
+# ---------------------------------------------------------------------------
+echo "▶ Assembling app bundle ($version)…"
+rm -rf "$app_bundle"
+mkdir -p "$macos_dir" "$resources_dir"
+cp .build/release/TurboFieldfareMac            "$macos_dir/"
+cp .build/release/TurboFieldfareDecodeService  "$macos_dir/"
+cp Sources/TurboFieldfareApp/Mac/Resources/turbofieldfare-app-icon.png \
+   "$resources_dir/"
+printf 'APPL????' > "$app_bundle/Contents/PkgInfo"
+
+cat > "$app_bundle/Contents/Info.plist" <<EOF
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+    <key>CFBundleDevelopmentRegion</key>
+    <string>en</string>
+    <key>CFBundleExecutable</key>
+    <string>TurboFieldfareMac</string>
+    <key>CFBundleIdentifier</key>
+    <string>com.turbofieldfare.mac</string>
+    <key>CFBundleInfoDictionaryVersion</key>
+    <string>6.0</string>
+    <key>CFBundleName</key>
+    <string>TurboFieldfare</string>
+    <key>CFBundlePackageType</key>
+    <string>APPL</string>
+    <key>CFBundleShortVersionString</key>
+    <string>$version</string>
+    <key>CFBundleVersion</key>
+    <string>$bundle_version</string>
+    <key>CFBundleIconFile</key>
+    <string>turbofieldfare-app-icon</string>
+    <key>LSMinimumSystemVersion</key>
+    <string>14.0</string>
+    <key>NSPrincipalClass</key>
+    <string>NSApplication</string>
+    <key>NSSupportsAutomaticTermination</key>
+    <true/>
+    <key>NSSupportsSuddenTermination</key>
+    <true/>
+    <key>NSHighResolutionCapable</key>
+    <true/>
+</dict>
+</plist>
+EOF
+
+# ---------------------------------------------------------------------------
+# Optional ad-hoc code signing (avoids Gatekeeper refusal on first launch)
+# ---------------------------------------------------------------------------
+if [[ "$codesign_bundle" == true ]]; then
+  echo "▶ Code signing (adhoc)…"
+  codesign --force --deep --sign - "$app_bundle"
+fi
+
+plutil -lint "$app_bundle/Contents/Info.plist"
+echo "✔ Bundle built: $app_bundle ($version)"

--- a/Scripts/install-app.sh
+++ b/Scripts/install-app.sh
@@ -11,9 +11,8 @@
 set -euo pipefail
 
 script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
-application_dir="/Applications"
 app_name="TurboFieldfare.app"
-destination="$application_dir/$app_name"
+destination="/Applications/$app_name"
 
 force=false
 no_codesign=false
@@ -48,24 +47,26 @@ fi
 
 source_bundle="$(cd -- "$script_directory/.." && pwd)/.build/release/$app_name"
 
-echo "▶ Building release bundle…"
-"$script_directory/build-app.sh" "${build_args[@]}"
+echo "Building release bundle..."
+"$script_directory/build-app.sh" "${build_args[@]:-}"
 
 if [[ -d "$destination" && "$force" == false ]]; then
   existing_id="$(plutil -extract CFBundleIdentifier raw "$destination/Contents/Info.plist" 2>/dev/null || echo "")"
-  echo "⛔ $destination already exists (bundle id: ${existing_id:-unknown})." >&2
+  echo "ERROR: $destination already exists (bundle id: ${existing_id:-unknown})." >&2
   echo "   Run with --force to replace it." >&2
   exit 1
 fi
 
 if pgrep -f "$app_name" >/dev/null; then
-  echo "⛔ $app_name is currently running; quit it before installing." >&2
+  echo "ERROR: $app_name is currently running; quit it before installing." >&2
   exit 1
 fi
 
-[[ "$force" == true ]] && echo "▶ Replacing existing app in $application_dir…"
+if [[ "$force" == true ]]; then
+  echo "Replacing existing app in /Applications..."
+fi
 rm -rf "$destination"
 cp -R "$source_bundle" "$destination"
 
 codesign --verify --deep "$destination"
-echo "✔ Installed to $destination"
+echo "Installed to $destination"

--- a/Scripts/install-app.sh
+++ b/Scripts/install-app.sh
@@ -1,0 +1,71 @@
+#!/usr/bin/env bash
+# Install the TurboFieldfare Mac app into /Applications.
+#
+# Usage:
+#   Scripts/install-app.sh [--force] [--no-codesign] [--version <shortVersion>]
+#
+# The app is built (via Scripts/build-app.sh), codesigned with an ad-hoc
+# signature unless --no-codesign is given, and installed to /Applications.
+# An already-installed copy blocks the install unless --force is passed.
+
+set -euo pipefail
+
+script_directory="$(cd -- "$(dirname -- "${BASH_SOURCE[0]}")" && pwd)"
+application_dir="/Applications"
+app_name="TurboFieldfare.app"
+destination="$application_dir/$app_name"
+
+force=false
+no_codesign=false
+version=""
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --force)      force=true;      shift ;;
+    --no-codesign) no_codesign=true; shift ;;
+    --version)
+      if [[ $# -lt 2 ]]; then
+        echo "--version requires a value" >&2
+        exit 1
+      fi
+      version="$2"
+      shift 2
+      ;;
+    *)
+      echo "unknown option: $1" >&2
+      exit 1
+      ;;
+  esac
+done
+
+build_args=()
+if [[ "$no_codesign" == false ]]; then
+  build_args+=(--codesign)
+fi
+if [[ -n "$version" ]]; then
+  build_args+=(--version "$version")
+fi
+
+source_bundle="$(cd -- "$script_directory/.." && pwd)/.build/release/$app_name"
+
+echo "▶ Building release bundle…"
+"$script_directory/build-app.sh" "${build_args[@]}"
+
+if [[ -d "$destination" && "$force" == false ]]; then
+  existing_id="$(plutil -extract CFBundleIdentifier raw "$destination/Contents/Info.plist" 2>/dev/null || echo "")"
+  echo "⛔ $destination already exists (bundle id: ${existing_id:-unknown})." >&2
+  echo "   Run with --force to replace it." >&2
+  exit 1
+fi
+
+if pgrep -f "$app_name" >/dev/null; then
+  echo "⛔ $app_name is currently running; quit it before installing." >&2
+  exit 1
+fi
+
+[[ "$force" == true ]] && echo "▶ Replacing existing app in $application_dir…"
+rm -rf "$destination"
+cp -R "$source_bundle" "$destination"
+
+codesign --verify --deep "$destination"
+echo "✔ Installed to $destination"

--- a/Sources/TurboFieldfare/Runtime/Inference/CognitiveCycle.swift
+++ b/Sources/TurboFieldfare/Runtime/Inference/CognitiveCycle.swift
@@ -1,5 +1,17 @@
 import Foundation
 
+/// One completed pass of the cognitive cycle, in display order.
+public struct CognitivePassSegment: Equatable, Sendable, Identifiable {
+    public let id = UUID()
+    public let kind: CognitiveStepKind
+    public let text: String
+
+    public init(kind: CognitiveStepKind, text: String) {
+        self.kind = kind
+        self.text = text
+    }
+}
+
 /// The four passes of the advanced cognitive cycle.
 public enum CognitiveStepKind: String, CaseIterable, Sendable, Equatable {
     case plan

--- a/Sources/TurboFieldfare/Runtime/Inference/CognitiveCycle.swift
+++ b/Sources/TurboFieldfare/Runtime/Inference/CognitiveCycle.swift
@@ -13,7 +13,7 @@ public struct CognitivePassSegment: Equatable, Sendable, Identifiable {
 }
 
 /// The four passes of the advanced cognitive cycle.
-public enum CognitiveStepKind: String, CaseIterable, Sendable, Equatable {
+public enum CognitiveStepKind: String, CaseIterable, Sendable, Equatable, Hashable {
     case plan
     case draft
     case critique
@@ -118,5 +118,24 @@ public struct CognitiveCycleEngine: Sendable, Equatable {
             \(outputs[.critique] ?? "")
             """
         }
+    }
+}
+
+/// Decides whether the final revision pass can be skipped because the
+/// critique found nothing actionable. Heuristic, prompt-format dependent.
+public enum CognitiveStopPolicy {
+    /// Returns true when the critique is empty or contains only positive
+    /// "nothing to fix" markers, so the draft can be kept as the answer.
+    public static func shouldSkipFinal(critique: String) -> Bool {
+        let trimmed = critique.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return true }
+        let lowered = trimmed.lowercased()
+        let positiveMarkers = [
+            "no issues", "no errors", "no problems", "no changes",
+            "no improvements", "nothing to fix", "nothing to change",
+            "looks good", "no major issues",
+            "no actionable feedback", "no critical issues",
+        ]
+        return positiveMarkers.contains { lowered.contains($0) }
     }
 }

--- a/Sources/TurboFieldfareApp/Core/Configuration/MacAppSettings.swift
+++ b/Sources/TurboFieldfareApp/Core/Configuration/MacAppSettings.swift
@@ -15,6 +15,8 @@ struct MacAppSettings: Codable, Equatable, Sendable {
     var prefillEnabled: Bool = true
     var newlineShortcut: AppNewlineShortcut = .return
     var showPromptExamples: Bool = true
+    var maxAttachmentFileSize: UInt64 = DocumentExtractor.maximumFileSize
+    var maxAttachmentTextLength: Int = DocumentExtractor.maximumTextLength
 
     private enum CodingKeys: String, CodingKey {
         case version
@@ -28,6 +30,8 @@ struct MacAppSettings: Codable, Equatable, Sendable {
         case prefillEnabled
         case newlineShortcut
         case showPromptExamples
+        case maxAttachmentFileSize
+        case maxAttachmentTextLength
     }
 
     init(version: Int = currentVersion,
@@ -40,7 +44,9 @@ struct MacAppSettings: Codable, Equatable, Sendable {
          topP: Double = 0.95,
          prefillEnabled: Bool = true,
          newlineShortcut: AppNewlineShortcut = .return,
-         showPromptExamples: Bool = true) {
+         showPromptExamples: Bool = true,
+         maxAttachmentFileSize: UInt64 = DocumentExtractor.maximumFileSize,
+         maxAttachmentTextLength: Int = DocumentExtractor.maximumTextLength) {
         self.version = version
         self.contextTokens = contextTokens
         self.expertCacheSlots = expertCacheSlots
@@ -52,6 +58,8 @@ struct MacAppSettings: Codable, Equatable, Sendable {
         self.prefillEnabled = prefillEnabled
         self.newlineShortcut = newlineShortcut
         self.showPromptExamples = showPromptExamples
+        self.maxAttachmentFileSize = maxAttachmentFileSize
+        self.maxAttachmentTextLength = maxAttachmentTextLength
     }
 
     init(from decoder: Decoder) throws {
@@ -71,6 +79,12 @@ struct MacAppSettings: Codable, Equatable, Sendable {
         showPromptExamples = try container.decodeIfPresent(
             Bool.self,
             forKey: .showPromptExamples) ?? true
+        maxAttachmentFileSize = try container.decodeIfPresent(
+            UInt64.self,
+            forKey: .maxAttachmentFileSize) ?? DocumentExtractor.maximumFileSize
+        maxAttachmentTextLength = try container.decodeIfPresent(
+            Int.self,
+            forKey: .maxAttachmentTextLength) ?? DocumentExtractor.maximumTextLength
     }
 
     func isValid() -> Bool {
@@ -80,6 +94,8 @@ struct MacAppSettings: Codable, Equatable, Sendable {
             && temperature.isFinite && (0...2).contains(temperature)
             && (1...256).contains(topK)
             && topP.isFinite && (0.01...1).contains(topP)
+            && maxAttachmentFileSize >= 1_048_576 && maxAttachmentFileSize <= 1_073_741_824
+            && maxAttachmentTextLength >= 10_000 && maxAttachmentTextLength <= 2_000_000
     }
 }
 

--- a/Sources/TurboFieldfareApp/Core/Configuration/MacAppSettings.swift
+++ b/Sources/TurboFieldfareApp/Core/Configuration/MacAppSettings.swift
@@ -17,6 +17,7 @@ struct MacAppSettings: Codable, Equatable, Sendable {
     var showPromptExamples: Bool = true
     var maxAttachmentFileSize: UInt64 = DocumentExtractor.maximumFileSize
     var maxAttachmentTextLength: Int = DocumentExtractor.maximumTextLength
+    var cognitiveModeEnabled: Bool = false
 
     private enum CodingKeys: String, CodingKey {
         case version
@@ -32,6 +33,7 @@ struct MacAppSettings: Codable, Equatable, Sendable {
         case showPromptExamples
         case maxAttachmentFileSize
         case maxAttachmentTextLength
+        case cognitiveModeEnabled
     }
 
     init(version: Int = currentVersion,
@@ -46,7 +48,8 @@ struct MacAppSettings: Codable, Equatable, Sendable {
          newlineShortcut: AppNewlineShortcut = .return,
          showPromptExamples: Bool = true,
          maxAttachmentFileSize: UInt64 = DocumentExtractor.maximumFileSize,
-         maxAttachmentTextLength: Int = DocumentExtractor.maximumTextLength) {
+         maxAttachmentTextLength: Int = DocumentExtractor.maximumTextLength,
+         cognitiveModeEnabled: Bool = false) {
         self.version = version
         self.contextTokens = contextTokens
         self.expertCacheSlots = expertCacheSlots
@@ -60,6 +63,7 @@ struct MacAppSettings: Codable, Equatable, Sendable {
         self.showPromptExamples = showPromptExamples
         self.maxAttachmentFileSize = maxAttachmentFileSize
         self.maxAttachmentTextLength = maxAttachmentTextLength
+        self.cognitiveModeEnabled = cognitiveModeEnabled
     }
 
     init(from decoder: Decoder) throws {
@@ -85,6 +89,9 @@ struct MacAppSettings: Codable, Equatable, Sendable {
         maxAttachmentTextLength = try container.decodeIfPresent(
             Int.self,
             forKey: .maxAttachmentTextLength) ?? DocumentExtractor.maximumTextLength
+        cognitiveModeEnabled = try container.decodeIfPresent(
+            Bool.self,
+            forKey: .cognitiveModeEnabled) ?? false
     }
 
     func isValid() -> Bool {

--- a/Sources/TurboFieldfareApp/Core/Configuration/TurboFieldfareAppearance.swift
+++ b/Sources/TurboFieldfareApp/Core/Configuration/TurboFieldfareAppearance.swift
@@ -1,0 +1,40 @@
+import SwiftUI
+
+/// Design system for TurboFieldfare's dark UI.
+public enum TurboFieldfareAppearance: Sendable {
+
+    /// Accent color: a fresh green that pops against the dark background.
+    public static let accent = Color(
+        red: 0.30, green: 0.78, blue: 0.38)
+
+    /// Secondary accent for destructive or high-attention states.
+    public static let danger = Color(
+        red: 0.85, green: 0.30, blue: 0.30)
+
+    /// Primary text color (slightly warm white).
+    public static let textPrimary = Color(
+        red: 0.93, green: 0.93, blue: 0.90)
+
+    /// Secondary text color (reduced contrast for metadata).
+    public static let textSecondary = Color(
+        red: 0.58, green: 0.58, blue: 0.55)
+
+    /// Subtle text for captions and timestamps.
+    public static let textTertiary = Color(
+        red: 0.40, green: 0.40, blue: 0.38)
+
+    /// Background: near-black with a warm undertone.
+    public static let background = Color(
+        red: 0.07, green: 0.07, blue: 0.09)
+
+    /// Elevated surface (cards, panels).
+    public static let surface = Color(
+        red: 0.10, green: 0.10, blue: 0.13)
+
+    /// Animated corner radii.
+    public static let cornerRadius: CGFloat = 12
+    public static let cornerRadiusLarge: CGFloat = 18
+
+    /// Icon size for metrics.
+    public static let metricIconSize: CGFloat = 16
+}

--- a/Sources/TurboFieldfareApp/Core/Inference/CognitiveCycle.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/CognitiveCycle.swift
@@ -1,0 +1,110 @@
+import Foundation
+
+/// The four passes of the advanced cognitive cycle.
+public enum CognitiveStepKind: String, CaseIterable, Sendable, Equatable {
+    case plan
+    case draft
+    case critique
+    case final
+
+    /// Header shown in the output pane before each pass.
+    public var header: String {
+        switch self {
+        case .plan: return "Plan"
+        case .draft: return "Draft"
+        case .critique: return "Critique"
+        case .final: return "Final answer"
+        }
+    }
+}
+
+/// One generation step of a cognitive cycle.
+public struct CognitiveStep: Equatable, Sendable {
+    public let kind: CognitiveStepKind
+    public let prompt: String
+
+    public init(kind: CognitiveStepKind, prompt: String) {
+        self.kind = kind
+        self.prompt = prompt
+    }
+}
+
+/// Stateful builder of the advanced cognitive cycle: plan, draft, critique,
+/// then a final revision. Each prompt embeds the outputs of the previous
+/// passes, so the model revises with full context. The engine is a pure
+/// value type: advance it with `nextStep()` and feed outputs back with
+/// `record(output:)`.
+public struct CognitiveCycleEngine: Sendable, Equatable {
+    public let userPrompt: String
+    public private(set) var outputs: [CognitiveStepKind: String] = [:]
+    public private(set) var isFinished = false
+
+    public init(userPrompt: String) {
+        self.userPrompt = userPrompt
+    }
+
+    /// The next step to run, or nil when the cycle is complete.
+    public mutating func nextStep() -> CognitiveStep? {
+        guard !isFinished, let kind = nextKind else { return nil }
+        return CognitiveStep(kind: kind, prompt: makePrompt(for: kind))
+    }
+
+    /// Records the output of the most recent step. The cycle advances only
+    /// when every step has produced output.
+    public mutating func record(output: String) {
+        guard let kind = nextKind else { return }
+        outputs[kind] = output
+        if nextKind == nil {
+            isFinished = true
+        }
+    }
+
+    private var nextKind: CognitiveStepKind? {
+        CognitiveStepKind.allCases.first { outputs[$0] == nil }
+    }
+
+    private func makePrompt(for kind: CognitiveStepKind) -> String {
+        switch kind {
+        case .plan:
+            return """
+            Plan your answer to the request below. List the main points in brief note form; do not write the full answer yet.
+
+            Request:
+            \(userPrompt)
+            """
+        case .draft:
+            return """
+            Write the complete answer to the request, following the plan.
+
+            Request:
+            \(userPrompt)
+
+            Plan:
+            \(outputs[.plan] ?? "")
+            """
+        case .critique:
+            return """
+            Critique the draft below. List concrete errors, missing facts, and weak arguments. Be specific and do not rewrite the answer.
+
+            Request:
+            \(userPrompt)
+
+            Draft:
+            \(outputs[.draft] ?? "")
+            """
+        case .final:
+            return """
+            Revise the draft to address the critique. Output only the final, complete answer.
+
+            Request:
+            \(userPrompt)
+
+            Draft:
+            \(outputs[.draft] ?? "")
+
+            Critique:
+            \(outputs[.critique] ?? "")
+            """
+        }
+    }
+}

--- a/Sources/TurboFieldfareApp/Core/Inference/DocumentAttachment.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/DocumentAttachment.swift
@@ -128,18 +128,27 @@ public struct DocumentAttachment: Identifiable, Sendable, Equatable, Codable {
 
 /// Text extractor for documents
 public struct DocumentExtractor: Sendable {
-    /// Maximum file size (50 MB)
+    /// Default maximum file size (50 MB)
     public static let maximumFileSize: UInt64 = 50 * 1_048_576
-    /// Maximum extracted text length (before truncation)
+    /// Default maximum extracted text length (before truncation)
     public static let maximumTextLength: Int = 500_000
-    
-    public init() {}
+
+    /// Maximum file size for this extractor
+    public let maximumFileSize: UInt64
+    /// Maximum extracted text length (before truncation)
+    public let maximumTextLength: Int
+
+    public init(maximumFileSize: UInt64 = DocumentExtractor.maximumFileSize,
+                maximumTextLength: Int = DocumentExtractor.maximumTextLength) {
+        self.maximumFileSize = maximumFileSize
+        self.maximumTextLength = maximumTextLength
+    }
     
     /// Extracts text from a file
     public func extract(from url: URL) throws -> DocumentAttachment {
         let fileSize = try fileSize(at: url)
-        guard fileSize <= Self.maximumFileSize else {
-            throw DocumentError.fileTooLarge(fileSize, maximum: Self.maximumFileSize)
+        guard fileSize <= maximumFileSize else {
+            throw DocumentError.fileTooLarge(fileSize, maximum: maximumFileSize)
         }
         
         let filename = url.lastPathComponent
@@ -154,8 +163,8 @@ public struct DocumentExtractor: Sendable {
         }
         
         // Truncate if needed
-        let truncated = text.count > Self.maximumTextLength
-        let finalText = truncated ? String(text.prefix(Self.maximumTextLength)) : text
+        let truncated = text.count > maximumTextLength
+        let finalText = truncated ? String(text.prefix(maximumTextLength)) : text
         
         return DocumentAttachment(
             filename: filename,

--- a/Sources/TurboFieldfareApp/Core/Inference/DocumentAttachment.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/DocumentAttachment.swift
@@ -3,7 +3,7 @@ import PDFKit
 import UniformTypeIdentifiers
 
 /// Supported document types for text extraction
-public enum DocumentType: String, CaseIterable, Sendable {
+public enum DocumentType: String, CaseIterable, Sendable, Codable {
     case pdf
     case docx
     case txt
@@ -72,7 +72,7 @@ public enum DocumentError: Error, LocalizedError, Sendable {
 }
 
 /// Metadata for an attached document
-public struct DocumentAttachment: Identifiable, Sendable, Equatable {
+public struct DocumentAttachment: Identifiable, Sendable, Equatable, Codable {
     public let id: UUID
     public let filename: String
     public let type: DocumentType

--- a/Sources/TurboFieldfareApp/Core/Inference/DocumentAttachment.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/DocumentAttachment.swift
@@ -190,7 +190,8 @@ public struct DocumentExtractor: Sendable {
         }
     }
     
-    /// PDF extraction via PDFKit
+    /// PDF extraction via PDFKit. Pages are separated with a `[Page N]`
+    /// marker so the model can cite where information came from.
     private func extractPDF(from url: URL) throws -> (String, Int?) {
         guard let document = PDFDocument(url: url) else {
             throw DocumentError.pdfExtractionFailed
@@ -199,7 +200,9 @@ public struct DocumentExtractor: Sendable {
         for pageIndex in 0..<document.pageCount {
             guard let page = document.page(at: pageIndex) else { continue }
             if let pageText = page.string {
-                if !text.isEmpty { text += "\n\n" }
+                if pageIndex > 0 {
+                    text += "\n\n[Page \(pageIndex + 1)]\n"
+                }
                 text += pageText
             }
         }

--- a/Sources/TurboFieldfareApp/Core/Inference/DocumentAttachment.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/DocumentAttachment.swift
@@ -1,0 +1,238 @@
+import Foundation
+import PDFKit
+import UniformTypeIdentifiers
+
+/// Supported document types for text extraction
+public enum DocumentType: String, CaseIterable, Sendable {
+    case pdf
+    case docx
+    case txt
+    case md
+    case rtf
+    
+    public var fileExtension: String { rawValue }
+    
+    public var utType: UTType {
+        switch self {
+        case .pdf: return .pdf
+        case .docx: return UTType("org.openxmlformats.wordprocessingml.document") ?? .data
+        case .txt: return .plainText
+        case .md: return UTType("net.daringfireball.markdown") ?? .plainText
+        case .rtf: return .rtf
+        }
+    }
+    
+    public var displayName: String {
+        switch self {
+        case .pdf: return "PDF"
+        case .docx: return "Word"
+        case .txt: return "Text"
+        case .md: return "Markdown"
+        case .rtf: return "RTF"
+        }
+    }
+    
+    public var icon: String {
+        switch self {
+        case .pdf: return "doc.fill"
+        case .docx: return "doc.text.fill"
+        case .txt, .md: return "doc.plaintext.fill"
+        case .rtf: return "doc.richtext.fill"
+        }
+    }
+}
+
+/// Document extraction errors
+public enum DocumentError: Error, LocalizedError, Sendable {
+    case unsupportedFormat(String)
+    case emptyDocument
+    case pdfExtractionFailed
+    case docxExtractionFailed
+    case fileTooLarge(UInt64, maximum: UInt64)
+    case readFailed(String)
+    
+    public var errorDescription: String? {
+        switch self {
+        case .unsupportedFormat(let ext):
+            return "Unsupported format: \(ext). Accepted formats: PDF, DOCX, TXT, MD, RTF."
+        case .emptyDocument:
+            return "The document contains no extractable text."
+        case .pdfExtractionFailed:
+            return "Could not extract text from the PDF. The file may be protected or corrupted."
+        case .docxExtractionFailed:
+            return "Could not extract text from the Word document."
+        case .fileTooLarge(let size, let max):
+            let sizeMB = Double(size) / 1_048_576
+            let maxMB = Double(max) / 1_048_576
+            return String(format: "File too large (%.1f MB). Maximum: %.1f MB.", sizeMB, maxMB)
+        case .readFailed(let reason):
+            return "Read error: \(reason)"
+        }
+    }
+}
+
+/// Metadata for an attached document
+public struct DocumentAttachment: Identifiable, Sendable, Equatable {
+    public let id: UUID
+    public let filename: String
+    public let type: DocumentType
+    public let fileSize: UInt64
+    public let extractedText: String
+    public let pageCount: Int?
+    public let truncated: Bool
+    public let originalLength: Int
+    
+    public init(id: UUID = UUID(),
+                filename: String,
+                type: DocumentType,
+                fileSize: UInt64,
+                extractedText: String,
+                pageCount: Int? = nil,
+                truncated: Bool = false,
+                originalLength: Int = 0) {
+        self.id = id
+        self.filename = filename
+        self.type = type
+        self.fileSize = fileSize
+        self.extractedText = extractedText
+        self.pageCount = pageCount
+        self.truncated = truncated
+        self.originalLength = originalLength
+    }
+    
+    /// Formatted size for display
+    public var formattedSize: String {
+        ByteCountFormatter.string(fromByteCount: Int64(fileSize), countStyle: .file)
+    }
+    
+    /// Truncated preview of the extracted text
+    public func preview(maxLength: Int = 200) -> String {
+        if extractedText.count <= maxLength {
+            return extractedText
+        }
+        let endIndex = extractedText.index(extractedText.startIndex, offsetBy: maxLength)
+        return String(extractedText[..<endIndex]) + "…"
+    }
+    
+    /// Text injected into the prompt, wrapped in context markers
+    public func promptContext() -> String {
+        var context = "\n\n[Document: \(filename)]\n"
+        context += extractedText
+        if truncated {
+            context += "\n[... document truncated ...]"
+        }
+        context += "\n[End of document]\n"
+        return context
+    }
+}
+
+/// Text extractor for documents
+public struct DocumentExtractor: Sendable {
+    /// Maximum file size (50 MB)
+    public static let maximumFileSize: UInt64 = 50 * 1_048_576
+    /// Maximum extracted text length (before truncation)
+    public static let maximumTextLength: Int = 500_000
+    
+    public init() {}
+    
+    /// Extracts text from a file
+    public func extract(from url: URL) throws -> DocumentAttachment {
+        let fileSize = try fileSize(at: url)
+        guard fileSize <= Self.maximumFileSize else {
+            throw DocumentError.fileTooLarge(fileSize, maximum: Self.maximumFileSize)
+        }
+        
+        let filename = url.lastPathComponent
+        let ext = url.pathExtension.lowercased()
+        guard let type = DocumentType(rawValue: ext) else {
+            throw DocumentError.unsupportedFormat(ext)
+        }
+        
+        let (text, pageCount) = try extractText(from: url, type: type)
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw DocumentError.emptyDocument
+        }
+        
+        // Truncate if needed
+        let truncated = text.count > Self.maximumTextLength
+        let finalText = truncated ? String(text.prefix(Self.maximumTextLength)) : text
+        
+        return DocumentAttachment(
+            filename: filename,
+            type: type,
+            fileSize: fileSize,
+            extractedText: finalText,
+            pageCount: pageCount,
+            truncated: truncated,
+            originalLength: text.count
+        )
+    }
+    
+    /// Extracts text according to the document type
+    private func extractText(from url: URL, type: DocumentType) throws -> (String, Int?) {
+        switch type {
+        case .pdf:
+            return try extractPDF(from: url)
+        case .docx:
+            return try extractDOCX(from: url)
+        case .txt, .md, .rtf:
+            let text = try extractPlainText(from: url)
+            return (text, nil)
+        }
+    }
+    
+    /// PDF extraction via PDFKit
+    private func extractPDF(from url: URL) throws -> (String, Int?) {
+        guard let document = PDFDocument(url: url) else {
+            throw DocumentError.pdfExtractionFailed
+        }
+        var text = ""
+        for pageIndex in 0..<document.pageCount {
+            guard let page = document.page(at: pageIndex) else { continue }
+            if let pageText = page.string {
+                if !text.isEmpty { text += "\n\n" }
+                text += pageText
+            }
+        }
+        return (text, document.pageCount)
+    }
+    
+    /// DOCX extraction via NSAttributedString
+    private func extractDOCX(from url: URL) throws -> (String, Int?) {
+        guard let data = try? Data(contentsOf: url),
+              let attributed = try? NSAttributedString(
+                data: data,
+                options: [.documentType: NSAttributedString.DocumentType.officeOpenXML],
+                documentAttributes: nil
+              ) else {
+            throw DocumentError.docxExtractionFailed
+        }
+        return (attributed.string, nil)
+    }
+    
+    /// Plain text extraction
+    private func extractPlainText(from url: URL) throws -> String {
+        guard let data = try? Data(contentsOf: url) else {
+            throw DocumentError.readFailed("Could not read the file")
+        }
+        guard let text = String(data: data, encoding: .utf8) ??
+                         String(data: data, encoding: .utf16) else {
+            throw DocumentError.readFailed("Unrecognized text encoding")
+        }
+        return text
+    }
+    
+    /// File size
+    private func fileSize(at url: URL) throws -> UInt64 {
+        let attrs = try FileManager.default.attributesOfItem(atPath: url.path)
+        guard let size = attrs[.size] as? NSNumber else {
+            throw DocumentError.readFailed("File size unavailable")
+        }
+        return size.uint64Value
+    }
+    
+    /// Accepted file types for the picker
+    public static var supportedTypes: [UTType] {
+        DocumentType.allCases.map(\.utType)
+    }
+}

--- a/Sources/TurboFieldfareApp/Core/Inference/Retrieval.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/Retrieval.swift
@@ -1,0 +1,99 @@
+import Foundation
+
+/// A slice of an extracted document used for retrieval.
+public struct DocumentChunk: Equatable, Sendable, Identifiable {
+    public let id = UUID()
+    public let sourceDocumentID: UUID
+    public let text: String
+
+    public init(sourceDocumentID: UUID, text: String) {
+        self.sourceDocumentID = sourceDocumentID
+        self.text = text
+    }
+}
+
+/// Splits extracted document text into overlapping word chunks, so long
+/// documents can be trimmed to the relevant parts instead of overflowing
+/// the context window.
+public enum DocumentChunker {
+    /// Target words per chunk.
+    public static let targetWordCount = 600
+    /// Words of overlap between consecutive chunks.
+    public static let overlapWordCount = 60
+
+    public static func chunk(_ text: String,
+                             documentID: UUID,
+                             targetWordCount: Int = targetWordCount,
+                             overlapWordCount: Int = overlapWordCount) -> [DocumentChunk] {
+        let words = text.split(whereSeparator: { $0.isWhitespace })
+        guard !words.isEmpty else { return [] }
+        guard words.count > targetWordCount else {
+            return [DocumentChunk(sourceDocumentID: documentID, text: text)]
+        }
+
+        let step = max(1, targetWordCount - overlapWordCount)
+        var chunks: [DocumentChunk] = []
+        var start = 0
+        while start < words.count {
+            let end = min(start + targetWordCount, words.count)
+            let chunkWords = words[start..<end]
+            chunks.append(DocumentChunk(
+                sourceDocumentID: documentID,
+                text: chunkWords.joined(separator: " ")))
+            if end == words.count { break }
+            start += step
+        }
+        return chunks
+    }
+}
+
+/// Lightweight TF-IDF retriever over document chunks. Pure Swift, no
+/// dependencies: enough to pick the chunks most relevant to a prompt when
+/// the full documents would not fit in the context window.
+public enum TfIdfRetriever {
+    /// Returns the `limit` most relevant chunks for `query`, best first.
+    public static func topChunks(_ chunks: [DocumentChunk],
+                                 query: String,
+                                 limit: Int) -> [DocumentChunk] {
+        guard !chunks.isEmpty else { return [] }
+        let chunkWordLists = chunks.map { tokenize($0.text) }
+        let queryTerms = Set(tokenize(query))
+        guard !queryTerms.isEmpty else { return Array(chunks.prefix(limit)) }
+
+        // Inverse document frequency over the chunk collection.
+        var documentFrequencies: [String: Int] = [:]
+        for words in chunkWordLists {
+            for term in Set(words) {
+                documentFrequencies[term, default: 0] += 1
+            }
+        }
+        let chunkCount = chunks.count
+        func idf(_ term: String) -> Double {
+            log(Double(chunkCount) / (1 + Double(documentFrequencies[term] ?? 0)))
+        }
+
+        // Score each chunk by the summed tf-idf of the query terms.
+        var scored: [(index: Int, score: Double)] = []
+        for (index, words) in chunkWordLists.enumerated() {
+            let total = Double(max(1, words.count))
+            let termFrequency = Dictionary(grouping: words, by: { $0 })
+                .mapValues { Double($0.count) / total }
+            var score = 0.0
+            for term in queryTerms {
+                score += (termFrequency[term] ?? 0) * idf(term)
+            }
+            if score > 0 {
+                scored.append((index, score))
+            }
+        }
+        scored.sort { $0.score > $1.score }
+        return scored.prefix(limit).map { chunks[$0.index] }
+    }
+
+    private static func tokenize(_ text: String) -> [String] {
+        text.lowercased()
+            .split(whereSeparator: { !$0.isLetter && !$0.isNumber })
+            .map(String.init)
+            .filter { $0.count > 1 }
+    }
+}

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -64,6 +64,8 @@ public final class AppModel {
     
     /// Persistent store of past conversations
     public private(set) var conversationStore: ConversationStore
+    /// Persistent library of extracted documents
+    public private(set) var documentLibrary: DocumentLibrary
     
     /// Conversation currently loaded from history
     public private(set) var activeConversationID: UUID?
@@ -99,7 +101,8 @@ public final class AppModel {
                 installer: any AppModelInstallerClient = RepackModelInstallerClient(),
                 memorySampler: AppMemorySampler = AppMemorySampler(),
                 settingsPersistenceEnabled: Bool = false,
-                conversationStore: ConversationStore? = nil) {
+                conversationStore: ConversationStore? = nil,
+                documentLibrary: DocumentLibrary? = nil) {
         let directory = (modelDirectory ?? AppModelLocation.defaultURL()).standardizedFileURL
         let installETAClock = SuspendingClock()
         let settings = settingsPersistenceEnabled
@@ -126,6 +129,7 @@ public final class AppModel {
         self.memorySampler = memorySampler
         self.settingsPersistenceEnabled = settingsPersistenceEnabled
         self.conversationStore = conversationStore ?? ConversationStore()
+        self.documentLibrary = documentLibrary ?? DocumentLibrary()
         self.installETAClock = installETAClock
         self.installETAOrigin = installETAClock.now
         refreshInstallReadiness()
@@ -1148,6 +1152,10 @@ public final class AppModel {
                 self.isExtractingAttachment = false
                 self.attachments.append(contentsOf: newAttachments)
                 self.attachmentErrors = errors
+                // Cache extracted documents in the persistent library.
+                for attachment in newAttachments {
+                    self.documentLibrary.upsert(attachment)
+                }
             }
         }
     }
@@ -1174,14 +1182,27 @@ public final class AppModel {
         attachmentErrors.remove(at: index)
     }
     
-    /// Full prompt text with attached document content injected
+    /// Full prompt text with attached document content injected. When the
+    /// full documents would overflow the context window, only the chunks most
+    /// relevant to the prompt are kept (lightweight retrieval).
     public var promptWithAttachments: String {
         guard !attachments.isEmpty else { return promptText }
-        var context = promptText
-        for attachment in attachments {
-            context += attachment.promptContext()
+        let fullContext = attachments.map { $0.promptContext() }.joined()
+        let estimatedTokens = (promptText.count + fullContext.count + 3) / 4
+        guard estimatedTokens > maxContextTokens * 2 else {
+            return promptText + fullContext
         }
-        return context
+        let chunks = attachments.flatMap {
+            DocumentChunker.chunk($0.extractedText, documentID: $0.id)
+        }
+        let selected = TfIdfRetriever.topChunks(chunks, query: promptText, limit: 16)
+        guard !selected.isEmpty else { return promptText + fullContext }
+        var context = "\n\n[Selected document excerpts relevant to the request]\n"
+        for chunk in selected {
+            context += "\n" + chunk.text + "\n"
+        }
+        context += "\n[End of excerpts]\n"
+        return promptText + context
     }
     
     /// Prompt that continues a loaded conversation: the full turn history,

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -25,6 +25,10 @@ public final class AppModel {
     public var topP: Double = 0.95
     public private(set) var newlineShortcut: AppNewlineShortcut = .return
     public private(set) var showPromptExamples: Bool = true
+    /// Maximum file size accepted for document attachments
+    public var maxAttachmentFileSize: UInt64 = DocumentExtractor.maximumFileSize
+    /// Maximum extracted text length for document attachments
+    public var maxAttachmentTextLength: Int = DocumentExtractor.maximumTextLength
     public var diagnostics: AppDiagnostics?
     public var error: AppInferenceError?
     public var installState: AppModelInstallState = .idle
@@ -101,6 +105,8 @@ public final class AppModel {
         self.topP = settings.topP
         self.newlineShortcut = settings.newlineShortcut
         self.showPromptExamples = settings.showPromptExamples
+        self.maxAttachmentFileSize = settings.maxAttachmentFileSize
+        self.maxAttachmentTextLength = settings.maxAttachmentTextLength
         self.installationStatus = AppModelInstallationProbe.status(at: directory)
         self.client = client
         self.installer = installer
@@ -648,6 +654,8 @@ public final class AppModel {
         topP = settings.topP
         newlineShortcut = settings.newlineShortcut
         showPromptExamples = settings.showPromptExamples
+        maxAttachmentFileSize = settings.maxAttachmentFileSize
+        maxAttachmentTextLength = settings.maxAttachmentTextLength
     }
 
     private func persistSettings() {
@@ -662,7 +670,9 @@ public final class AppModel {
             topP: topP,
             prefillEnabled: runtimeOptions.prefillEnabled,
             newlineShortcut: newlineShortcut,
-            showPromptExamples: showPromptExamples)
+            showPromptExamples: showPromptExamples,
+            maxAttachmentFileSize: maxAttachmentFileSize,
+            maxAttachmentTextLength: maxAttachmentTextLength)
         let modelDirectory = URL(fileURLWithPath: modelPathText, isDirectory: true)
         try? MacAppSettingsFileStore.save(
             settings,
@@ -893,9 +903,11 @@ public final class AppModel {
         guard !urls.isEmpty else { return }
         isExtractingAttachment = true
         attachmentErrors = []
+        // Capture the configured limits before leaving the main actor.
+        let extractor = DocumentExtractor(maximumFileSize: maxAttachmentFileSize,
+                                          maximumTextLength: maxAttachmentTextLength)
         
-        Task.detached(priority: .userInitiated) { [weak self] in
-            let extractor = DocumentExtractor()
+        Task.detached(priority: .userInitiated) { [weak self, extractor] in
             var newAttachments: [DocumentAttachment] = []
             var errors: [String] = []
             
@@ -1035,5 +1047,29 @@ public final class AppModel {
         if activeConversationID == conversation.id {
             newConversation()
         }
+    }
+    
+    /// Renames a conversation in the history
+    public func renameConversation(_ conversation: Conversation, title: String) {
+        let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return }
+        conversationStore.upsert(conversation.replacing(title: trimmed))
+    }
+    
+    /// Pins or unpins a conversation so it stays at the top of the list
+    public func togglePin(_ conversation: Conversation) {
+        conversationStore.upsert(conversation.replacing(isPinned: !conversation.isPinned))
+    }
+    
+    /// Exports all conversations to a JSON file
+    public func exportConversations(to url: URL) throws {
+        let data = try conversationStore.exportJSON()
+        try data.write(to: url, options: .atomic)
+    }
+    
+    /// Imports conversations from an exported JSON file; returns the count
+    public func importConversations(from url: URL) throws -> Int {
+        let data = try Data(contentsOf: url)
+        return try conversationStore.importJSON(data)
     }
 }

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -64,6 +64,12 @@ public final class AppModel {
     /// Conversation currently loaded from history
     public private(set) var activeConversationID: UUID?
 
+    // MARK: - Cognitive mode
+    
+    /// Whether generation runs the advanced cognitive cycle (plan, draft,
+    /// critique, final revision) instead of a single pass.
+    public var cognitiveModeEnabled = false
+
     private let client: any AppInferenceClient
     private let installer: any AppModelInstallerClient
     private var runTask: Task<Void, Never>?
@@ -107,6 +113,7 @@ public final class AppModel {
         self.showPromptExamples = settings.showPromptExamples
         self.maxAttachmentFileSize = settings.maxAttachmentFileSize
         self.maxAttachmentTextLength = settings.maxAttachmentTextLength
+        self.cognitiveModeEnabled = settings.cognitiveModeEnabled
         self.installationStatus = AppModelInstallationProbe.status(at: directory)
         self.client = client
         self.installer = installer
@@ -656,6 +663,7 @@ public final class AppModel {
         showPromptExamples = settings.showPromptExamples
         maxAttachmentFileSize = settings.maxAttachmentFileSize
         maxAttachmentTextLength = settings.maxAttachmentTextLength
+        cognitiveModeEnabled = settings.cognitiveModeEnabled
     }
 
     private func persistSettings() {
@@ -672,7 +680,8 @@ public final class AppModel {
             newlineShortcut: newlineShortcut,
             showPromptExamples: showPromptExamples,
             maxAttachmentFileSize: maxAttachmentFileSize,
-            maxAttachmentTextLength: maxAttachmentTextLength)
+            maxAttachmentTextLength: maxAttachmentTextLength,
+            cognitiveModeEnabled: cognitiveModeEnabled)
         let modelDirectory = URL(fileURLWithPath: modelPathText, isDirectory: true)
         try? MacAppSettingsFileStore.save(
             settings,
@@ -751,7 +760,11 @@ public final class AppModel {
             return
         }
         persistSettings()
-        runStandardGeneration(request: request)
+        if cognitiveModeEnabled {
+            runCognitiveCycle(request: request)
+        } else {
+            runStandardGeneration(request: request)
+        }
     }
     
     private func runStandardGeneration(request: AppGenerationRequest) {
@@ -787,6 +800,147 @@ public final class AppModel {
                 await self.finishStreamFailure(.unknown("\(error)"))
             }
         }
+    }
+    
+    /// Runs the advanced cognitive cycle: plan, draft, critique, final
+    /// revision. Each pass streams into the output pane under its own
+    /// header; the conversation history stores the final revision.
+    private func runCognitiveCycle(request: AppGenerationRequest) {
+        generationTranscriptMailbox?.reset()
+        outputPromptText = request.prompt
+        outputText = ""
+        diagnostics = nil
+        error = nil
+        hasHandledTerminalEvent = false
+        activeRunRuntimeKey = AppLoadedRuntimeKey(
+            modelDirectory: request.modelDirectory,
+            maxContextTokens: request.maxContextTokens,
+            options: request.runtimeOptions,
+            forceLogitsHead: !request.isPureGreedy)
+        isCancellationPending = false
+        liveTokenCount = 0
+        liveElapsedDecodeSeconds = 0
+        livePrefillDone = 0
+        livePrefillTotal = 0
+        liveMemoryBytes = nil
+        phase = .prefill
+        runState = .running
+
+        runTask = Task.detached { [weak self, client, request] in
+            guard let self else { return }
+            var engine = CognitiveCycleEngine(userPrompt: request.prompt)
+            var finalText = ""
+            var finalDiagnostics: AppDiagnostics?
+            var cancelled = false
+
+            while let step = engine.nextStep() {
+                var passRequest = request
+                passRequest.prompt = step.prompt
+
+                // Reset the per-pass counters and open the pass in the output.
+                await MainActor.run {
+                    self.phase = .prefill
+                    self.liveTokenCount = 0
+                    self.liveElapsedDecodeSeconds = 0
+                    self.livePrefillDone = 0
+                    self.livePrefillTotal = 0
+                    if !self.outputText.isEmpty { self.outputText += "\n\n" }
+                    self.outputText += "— \(step.kind.header) —\n"
+                }
+
+                var passText = ""
+                var passDiagnostics: AppDiagnostics?
+                var passCancelled = false
+                var passFailed = false
+
+                do {
+                    for try await event in client.generate(passRequest) {
+                        switch event {
+                        case .prefillProgress(let done, let total):
+                            await MainActor.run {
+                                self.phase = .prefill
+                                self.livePrefillDone = done
+                                self.livePrefillTotal = total
+                            }
+                        case .token(let token):
+                            passText += token.textDelta
+                            await MainActor.run {
+                                self.phase = .decode
+                                self.liveTokenCount = token.index + 1
+                                self.liveElapsedDecodeSeconds = token.elapsedDecodeSeconds
+                                if let reporter = self.client as? any AppInferenceMemoryReporting {
+                                    self.liveMemoryBytes = reporter.currentInferenceMemoryBytes
+                                } else {
+                                    self.liveMemoryBytes = self.memorySampler.sample()
+                                }
+                                if !token.textDelta.isEmpty {
+                                    self.outputText += token.textDelta
+                                }
+                            }
+                        case .finished(let diagnostics):
+                            passDiagnostics = diagnostics
+                        case .cancelled(let diagnostics):
+                            passDiagnostics = diagnostics
+                            passCancelled = true
+                        case .failed(let appError, let partial):
+                            passDiagnostics = partial
+                            await self.finishCognitiveCycleFailure(appError, partial: partial)
+                            passFailed = true
+                        }
+                        if passCancelled || passFailed { break }
+                    }
+                } catch let appError as AppInferenceError {
+                    await self.finishCognitiveCycleFailure(appError, partial: passDiagnostics)
+                    passFailed = true
+                } catch {
+                    await self.finishCognitiveCycleFailure(.unknown("\(error)"), partial: passDiagnostics)
+                    passFailed = true
+                }
+
+                if passCancelled {
+                    cancelled = true
+                    await self.finishCognitiveCycleCancelled(passDiagnostics)
+                    break
+                }
+                if passFailed { return }
+
+                engine.record(output: passText)
+                finalText = passText
+                finalDiagnostics = passDiagnostics
+            }
+
+            if !cancelled {
+                let handled = await MainActor.run { self.hasHandledTerminalEvent }
+                if !handled {
+                    await self.finishCognitiveCycle(finalDiagnostics, response: finalText)
+                }
+            }
+        }
+    }
+    
+    private func finishCognitiveCycle(_ diagnostics: AppDiagnostics?, response: String) {
+        guard !hasHandledTerminalEvent else { return }
+        hasHandledTerminalEvent = true
+        self.diagnostics = diagnostics
+        finishTerminalRun()
+        saveCurrentConversation(diagnostic: diagnostics, response: response)
+    }
+    
+    private func finishCognitiveCycleCancelled(_ diagnostics: AppDiagnostics?) {
+        guard !hasHandledTerminalEvent else { return }
+        hasHandledTerminalEvent = true
+        self.diagnostics = diagnostics
+        error = .cancelled
+        finishTerminalRun()
+        saveCurrentConversation(diagnostic: diagnostics)
+    }
+    
+    private func finishCognitiveCycleFailure(_ appError: AppInferenceError, partial: AppDiagnostics?) {
+        guard !hasHandledTerminalEvent else { return }
+        hasHandledTerminalEvent = true
+        diagnostics = partial
+        error = appError
+        finishTerminalRun()
     }
 
     public func cancel() {
@@ -989,7 +1143,7 @@ public final class AppModel {
     // MARK: - Conversation history management
     
     /// Saves the current conversation to history
-    public func saveCurrentConversation(diagnostic: AppDiagnostics? = nil) {
+    public func saveCurrentConversation(diagnostic: AppDiagnostics? = nil, response: String? = nil) {
         guard !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         
         let now = Date()
@@ -998,13 +1152,14 @@ public final class AppModel {
         let active = activeConversationID.flatMap { id in
             conversationStore.conversations.first { $0.id == id }
         }
+        let savedResponse = response ?? outputText
         let conversation: Conversation
         if let active, active.prompt == promptText {
             conversation = Conversation(
                 id: active.id,
                 title: active.title,
                 prompt: promptText,
-                response: outputText,
+                response: savedResponse,
                 createdAt: active.createdAt,
                 updatedAt: now,
                 promptTokenCount: diagnostic?.promptTokenCount,
@@ -1017,7 +1172,7 @@ public final class AppModel {
                 id: UUID(),
                 title: Conversation.title(from: promptText),
                 prompt: promptText,
-                response: outputText,
+                response: savedResponse,
                 createdAt: now,
                 updatedAt: now,
                 promptTokenCount: diagnostic?.promptTokenCount,

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -1288,6 +1288,32 @@ public final class AppModel {
         }
     }
     
+    /// Forks a conversation into a new entry: same turns (up to the given
+    /// turn when provided), a "Fork of" title, and a link to the source.
+    /// The fork becomes the active conversation, ready to continue.
+    public func forkConversation(_ conversation: Conversation,
+                                 upTo turn: Turn? = nil) {
+        guard !isRunning else { return }
+        let forkedTurns: [Turn]
+        if let turn, let index = conversation.turns.firstIndex(where: { $0.id == turn.id }) {
+            forkedTurns = Array(conversation.turns[...index])
+        } else {
+            forkedTurns = conversation.turns
+        }
+        let now = Date()
+        let fork = Conversation(
+            title: "Fork of \(conversation.title)",
+            turns: forkedTurns,
+            createdAt: now,
+            updatedAt: now,
+            attachments: conversation.attachments,
+            maxNewTokens: conversation.maxNewTokens,
+            parentConversationID: conversation.id
+        )
+        conversationStore.upsert(fork)
+        loadConversation(fork)
+    }
+    
     /// Renames a conversation in the history
     public func renameConversation(_ conversation: Conversation, title: String) {
         let trimmed = title.trimmingCharacters(in: .whitespacesAndNewlines)
@@ -1310,5 +1336,27 @@ public final class AppModel {
     public func importConversations(from url: URL) throws -> Int {
         let data = try Data(contentsOf: url)
         return try conversationStore.importJSON(data)
+    }
+    
+    /// Renders a conversation as Markdown (title, metadata, labelled turns).
+    public func exportConversationMarkdown(_ conversation: Conversation) -> String {
+        var markdown = "# \(conversation.title)\n\n"
+        let formatter = DateFormatter()
+        formatter.dateStyle = .medium
+        formatter.timeStyle = .short
+        markdown += "*\(formatter.string(from: conversation.updatedAt))*\n"
+        if let parentID = conversation.parentConversationID {
+            markdown += "_Fork of \(parentID.uuidString.prefix(8))_\n"
+        }
+        markdown += "\n"
+        for turn in conversation.turns {
+            switch turn.role {
+            case .user:
+                markdown += "## User\n\n\(turn.text)\n\n"
+            case .model:
+                markdown += "## Assistant\n\n\(turn.text)\n\n"
+            }
+        }
+        return markdown.trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
     }
 }

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -899,6 +899,14 @@ public final class AppModel {
             var errors: [String] = []
             
             for url in urls {
+                // Enable secure access for sandboxed files and always release
+                // it when extraction finishes, regardless of the outcome.
+                let isAccessing = url.startAccessingSecurityScopedResource()
+                defer {
+                    if isAccessing {
+                        url.stopAccessingSecurityScopedResource()
+                    }
+                }
                 do {
                     let attachment = try extractor.extract(from: url)
                     newAttachments.append(attachment)

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -47,8 +47,8 @@ public final class AppModel {
     
     /// Documents attached to the current prompt
     public var attachments: [DocumentAttachment] = []
-    /// Attachment error for the current prompt
-    public var attachmentError: DocumentError?
+    /// Per-file extraction errors for the current prompt
+    public var attachmentErrors: [String] = []
     /// Whether an attachment extraction is in progress
     public private(set) var isExtractingAttachment: Bool = false
 
@@ -82,7 +82,8 @@ public final class AppModel {
                 client: any AppInferenceClient = RealInferenceClient(),
                 installer: any AppModelInstallerClient = RepackModelInstallerClient(),
                 memorySampler: AppMemorySampler = AppMemorySampler(),
-                settingsPersistenceEnabled: Bool = false) {
+                settingsPersistenceEnabled: Bool = false,
+                conversationStore: ConversationStore? = nil) {
         let directory = (modelDirectory ?? AppModelLocation.defaultURL()).standardizedFileURL
         let installETAClock = SuspendingClock()
         let settings = settingsPersistenceEnabled
@@ -105,7 +106,7 @@ public final class AppModel {
         self.installer = installer
         self.memorySampler = memorySampler
         self.settingsPersistenceEnabled = settingsPersistenceEnabled
-        self.conversationStore = ConversationStore()
+        self.conversationStore = conversationStore ?? ConversationStore()
         self.installETAClock = installETAClock
         self.installETAOrigin = installETAClock.now
         refreshInstallReadiness()
@@ -891,7 +892,7 @@ public final class AppModel {
     public func attachDocuments(from urls: [URL]) {
         guard !urls.isEmpty else { return }
         isExtractingAttachment = true
-        attachmentError = nil
+        attachmentErrors = []
         
         Task.detached(priority: .userInitiated) { [weak self] in
             let extractor = DocumentExtractor()
@@ -921,13 +922,7 @@ public final class AppModel {
                 guard let self else { return }
                 self.isExtractingAttachment = false
                 self.attachments.append(contentsOf: newAttachments)
-                
-                if !errors.isEmpty {
-                    // Use the first error as the main error
-                    if let firstError = errors.first {
-                        self.attachmentError = .readFailed(firstError)
-                    }
-                }
+                self.attachmentErrors = errors
             }
         }
     }
@@ -940,7 +935,7 @@ public final class AppModel {
     /// Removes all attached documents
     public func clearAttachments() {
         attachments.removeAll()
-        attachmentError = nil
+        attachmentErrors = []
     }
     
     /// Full prompt text with attached document content injected
@@ -969,19 +964,40 @@ public final class AppModel {
     public func saveCurrentConversation(diagnostic: AppDiagnostics? = nil) {
         guard !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         
-        let title = Conversation.title(from: promptText)
         let now = Date()
-        let conversation = Conversation(
-            id: activeConversationID ?? UUID(),
-            title: title,
-            prompt: promptText,
-            response: outputText,
-            createdAt: now,
-            updatedAt: now,
-            promptTokenCount: diagnostic?.promptTokenCount,
-            generatedTokenCount: diagnostic?.generatedTokens,
-            stopReason: diagnostic?.stopReason.rawValue
-        )
+        // Regenerating the same prompt updates the active conversation instead
+        // of creating a duplicate entry; a different prompt starts a new one.
+        let active = activeConversationID.flatMap { id in
+            conversationStore.conversations.first { $0.id == id }
+        }
+        let conversation: Conversation
+        if let active, active.prompt == promptText {
+            conversation = Conversation(
+                id: active.id,
+                title: active.title,
+                prompt: promptText,
+                response: outputText,
+                createdAt: active.createdAt,
+                updatedAt: now,
+                promptTokenCount: diagnostic?.promptTokenCount,
+                generatedTokenCount: diagnostic?.generatedTokens,
+                stopReason: diagnostic?.stopReason.rawValue,
+                attachments: attachments
+            )
+        } else {
+            conversation = Conversation(
+                id: UUID(),
+                title: Conversation.title(from: promptText),
+                prompt: promptText,
+                response: outputText,
+                createdAt: now,
+                updatedAt: now,
+                promptTokenCount: diagnostic?.promptTokenCount,
+                generatedTokenCount: diagnostic?.generatedTokens,
+                stopReason: diagnostic?.stopReason.rawValue,
+                attachments: attachments
+            )
+        }
         
         conversationStore.upsert(conversation)
         activeConversationID = conversation.id
@@ -994,6 +1010,9 @@ public final class AppModel {
         promptText = conversation.prompt
         outputPromptText = conversation.prompt
         outputText = conversation.response
+        // Restore attached documents so regenerating keeps the context
+        attachments = conversation.attachments
+        attachmentErrors = []
         // Clear the previous generation state
         diagnostics = nil
         error = nil

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -551,21 +551,47 @@ public final class AppModel {
         }
     }
 
+    /// Appends a dated line to the install journal for diagnostics.
+    private func appendInstallLog(_ message: String) {
+        let folder = ConversationStore.defaultStorageURL().deletingLastPathComponent()
+        let url = folder.appendingPathComponent("install.log")
+        let line = "[\(Self.installLogFormatter.string(from: Date()))] \(message)\n"
+        if let handle = try? FileHandle(forWritingTo: url) {
+            handle.seekToEndOfFile()
+            handle.write(Data(line.utf8))
+            try? handle.close()
+        } else {
+            try? FileManager.default.createDirectory(
+                at: folder, withIntermediateDirectories: true)
+            try? Data(line.utf8).write(to: url, options: .atomic)
+        }
+    }
+
+    private static let installLogFormatter: ISO8601DateFormatter = {
+        let formatter = ISO8601DateFormatter()
+        formatter.formatOptions = [.withInternetDateTime]
+        return formatter
+    }()
+
     private func applyInstallEvent(_ event: AppModelInstallEvent, generation: UInt64) {
         guard generation == installGeneration else { return }
         switch event {
         case .checking:
             resetInstallETA()
             installState = .checking
+            appendInstallLog("install check")
         case .downloadingMetadata:
             resetInstallETA()
             installState = .downloadingMetadata
+            appendInstallLog("downloading metadata")
         case .planning:
             resetInstallETA()
             installState = .planning
+            appendInstallLog("planning")
         case .reservingOutput:
             resetInstallETA()
             installState = .reservingOutput
+            appendInstallLog("reserving output")
         case .copyingPayload(let reused, let downloadedThisRun, let total):
             installState = .copyingPayload(
                 reusedBytes: reused,
@@ -578,12 +604,15 @@ public final class AppModel {
         case .hashingOutput(let file):
             resetInstallETA()
             installState = .hashingOutput(file)
+            appendInstallLog("hashing output \((file as NSString).lastPathComponent)")
         case .finalizing:
             resetInstallETA()
             installState = .finalizing
+            appendInstallLog("finalizing")
         case .installed(let directory):
             resetInstallETA()
             let directory = directory.standardizedFileURL
+            appendInstallLog("installed at \(directory.path)")
             installationStatus = AppModelInstallationProbe.status(
                 at: directory,
                 descriptor: installer.descriptor)
@@ -698,6 +727,7 @@ public final class AppModel {
         guard generation == installGeneration else { return }
         installTask = nil
         resetInstallETA()
+        appendInstallLog("failed: \(error)")
         let hasSavedDownload = hasPartialModelDownload
         installState = hasSavedDownload ? .recoverable("\(error)") : .failed("\(error)")
         if let repackError = error as? RepackError,
@@ -1224,7 +1254,10 @@ public final class AppModel {
                 stopReason: diagnostic?.stopReason.rawValue,
                 attachments: attachments,
                 isPinned: active.isPinned,
-                maxNewTokens: maxNewTokensOverride ?? active.maxNewTokens
+                maxNewTokens: maxNewTokensOverride ?? active.maxNewTokens,
+                parentConversationID: active.parentConversationID,
+                isTemplate: active.isTemplate,
+                tags: active.tags
             )
         } else {
             conversation = Conversation(
@@ -1324,6 +1357,24 @@ public final class AppModel {
     /// Pins or unpins a conversation so it stays at the top of the list
     public func togglePin(_ conversation: Conversation) {
         conversationStore.upsert(conversation.replacing(isPinned: !conversation.isPinned))
+    }
+    
+    /// Marks or unmarks a conversation as a reusable template.
+    public func setTemplate(_ conversation: Conversation, isTemplate: Bool) {
+        guard let current = conversationStore.conversations
+            .first(where: { $0.id == conversation.id }) else { return }
+        conversationStore.upsert(current.replacing(isTemplate: isTemplate))
+    }
+    
+    /// Replaces the tags of a conversation.
+    public func setTags(_ conversation: Conversation, tags: [String]) {
+        guard let current = conversationStore.conversations
+            .first(where: { $0.id == conversation.id }) else { return }
+        let normalized = tags
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        let unique = Array(NSOrderedSet(array: normalized)) as? [String] ?? normalized
+        conversationStore.upsert(current.replacing(tags: unique))
     }
     
     /// Exports all conversations to a JSON file

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -42,6 +42,23 @@ public final class AppModel {
     public private(set) var livePrefillTotal: Int = 0
     public private(set) var liveMemoryBytes: UInt64?
     public private(set) var isCancellationPending: Bool = false
+    
+    // MARK: - Document attachments
+    
+    /// Documents attached to the current prompt
+    public var attachments: [DocumentAttachment] = []
+    /// Attachment error for the current prompt
+    public var attachmentError: DocumentError?
+    /// Whether an attachment extraction is in progress
+    public private(set) var isExtractingAttachment: Bool = false
+
+    // MARK: - Conversation history
+    
+    /// Persistent store of past conversations
+    public private(set) var conversationStore: ConversationStore
+    
+    /// Conversation currently loaded from history
+    public private(set) var activeConversationID: UUID?
 
     private let client: any AppInferenceClient
     private let installer: any AppModelInstallerClient
@@ -88,6 +105,7 @@ public final class AppModel {
         self.installer = installer
         self.memorySampler = memorySampler
         self.settingsPersistenceEnabled = settingsPersistenceEnabled
+        self.conversationStore = ConversationStore()
         self.installETAClock = installETAClock
         self.installETAOrigin = installETAClock.now
         refreshInstallReadiness()
@@ -722,7 +740,10 @@ public final class AppModel {
             return
         }
         persistSettings()
-
+        runStandardGeneration(request: request)
+    }
+    
+    private func runStandardGeneration(request: AppGenerationRequest) {
         generationTranscriptMailbox?.reset()
         outputPromptText = request.prompt
         outputText = ""
@@ -764,9 +785,11 @@ public final class AppModel {
     }
 
     public func makeRequest() throws -> AppGenerationRequest {
+        // Append attached document text to the prompt when present
+        let effectivePrompt = hasAttachments ? promptWithAttachments : promptText
         let request = AppGenerationRequest(
             modelDirectory: URL(fileURLWithPath: modelPathText),
-            prompt: promptText,
+            prompt: effectivePrompt,
             maxNewTokens: maxNewTokensOverride ?? maxContextTokens,
             maxContextTokens: maxContextTokens,
             temperature: Float(temperature),
@@ -813,6 +836,7 @@ public final class AppModel {
         materializeServiceTranscript()
         self.diagnostics = diagnostics
         finishTerminalRun()
+        saveCurrentConversation(diagnostic: diagnostics)  // History
     }
 
     private func finishCancelled(_ diagnostics: AppDiagnostics) {
@@ -822,6 +846,7 @@ public final class AppModel {
         self.diagnostics = diagnostics
         error = .cancelled
         finishTerminalRun()
+        saveCurrentConversation(diagnostic: diagnostics)  // History (stopped run)
     }
 
     private func materializeServiceTranscript() {
@@ -858,5 +883,130 @@ public final class AppModel {
     private func clearUnloadTask(generation: UInt64) {
         guard generation == unloadGeneration else { return }
         unloadTask = nil
+    }
+    
+    // MARK: - Document attachment management
+    
+    /// Attaches documents to the current prompt
+    public func attachDocuments(from urls: [URL]) {
+        guard !urls.isEmpty else { return }
+        isExtractingAttachment = true
+        attachmentError = nil
+        
+        Task.detached(priority: .userInitiated) { [weak self] in
+            let extractor = DocumentExtractor()
+            var newAttachments: [DocumentAttachment] = []
+            var errors: [String] = []
+            
+            for url in urls {
+                do {
+                    let attachment = try extractor.extract(from: url)
+                    newAttachments.append(attachment)
+                } catch let error as DocumentError {
+                    errors.append("\(url.lastPathComponent): \(error.localizedDescription)")
+                } catch {
+                    errors.append("\(url.lastPathComponent): \(error.localizedDescription)")
+                }
+            }
+            
+            await MainActor.run { [weak self] in
+                guard let self else { return }
+                self.isExtractingAttachment = false
+                self.attachments.append(contentsOf: newAttachments)
+                
+                if !errors.isEmpty {
+                    // Use the first error as the main error
+                    if let firstError = errors.first {
+                        self.attachmentError = .readFailed(firstError)
+                    }
+                }
+            }
+        }
+    }
+    
+    /// Removes an attached document
+    public func removeAttachment(_ attachment: DocumentAttachment) {
+        attachments.removeAll { $0.id == attachment.id }
+    }
+    
+    /// Removes all attached documents
+    public func clearAttachments() {
+        attachments.removeAll()
+        attachmentError = nil
+    }
+    
+    /// Full prompt text with attached document content injected
+    public var promptWithAttachments: String {
+        guard !attachments.isEmpty else { return promptText }
+        var context = promptText
+        for attachment in attachments {
+            context += attachment.promptContext()
+        }
+        return context
+    }
+    
+    /// Total size of attached documents in bytes
+    public var totalAttachmentBytes: UInt64 {
+        attachments.reduce(0) { $0 + $1.fileSize }
+    }
+    
+    /// Whether the prompt has attached documents
+    public var hasAttachments: Bool {
+        !attachments.isEmpty
+    }
+    
+    // MARK: - Conversation history management
+    
+    /// Saves the current conversation to history
+    public func saveCurrentConversation(diagnostic: AppDiagnostics? = nil) {
+        guard !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
+        
+        let title = Conversation.title(from: promptText)
+        let now = Date()
+        let conversation = Conversation(
+            id: activeConversationID ?? UUID(),
+            title: title,
+            prompt: promptText,
+            response: outputText,
+            createdAt: now,
+            updatedAt: now,
+            promptTokenCount: diagnostic?.promptTokenCount,
+            generatedTokenCount: diagnostic?.generatedTokens,
+            stopReason: diagnostic?.stopReason.rawValue
+        )
+        
+        conversationStore.upsert(conversation)
+        activeConversationID = conversation.id
+    }
+    
+    /// Loads an existing conversation from history
+    public func loadConversation(_ conversation: Conversation) {
+        guard !isRunning else { return }
+        activeConversationID = conversation.id
+        promptText = conversation.prompt
+        outputPromptText = conversation.prompt
+        outputText = conversation.response
+        // Clear the previous generation state
+        diagnostics = nil
+        error = nil
+        phase = .idle
+    }
+    
+    /// Starts a new empty conversation
+    public func newConversation() {
+        guard !isRunning else { return }
+        activeConversationID = nil
+        promptText = ""
+        outputPromptText = ""
+        outputText = ""
+        clearAttachments()
+    }
+    
+    /// Deletes a conversation from history
+    public func deleteConversation(_ conversation: Conversation) {
+        conversationStore.delete(conversation)
+        if activeConversationID == conversation.id {
+            newConversation()
+        }
     }
 }

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -867,11 +867,17 @@ public final class AppModel {
         runTask = Task.detached { [weak self, client, request] in
             guard let self else { return }
             var engine = CognitiveCycleEngine(userPrompt: request.prompt)
-            var finalText = ""
+            var draftText = ""
             var finalDiagnostics: AppDiagnostics?
             var cancelled = false
 
             while let step = engine.nextStep() {
+                // H.2: skip the final revision when the critique found nothing
+                // actionable; the draft then becomes the answer.
+                if step.kind == .final,
+                   CognitiveStopPolicy.shouldSkipFinal(critique: engine.outputs[.critique] ?? "") {
+                    break
+                }
                 var passRequest = request
                 passRequest.prompt = step.prompt
 
@@ -944,7 +950,9 @@ public final class AppModel {
 
                 engine.record(output: passText)
                 finalDiagnostics = passDiagnostics
-                finalText = passText
+                if step.kind == .draft {
+                    draftText = passText
+                }
                 await MainActor.run {
                     self.cognitiveTranscript.append(
                         CognitivePassSegment(kind: step.kind, text: passText))
@@ -954,7 +962,8 @@ public final class AppModel {
             if !cancelled {
                 let handled = await MainActor.run { self.hasHandledTerminalEvent }
                 if !handled {
-                    await self.finishCognitiveCycle(finalDiagnostics, response: finalText)
+                    let answer = engine.outputs[.final] ?? draftText
+                    await self.finishCognitiveCycle(finalDiagnostics, response: answer)
                 }
             }
         }

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -67,6 +67,8 @@ public final class AppModel {
     
     /// Conversation currently loaded from history
     public private(set) var activeConversationID: UUID?
+    /// Turns of the loaded conversation, used to continue the dialogue.
+    public private(set) var activeConversationTurns: [Turn] = []
 
     // MARK: - Cognitive mode
     
@@ -960,8 +962,16 @@ public final class AppModel {
     }
 
     public func makeRequest() throws -> AppGenerationRequest {
-        // Append attached document text to the prompt when present
-        let effectivePrompt = hasAttachments ? promptWithAttachments : promptText
+        // Continue a loaded conversation, or compose the single-shot prompt
+        // (attached documents appended when present).
+        let effectivePrompt: String
+        if !activeConversationTurns.isEmpty && !promptText.isEmpty {
+            effectivePrompt = continuationPromptText
+        } else if hasAttachments {
+            effectivePrompt = promptWithAttachments
+        } else {
+            effectivePrompt = promptText
+        }
         let request = AppGenerationRequest(
             modelDirectory: URL(fileURLWithPath: modelPathText),
             prompt: effectivePrompt,
@@ -1135,6 +1145,19 @@ public final class AppModel {
         return context
     }
     
+    /// Prompt that continues a loaded conversation: the full turn history,
+    /// then the new user message (with attached documents).
+    public var continuationPromptText: String {
+        var history = activeConversationTurns.map { turn in
+            turn.role == .user ? "User:\n\(turn.text)" : "Model:\n\(turn.text)"
+        }.joined(separator: "\n\n")
+        let userText = hasAttachments ? promptWithAttachments : promptText
+        if !history.isEmpty {
+            history += "\n\n"
+        }
+        return history + "User:\n" + userText
+    }
+    
     /// Total size of attached documents in bytes
     public var totalAttachmentBytes: UInt64 {
         attachments.reduce(0) { $0 + $1.fileSize }
@@ -1168,54 +1191,73 @@ public final class AppModel {
         guard !promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else { return }
         
         let now = Date()
-        // Regenerating the same prompt updates the active conversation instead
-        // of creating a duplicate entry; a different prompt starts a new one.
         let active = activeConversationID.flatMap { id in
             conversationStore.conversations.first { $0.id == id }
         }
         let savedResponse = response ?? outputText
         let conversation: Conversation
-        if let active, active.prompt == promptText {
+        if let active {
+            var turns = active.turns
+            // Regenerating the same prompt replaces the previous model answer;
+            // otherwise the new user message and answer extend the history.
+            let regenerating = turns.count >= 2
+                && turns[turns.count - 1].role == .model
+                && turns[turns.count - 2].role == .user
+                && turns[turns.count - 2].text == promptText
+            if regenerating {
+                turns[turns.count - 1] = Turn(role: .model, text: savedResponse,
+                                              createdAt: now)
+            } else if turns.last?.role == .user, turns.last?.text == promptText {
+                turns.append(Turn(role: .model, text: savedResponse, createdAt: now))
+            } else {
+                turns.append(Turn(role: .user, text: promptText, createdAt: now))
+                turns.append(Turn(role: .model, text: savedResponse, createdAt: now))
+            }
             conversation = Conversation(
                 id: active.id,
                 title: active.title,
-                prompt: promptText,
-                response: savedResponse,
+                turns: turns,
                 createdAt: active.createdAt,
                 updatedAt: now,
                 promptTokenCount: diagnostic?.promptTokenCount,
                 generatedTokenCount: diagnostic?.generatedTokens,
                 stopReason: diagnostic?.stopReason.rawValue,
                 attachments: attachments,
-                maxNewTokens: maxNewTokensOverride
+                isPinned: active.isPinned,
+                maxNewTokens: maxNewTokensOverride ?? active.maxNewTokens
             )
         } else {
             conversation = Conversation(
                 id: UUID(),
                 title: Conversation.title(from: promptText),
-                prompt: promptText,
-                response: savedResponse,
+                turns: [
+                    Turn(role: .user, text: promptText, createdAt: now),
+                    Turn(role: .model, text: savedResponse, createdAt: now),
+                ],
                 createdAt: now,
                 updatedAt: now,
                 promptTokenCount: diagnostic?.promptTokenCount,
                 generatedTokenCount: diagnostic?.generatedTokens,
                 stopReason: diagnostic?.stopReason.rawValue,
                 attachments: attachments,
+                isPinned: false,
                 maxNewTokens: maxNewTokensOverride
             )
         }
         
         conversationStore.upsert(conversation)
         activeConversationID = conversation.id
+        activeConversationTurns = conversation.turns
     }
     
     /// Loads an existing conversation from history
     public func loadConversation(_ conversation: Conversation) {
         guard !isRunning else { return }
         activeConversationID = conversation.id
-        promptText = conversation.prompt
-        outputPromptText = conversation.prompt
-        outputText = conversation.response
+        activeConversationTurns = conversation.turns
+        promptText = ""
+        outputPromptText = ""
+        outputText = conversation.displayTranscript
         // Restore attached documents so regenerating keeps the context
         attachments = conversation.attachments
         attachmentErrors = []
@@ -1231,6 +1273,7 @@ public final class AppModel {
     public func newConversation() {
         guard !isRunning else { return }
         activeConversationID = nil
+        activeConversationTurns = []
         promptText = ""
         outputPromptText = ""
         outputText = ""

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -970,6 +970,22 @@ public final class AppModel {
         !attachments.isEmpty
     }
     
+    /// Rough token estimate of the effective prompt, including attached
+    /// documents. The app never loads the tokenizer in-process, so this is
+    /// an approximation used only for the composer hint.
+    public var estimatedPromptTokenCount: Int {
+        let text = hasAttachments ? promptWithAttachments : promptText
+        guard !text.isEmpty else { return 0 }
+        return (text.count + 3) / 4
+    }
+    
+    /// Whether the estimated prompt (with documents) exceeds the configured
+    /// context window. Generation would still run but tokens beyond the
+    /// window would be cut during prompt formatting.
+    public var estimatedPromptExceedsContext: Bool {
+        estimatedPromptTokenCount > maxContextTokens
+    }
+    
     // MARK: - Conversation history management
     
     /// Saves the current conversation to history

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TurboFieldfare
 import TurboFieldfareRepackCore
 import Observation
 
@@ -55,6 +56,9 @@ public final class AppModel {
     public var attachmentErrors: [String] = []
     /// Whether an attachment extraction is in progress
     public private(set) var isExtractingAttachment: Bool = false
+    /// Segments of the completed cognitive cycle (plan/draft/critique/final),
+    /// in order. Empty for a single-pass generation.
+    public private(set) var cognitiveTranscript: [CognitivePassSegment] = []
 
     // MARK: - Conversation history
     
@@ -771,6 +775,7 @@ public final class AppModel {
         generationTranscriptMailbox?.reset()
         outputPromptText = request.prompt
         outputText = ""
+        cognitiveTranscript = []
         diagnostics = nil
         error = nil
         hasHandledTerminalEvent = false
@@ -809,6 +814,7 @@ public final class AppModel {
         generationTranscriptMailbox?.reset()
         outputPromptText = request.prompt
         outputText = ""
+        cognitiveTranscript = []
         diagnostics = nil
         error = nil
         hasHandledTerminalEvent = false
@@ -905,8 +911,12 @@ public final class AppModel {
                 if passFailed { return }
 
                 engine.record(output: passText)
-                finalText = passText
                 finalDiagnostics = passDiagnostics
+                finalText = passText
+                await MainActor.run {
+                    self.cognitiveTranscript.append(
+                        CognitivePassSegment(kind: step.kind, text: passText))
+                }
             }
 
             if !cancelled {
@@ -1103,6 +1113,17 @@ public final class AppModel {
         attachments.removeAll()
         attachmentErrors = []
     }
+
+    /// Clears the attachment error list (e.g. after user dismissal)
+    public func clearAttachmentErrors() {
+        attachmentErrors = []
+    }
+
+    /// Dismisses a single attachment error message
+    public func dismissAttachmentError(at index: Int) {
+        guard attachmentErrors.indices.contains(index) else { return }
+        attachmentErrors.remove(at: index)
+    }
     
     /// Full prompt text with attached document content injected
     public var promptWithAttachments: String {
@@ -1165,7 +1186,8 @@ public final class AppModel {
                 promptTokenCount: diagnostic?.promptTokenCount,
                 generatedTokenCount: diagnostic?.generatedTokens,
                 stopReason: diagnostic?.stopReason.rawValue,
-                attachments: attachments
+                attachments: attachments,
+                maxNewTokens: maxNewTokensOverride
             )
         } else {
             conversation = Conversation(
@@ -1178,7 +1200,8 @@ public final class AppModel {
                 promptTokenCount: diagnostic?.promptTokenCount,
                 generatedTokenCount: diagnostic?.generatedTokens,
                 stopReason: diagnostic?.stopReason.rawValue,
-                attachments: attachments
+                attachments: attachments,
+                maxNewTokens: maxNewTokensOverride
             )
         }
         
@@ -1196,6 +1219,8 @@ public final class AppModel {
         // Restore attached documents so regenerating keeps the context
         attachments = conversation.attachments
         attachmentErrors = []
+        // Restore per-conversation response limits
+        maxNewTokensOverride = conversation.maxNewTokens
         // Clear the previous generation state
         diagnostics = nil
         error = nil

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -1419,4 +1419,29 @@ public final class AppModel {
         }
         return markdown.trimmingCharacters(in: .whitespacesAndNewlines) + "\n"
     }
+    
+    /// Other history entries that share the same first user turn, useful
+    /// for comparing runs of the same prompt. Ordered by update time.
+    public func conversationsSharingPrompt(with conversation: Conversation) -> [Conversation] {
+        conversationStore.conversations
+            .filter { $0.id != conversation.id && $0.firstPrompt == conversation.firstPrompt }
+            .sorted { $0.updatedAt > $1.updatedAt }
+    }
+    
+    /// Starts a new conversation that asks the model to summarize another
+    /// conversation, and launches the generation automatically.
+    public func beginSummary(of conversation: Conversation) {
+        guard !isRunning, !conversation.turns.isEmpty else { return }
+        newConversation()
+        let transcript = conversation.displayTranscript
+        promptText = """
+        Summarize the conversation below, keeping all key facts, decisions, and the user's constraints. Output only the summary.
+
+        Conversation:
+        \(transcript)
+        """
+        outputPromptText = promptText
+        outputText = transcript
+        run()
+    }
 }

--- a/Sources/TurboFieldfareApp/Core/State/Conversation.swift
+++ b/Sources/TurboFieldfareApp/Core/State/Conversation.swift
@@ -14,6 +14,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
     public var stopReason: String?
     public var attachments: [DocumentAttachment]
     public var isPinned: Bool
+    /// Per-conversation max response length; nil means "use the global default".
+    public var maxNewTokens: Int?
 
     public init(id: UUID = UUID(),
                 title: String,
@@ -25,7 +27,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                 generatedTokenCount: Int? = nil,
                 stopReason: String? = nil,
                 attachments: [DocumentAttachment] = [],
-                isPinned: Bool = false) {
+                isPinned: Bool = false,
+                maxNewTokens: Int? = nil) {
         self.id = id
         self.title = title
         self.prompt = prompt
@@ -37,6 +40,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.stopReason = stopReason
         self.attachments = attachments
         self.isPinned = isPinned
+        self.maxNewTokens = maxNewTokens
     }
 
     /// Returns a copy with the given mutable fields replaced.
@@ -54,7 +58,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                      generatedTokenCount: generatedTokenCount,
                      stopReason: stopReason,
                      attachments: attachments ?? self.attachments,
-                     isPinned: isPinned ?? self.isPinned)
+                     isPinned: isPinned ?? self.isPinned,
+                     maxNewTokens: maxNewTokens)
     }
 
     /// Automatic title from the prompt when none is provided.
@@ -77,7 +82,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
     private enum CodingKeys: String, CodingKey {
         case id, title, prompt, response, createdAt, updatedAt
         case promptTokenCount, generatedTokenCount, stopReason
-        case attachments, isPinned
+        case attachments, isPinned, maxNewTokens
     }
 
     public init(from decoder: Decoder) throws {
@@ -94,6 +99,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         // Older history files predate document attachments and pinning.
         self.attachments = try container.decodeIfPresent([DocumentAttachment].self, forKey: .attachments) ?? []
         self.isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
+        self.maxNewTokens = try container.decodeIfPresent(Int.self, forKey: .maxNewTokens)
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -109,6 +115,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         try container.encodeIfPresent(stopReason, forKey: .stopReason)
         try container.encode(attachments, forKey: .attachments)
         try container.encode(isPinned, forKey: .isPinned)
+        try container.encodeIfPresent(maxNewTokens, forKey: .maxNewTokens)
     }
 }
 
@@ -121,6 +128,11 @@ public final class ConversationStore {
         category: "conversation-store")
 
     public private(set) var conversations: [Conversation] = []
+
+    /// Set to true when the stored history file was unreadable and had to be
+    /// reset. The existing file is preserved with a `.corrupted` suffix, so no
+    /// data is lost; the flag tells the UI a re-review may be worthwhile.
+    public private(set) var didLoadFromCorrupted: Bool = false
 
     private let storageURL: URL
     private let fileManager: FileManager
@@ -205,6 +217,10 @@ public final class ConversationStore {
             sortConversations()
         } catch {
             Self.logger.error("Failed to decode conversation history at \(self.storageURL.path): \(error)")
+            didLoadFromCorrupted = true
+            // Preserve the unreadable file for inspection, then start fresh.
+            let backupURL = storageURL.appendingPathExtension("corrupted")
+            try? fileManager.moveItem(at: storageURL, to: backupURL)
             conversations = []
         }
     }

--- a/Sources/TurboFieldfareApp/Core/State/Conversation.swift
+++ b/Sources/TurboFieldfareApp/Core/State/Conversation.swift
@@ -1,0 +1,145 @@
+import Foundation
+
+/// A past conversation between the user and the model.
+public struct Conversation: Identifiable, Codable, Equatable, Sendable {
+    public let id: UUID
+    public var title: String
+    public var prompt: String
+    public var response: String
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var promptTokenCount: Int?
+    public var generatedTokenCount: Int?
+    public var stopReason: String?
+
+    public init(id: UUID = UUID(),
+                title: String,
+                prompt: String,
+                response: String,
+                createdAt: Date = Date(),
+                updatedAt: Date = Date(),
+                promptTokenCount: Int? = nil,
+                generatedTokenCount: Int? = nil,
+                stopReason: String? = nil) {
+        self.id = id
+        self.title = title
+        self.prompt = prompt
+        self.response = response
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.promptTokenCount = promptTokenCount
+        self.generatedTokenCount = generatedTokenCount
+        self.stopReason = stopReason
+    }
+
+    /// Automatic title from the prompt when none is provided.
+    public static func title(from prompt: String, maxLength: Int = 60) -> String {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "New conversation" }
+        if trimmed.count <= maxLength { return trimmed }
+        let end = trimmed.index(trimmed.startIndex, offsetBy: maxLength)
+        return String(trimmed[..<end]) + "…"
+    }
+
+    /// Short response preview for list display.
+    public var responsePreview: String {
+        let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.count <= 100 { return trimmed }
+        let end = trimmed.index(trimmed.startIndex, offsetBy: 100)
+        return String(trimmed[..<end]) + "…"
+    }
+}
+
+/// Persistent conversation store, saved as JSON.
+@MainActor
+@Observable
+public final class ConversationStore {
+    public private(set) var conversations: [Conversation] = []
+
+    private let storageURL: URL
+    private let fileManager: FileManager
+
+    public init(storageURL: URL? = nil,
+                fileManager: FileManager = .default) {
+        let base = storageURL ?? Self.defaultStorageURL()
+        self.storageURL = base
+        self.fileManager = fileManager
+        load()
+    }
+
+    public static func defaultStorageURL() -> URL {
+        let appSupport = FileManager.default.urls(for: .applicationSupportDirectory,
+                                                  in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory())
+        let folder = appSupport.appendingPathComponent("TurboFieldfare", isDirectory: true)
+        return folder.appendingPathComponent("conversations.json")
+    }
+
+    /// Adds or updates a conversation.
+    public func upsert(_ conversation: Conversation) {
+        if let index = conversations.firstIndex(where: { $0.id == conversation.id }) {
+            conversations[index] = conversation
+        } else {
+            conversations.insert(conversation, at: 0)
+        }
+        // Keep most recently updated first
+        conversations.sort { $0.updatedAt > $1.updatedAt }
+        save()
+    }
+
+    /// Deletes a conversation.
+    public func delete(_ conversation: Conversation) {
+        conversations.removeAll { $0.id == conversation.id }
+        save()
+    }
+
+    /// Deletes all conversations.
+    public func clearAll() {
+        conversations.removeAll()
+        save()
+    }
+
+    /// Reloads from disk.
+    public func reload() {
+        load()
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: storageURL), !data.isEmpty else { return }
+        do {
+            conversations = try JSONDecoderValue.decode([Conversation].self, from: data)
+            conversations.sort { $0.updatedAt > $1.updatedAt }
+        } catch {
+            conversations = []
+        }
+    }
+
+    private func save() {
+        do {
+            let folder = storageURL.deletingLastPathComponent()
+            try fileManager.createDirectory(at: folder, withIntermediateDirectories: true)
+            let data = try JSONEncoderValue.encode(conversations)
+            try data.write(to: storageURL, options: .atomic)
+        } catch {
+            // Silent: history is not critical
+        }
+    }
+}
+
+// JSON helpers with ISO8601 dates
+private enum JSONDecoderValue {
+    static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(T.self, from: data)
+    }
+}
+
+private enum JSONEncoderValue {
+    static func encode<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .prettyPrinted
+        return try encoder.encode(value)
+    }
+}

--- a/Sources/TurboFieldfareApp/Core/State/Conversation.swift
+++ b/Sources/TurboFieldfareApp/Core/State/Conversation.swift
@@ -1,4 +1,5 @@
 import Foundation
+import OSLog
 
 /// A past conversation between the user and the model.
 public struct Conversation: Identifiable, Codable, Equatable, Sendable {
@@ -115,6 +116,10 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
 @MainActor
 @Observable
 public final class ConversationStore {
+    private static let logger = Logger(
+        subsystem: "app.turbofieldfare",
+        category: "conversation-store")
+
     public private(set) var conversations: [Conversation] = []
 
     private let storageURL: URL
@@ -199,6 +204,7 @@ public final class ConversationStore {
             conversations = try JSONDecoderValue.decode([Conversation].self, from: data)
             sortConversations()
         } catch {
+            Self.logger.error("Failed to decode conversation history at \(self.storageURL.path): \(error)")
             conversations = []
         }
     }
@@ -210,16 +216,32 @@ public final class ConversationStore {
             let data = try JSONEncoderValue.encode(conversations)
             try data.write(to: storageURL, options: .atomic)
         } catch {
-            // Silent: history is not critical
+            Self.logger.error("Failed to save conversation history at \(self.storageURL.path): \(error)")
         }
     }
 }
 
-// JSON helpers with ISO8601 dates
+// JSON helpers with ISO8601 dates. Decoding accepts both whole-second and
+// fractional-second timestamps so files written by other tools still load.
 private enum JSONDecoderValue {
     static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
         let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
+        decoder.dateDecodingStrategy = .custom { decoder in
+            let container = try decoder.singleValueContainer()
+            let string = try container.decode(String.self)
+            let formatter = ISO8601DateFormatter()
+            formatter.formatOptions = [.withInternetDateTime, .withFractionalSeconds]
+            if let date = formatter.date(from: string) {
+                return date
+            }
+            formatter.formatOptions = [.withInternetDateTime]
+            if let date = formatter.date(from: string) {
+                return date
+            }
+            throw DecodingError.dataCorruptedError(
+                in: container,
+                debugDescription: "Invalid ISO8601 date: \(string)")
+        }
         return try decoder.decode(T.self, from: data)
     }
 }

--- a/Sources/TurboFieldfareApp/Core/State/Conversation.swift
+++ b/Sources/TurboFieldfareApp/Core/State/Conversation.swift
@@ -1,21 +1,61 @@
 import Foundation
 import OSLog
 
+/// One turn of a multi-turn conversation.
+public struct Turn: Identifiable, Codable, Equatable, Sendable {
+    public enum Role: String, Codable, Sendable {
+        case user
+        case model
+    }
+
+    public let id: UUID
+    public var role: Role
+    public var text: String
+    public var createdAt: Date
+    /// Token count attributed to this turn, if known.
+    public var tokenCount: Int?
+
+    public init(id: UUID = UUID(),
+                role: Role,
+                text: String,
+                createdAt: Date = Date(),
+                tokenCount: Int? = nil) {
+        self.id = id
+        self.role = role
+        self.text = text
+        self.createdAt = createdAt
+        self.tokenCount = tokenCount
+    }
+}
+
 /// A past conversation between the user and the model.
 public struct Conversation: Identifiable, Codable, Equatable, Sendable {
     public let id: UUID
     public var title: String
-    public var prompt: String
-    public var response: String
+    /// Ordered turns of the conversation. Non-empty for loaded history.
+    public var turns: [Turn]
     public var createdAt: Date
     public var updatedAt: Date
+    /// Prompt token count of the last generated turn.
     public var promptTokenCount: Int?
+    /// Generated token count of the last generated turn.
     public var generatedTokenCount: Int?
+    /// Stop reason of the last generated turn.
     public var stopReason: String?
     public var attachments: [DocumentAttachment]
     public var isPinned: Bool
     /// Per-conversation max response length; nil means "use the global default".
     public var maxNewTokens: Int?
+
+    /// The first user turn, or an empty string when there is none.
+    public var firstPrompt: String {
+        turns.first { $0.role == .user }?.text ?? ""
+    }
+
+    /// The last model turn, or an empty string when there is none.
+    public var lastResponse: String {
+        turns.last { $0.role == .model }?.text ?? ""
+    }
 
     public init(id: UUID = UUID(),
                 title: String,
@@ -31,8 +71,37 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                 maxNewTokens: Int? = nil) {
         self.id = id
         self.title = title
-        self.prompt = prompt
-        self.response = response
+        self.turns = [
+            Turn(role: .user, text: prompt, createdAt: createdAt,
+                 tokenCount: promptTokenCount),
+            Turn(role: .model, text: response, createdAt: updatedAt,
+                 tokenCount: generatedTokenCount),
+        ].filter { !$0.text.isEmpty }
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.promptTokenCount = promptTokenCount
+        self.generatedTokenCount = generatedTokenCount
+        self.stopReason = stopReason
+        self.attachments = attachments
+        self.isPinned = isPinned
+        self.maxNewTokens = maxNewTokens
+    }
+
+    /// Creates a conversation with an explicit turn list (for multi-turn history).
+    public init(id: UUID = UUID(),
+                title: String,
+                turns: [Turn],
+                createdAt: Date = Date(),
+                updatedAt: Date = Date(),
+                promptTokenCount: Int? = nil,
+                generatedTokenCount: Int? = nil,
+                stopReason: String? = nil,
+                attachments: [DocumentAttachment] = [],
+                isPinned: Bool = false,
+                maxNewTokens: Int? = nil) {
+        self.id = id
+        self.title = title
+        self.turns = turns
         self.createdAt = createdAt
         self.updatedAt = updatedAt
         self.promptTokenCount = promptTokenCount
@@ -45,69 +114,93 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
 
     /// Returns a copy with the given mutable fields replaced.
     public func replacing(title: String? = nil,
-                          response: String? = nil,
-                          attachments: [DocumentAttachment]? = nil,
+                          turns: [Turn]? = nil,
                           isPinned: Bool? = nil) -> Conversation {
         Conversation(id: id,
                      title: title ?? self.title,
-                     prompt: prompt,
-                     response: response ?? self.response,
+                     turns: turns ?? self.turns,
                      createdAt: createdAt,
                      updatedAt: updatedAt,
                      promptTokenCount: promptTokenCount,
                      generatedTokenCount: generatedTokenCount,
                      stopReason: stopReason,
-                     attachments: attachments ?? self.attachments,
+                     attachments: attachments,
                      isPinned: isPinned ?? self.isPinned,
                      maxNewTokens: maxNewTokens)
     }
 
-    /// Automatic title from the prompt when none is provided.
-    public static func title(from prompt: String, maxLength: Int = 60) -> String {
-        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
-        guard !trimmed.isEmpty else { return "New conversation" }
-        if trimmed.count <= maxLength { return trimmed }
-        let end = trimmed.index(trimmed.startIndex, offsetBy: maxLength)
-        return String(trimmed[..<end]) + "…"
+    /// Formats the full multi-turn history as a single prompt for generation.
+    /// Each turn is labelled; the model is expected to continue as model.
+    public func asPrompt() -> String {
+        turns.map { turn in
+            switch turn.role {
+            case .user: return "User:\n\(turn.text)"
+            case .model: return "Model:\n\(turn.text)"
+            }
+        }.joined(separator: "\n\n") + "\n\nModel:"
     }
 
-    /// Short response preview for list display.
+    /// Human-readable transcript for display and copy operations.
+    public var displayTranscript: String {
+        turns.map { turn in
+            switch turn.role {
+            case .user: return "You:\n\(turn.text)"
+            case .model: return "Answer:\n\(turn.text)"
+            }
+        }.joined(separator: "\n\n")
+    }
+
+    /// Short response preview for list display (last model turn).
     public var responsePreview: String {
-        let trimmed = response.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmed = lastResponse.trimmingCharacters(in: .whitespacesAndNewlines)
         if trimmed.count <= 100 { return trimmed }
         let end = trimmed.index(trimmed.startIndex, offsetBy: 100)
         return String(trimmed[..<end]) + "…"
     }
 
+    /// Total character count across all turns (for context estimates).
+    public var characterCount: Int {
+        turns.reduce(0) { $0 + $1.text.count }
+    }
+
     private enum CodingKeys: String, CodingKey {
-        case id, title, prompt, response, createdAt, updatedAt
+        case id, title, createdAt, updatedAt
         case promptTokenCount, generatedTokenCount, stopReason
-        case attachments, isPinned, maxNewTokens
+        case attachments, isPinned, maxNewTokens, turns
+        // Legacy single-exchange keys, kept for backward decoding.
+        case prompt, response
     }
 
     public init(from decoder: Decoder) throws {
         let container = try decoder.container(keyedBy: CodingKeys.self)
         self.id = try container.decode(UUID.self, forKey: .id)
         self.title = try container.decode(String.self, forKey: .title)
-        self.prompt = try container.decode(String.self, forKey: .prompt)
-        self.response = try container.decode(String.self, forKey: .response)
         self.createdAt = try container.decode(Date.self, forKey: .createdAt)
         self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
         self.promptTokenCount = try container.decodeIfPresent(Int.self, forKey: .promptTokenCount)
         self.generatedTokenCount = try container.decodeIfPresent(Int.self, forKey: .generatedTokenCount)
         self.stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
-        // Older history files predate document attachments and pinning.
         self.attachments = try container.decodeIfPresent([DocumentAttachment].self, forKey: .attachments) ?? []
         self.isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
         self.maxNewTokens = try container.decodeIfPresent(Int.self, forKey: .maxNewTokens)
+        // Newer files carry turns; legacy files used prompt/response fields.
+        if let turns = try container.decodeIfPresent([Turn].self, forKey: .turns),
+           !turns.isEmpty {
+            self.turns = turns
+        } else {
+            let prompt = try container.decode(String.self, forKey: .prompt)
+            let response = try container.decode(String.self, forKey: .response)
+            self.turns = [
+                Turn(role: .user, text: prompt, createdAt: createdAt),
+                Turn(role: .model, text: response, createdAt: updatedAt),
+            ].filter { !$0.text.isEmpty }
+        }
     }
 
     public func encode(to encoder: Encoder) throws {
         var container = encoder.container(keyedBy: CodingKeys.self)
         try container.encode(id, forKey: .id)
         try container.encode(title, forKey: .title)
-        try container.encode(prompt, forKey: .prompt)
-        try container.encode(response, forKey: .response)
         try container.encode(createdAt, forKey: .createdAt)
         try container.encode(updatedAt, forKey: .updatedAt)
         try container.encodeIfPresent(promptTokenCount, forKey: .promptTokenCount)
@@ -116,6 +209,16 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         try container.encode(attachments, forKey: .attachments)
         try container.encode(isPinned, forKey: .isPinned)
         try container.encodeIfPresent(maxNewTokens, forKey: .maxNewTokens)
+        try container.encode(turns, forKey: .turns)
+    }
+
+    /// Placeholder title from the first user turn when no title exists.
+    public static func title(from prompt: String, maxLength: Int = 60) -> String {
+        let trimmed = prompt.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return "New conversation" }
+        if trimmed.count <= maxLength { return trimmed }
+        let end = trimmed.index(trimmed.startIndex, offsetBy: maxLength)
+        return String(trimmed[..<end]) + "…"
     }
 }
 

--- a/Sources/TurboFieldfareApp/Core/State/Conversation.swift
+++ b/Sources/TurboFieldfareApp/Core/State/Conversation.swift
@@ -11,6 +11,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
     public var promptTokenCount: Int?
     public var generatedTokenCount: Int?
     public var stopReason: String?
+    public var attachments: [DocumentAttachment]
 
     public init(id: UUID = UUID(),
                 title: String,
@@ -20,7 +21,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                 updatedAt: Date = Date(),
                 promptTokenCount: Int? = nil,
                 generatedTokenCount: Int? = nil,
-                stopReason: String? = nil) {
+                stopReason: String? = nil,
+                attachments: [DocumentAttachment] = []) {
         self.id = id
         self.title = title
         self.prompt = prompt
@@ -30,6 +32,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.promptTokenCount = promptTokenCount
         self.generatedTokenCount = generatedTokenCount
         self.stopReason = stopReason
+        self.attachments = attachments
     }
 
     /// Automatic title from the prompt when none is provided.
@@ -47,6 +50,40 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         if trimmed.count <= 100 { return trimmed }
         let end = trimmed.index(trimmed.startIndex, offsetBy: 100)
         return String(trimmed[..<end]) + "…"
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case id, title, prompt, response, createdAt, updatedAt
+        case promptTokenCount, generatedTokenCount, stopReason, attachments
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.id = try container.decode(UUID.self, forKey: .id)
+        self.title = try container.decode(String.self, forKey: .title)
+        self.prompt = try container.decode(String.self, forKey: .prompt)
+        self.response = try container.decode(String.self, forKey: .response)
+        self.createdAt = try container.decode(Date.self, forKey: .createdAt)
+        self.updatedAt = try container.decode(Date.self, forKey: .updatedAt)
+        self.promptTokenCount = try container.decodeIfPresent(Int.self, forKey: .promptTokenCount)
+        self.generatedTokenCount = try container.decodeIfPresent(Int.self, forKey: .generatedTokenCount)
+        self.stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
+        // Older history files predate document attachments.
+        self.attachments = try container.decodeIfPresent([DocumentAttachment].self, forKey: .attachments) ?? []
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encode(id, forKey: .id)
+        try container.encode(title, forKey: .title)
+        try container.encode(prompt, forKey: .prompt)
+        try container.encode(response, forKey: .response)
+        try container.encode(createdAt, forKey: .createdAt)
+        try container.encode(updatedAt, forKey: .updatedAt)
+        try container.encodeIfPresent(promptTokenCount, forKey: .promptTokenCount)
+        try container.encodeIfPresent(generatedTokenCount, forKey: .generatedTokenCount)
+        try container.encodeIfPresent(stopReason, forKey: .stopReason)
+        try container.encode(attachments, forKey: .attachments)
     }
 }
 

--- a/Sources/TurboFieldfareApp/Core/State/Conversation.swift
+++ b/Sources/TurboFieldfareApp/Core/State/Conversation.swift
@@ -48,6 +48,10 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
     public var maxNewTokens: Int?
     /// Id of the conversation this one was forked from, if any.
     public var parentConversationID: UUID?
+    /// Whether this conversation is a reusable template.
+    public var isTemplate: Bool
+    /// User-defined tags used for filtering (e.g. "#work").
+    public var tags: [String]
 
     /// The first user turn, or an empty string when there is none.
     public var firstPrompt: String {
@@ -71,7 +75,9 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                 attachments: [DocumentAttachment] = [],
                 isPinned: Bool = false,
                 maxNewTokens: Int? = nil,
-                parentConversationID: UUID? = nil) {
+                parentConversationID: UUID? = nil,
+                isTemplate: Bool = false,
+                tags: [String] = []) {
         self.id = id
         self.title = title
         self.turns = [
@@ -89,6 +95,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.isPinned = isPinned
         self.maxNewTokens = maxNewTokens
         self.parentConversationID = parentConversationID
+        self.isTemplate = isTemplate
+        self.tags = tags
     }
 
     /// Creates a conversation with an explicit turn list (for multi-turn history).
@@ -103,7 +111,9 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                 attachments: [DocumentAttachment] = [],
                 isPinned: Bool = false,
                 maxNewTokens: Int? = nil,
-                parentConversationID: UUID? = nil) {
+                parentConversationID: UUID? = nil,
+                isTemplate: Bool = false,
+                tags: [String] = []) {
         self.id = id
         self.title = title
         self.turns = turns
@@ -116,12 +126,16 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.isPinned = isPinned
         self.maxNewTokens = maxNewTokens
         self.parentConversationID = parentConversationID
+        self.isTemplate = isTemplate
+        self.tags = tags
     }
 
     /// Returns a copy with the given mutable fields replaced.
     public func replacing(title: String? = nil,
                           turns: [Turn]? = nil,
-                          isPinned: Bool? = nil) -> Conversation {
+                          isPinned: Bool? = nil,
+                          isTemplate: Bool? = nil,
+                          tags: [String]? = nil) -> Conversation {
         Conversation(id: id,
                      title: title ?? self.title,
                      turns: turns ?? self.turns,
@@ -133,7 +147,9 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                      attachments: attachments,
                      isPinned: isPinned ?? self.isPinned,
                      maxNewTokens: maxNewTokens,
-                     parentConversationID: parentConversationID)
+                     parentConversationID: parentConversationID,
+                     isTemplate: isTemplate ?? self.isTemplate,
+                     tags: tags ?? self.tags)
     }
 
     /// Formats the full multi-turn history as a single prompt for generation.
@@ -174,7 +190,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         case id, title, createdAt, updatedAt
         case promptTokenCount, generatedTokenCount, stopReason
         case attachments, isPinned, maxNewTokens, turns
-        case parentConversationID
+        case parentConversationID, isTemplate, tags
         // Legacy single-exchange keys, kept for backward decoding.
         case prompt, response
     }
@@ -192,6 +208,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
         self.maxNewTokens = try container.decodeIfPresent(Int.self, forKey: .maxNewTokens)
         self.parentConversationID = try container.decodeIfPresent(UUID.self, forKey: .parentConversationID)
+        self.isTemplate = try container.decodeIfPresent(Bool.self, forKey: .isTemplate) ?? false
+        self.tags = try container.decodeIfPresent([String].self, forKey: .tags) ?? []
         // Newer files carry turns; legacy files used prompt/response fields.
         if let turns = try container.decodeIfPresent([Turn].self, forKey: .turns),
            !turns.isEmpty {
@@ -219,6 +237,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         try container.encode(isPinned, forKey: .isPinned)
         try container.encodeIfPresent(maxNewTokens, forKey: .maxNewTokens)
         try container.encodeIfPresent(parentConversationID, forKey: .parentConversationID)
+        try container.encode(isTemplate, forKey: .isTemplate)
+        try container.encode(tags, forKey: .tags)
         try container.encode(turns, forKey: .turns)
     }
 

--- a/Sources/TurboFieldfareApp/Core/State/Conversation.swift
+++ b/Sources/TurboFieldfareApp/Core/State/Conversation.swift
@@ -12,6 +12,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
     public var generatedTokenCount: Int?
     public var stopReason: String?
     public var attachments: [DocumentAttachment]
+    public var isPinned: Bool
 
     public init(id: UUID = UUID(),
                 title: String,
@@ -22,7 +23,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                 promptTokenCount: Int? = nil,
                 generatedTokenCount: Int? = nil,
                 stopReason: String? = nil,
-                attachments: [DocumentAttachment] = []) {
+                attachments: [DocumentAttachment] = [],
+                isPinned: Bool = false) {
         self.id = id
         self.title = title
         self.prompt = prompt
@@ -33,6 +35,25 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.generatedTokenCount = generatedTokenCount
         self.stopReason = stopReason
         self.attachments = attachments
+        self.isPinned = isPinned
+    }
+
+    /// Returns a copy with the given mutable fields replaced.
+    public func replacing(title: String? = nil,
+                          response: String? = nil,
+                          attachments: [DocumentAttachment]? = nil,
+                          isPinned: Bool? = nil) -> Conversation {
+        Conversation(id: id,
+                     title: title ?? self.title,
+                     prompt: prompt,
+                     response: response ?? self.response,
+                     createdAt: createdAt,
+                     updatedAt: updatedAt,
+                     promptTokenCount: promptTokenCount,
+                     generatedTokenCount: generatedTokenCount,
+                     stopReason: stopReason,
+                     attachments: attachments ?? self.attachments,
+                     isPinned: isPinned ?? self.isPinned)
     }
 
     /// Automatic title from the prompt when none is provided.
@@ -54,7 +75,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
 
     private enum CodingKeys: String, CodingKey {
         case id, title, prompt, response, createdAt, updatedAt
-        case promptTokenCount, generatedTokenCount, stopReason, attachments
+        case promptTokenCount, generatedTokenCount, stopReason
+        case attachments, isPinned
     }
 
     public init(from decoder: Decoder) throws {
@@ -68,8 +90,9 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.promptTokenCount = try container.decodeIfPresent(Int.self, forKey: .promptTokenCount)
         self.generatedTokenCount = try container.decodeIfPresent(Int.self, forKey: .generatedTokenCount)
         self.stopReason = try container.decodeIfPresent(String.self, forKey: .stopReason)
-        // Older history files predate document attachments.
+        // Older history files predate document attachments and pinning.
         self.attachments = try container.decodeIfPresent([DocumentAttachment].self, forKey: .attachments) ?? []
+        self.isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -84,6 +107,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         try container.encodeIfPresent(generatedTokenCount, forKey: .generatedTokenCount)
         try container.encodeIfPresent(stopReason, forKey: .stopReason)
         try container.encode(attachments, forKey: .attachments)
+        try container.encode(isPinned, forKey: .isPinned)
     }
 }
 
@@ -119,8 +143,7 @@ public final class ConversationStore {
         } else {
             conversations.insert(conversation, at: 0)
         }
-        // Keep most recently updated first
-        conversations.sort { $0.updatedAt > $1.updatedAt }
+        sortConversations()
         save()
     }
 
@@ -141,11 +164,40 @@ public final class ConversationStore {
         load()
     }
 
+    /// Exports all conversations in the same JSON format the store uses.
+    public func exportJSON() throws -> Data {
+        try JSONEncoderValue.encode(conversations)
+    }
+
+    /// Imports conversations from exported JSON. Existing entries with the
+    /// same id are replaced; new ones are inserted. Returns the count.
+    public func importJSON(_ data: Data) throws -> Int {
+        let imported = try JSONDecoderValue.decode([Conversation].self, from: data)
+        for conversation in imported {
+            if let index = conversations.firstIndex(where: { $0.id == conversation.id }) {
+                conversations[index] = conversation
+            } else {
+                conversations.append(conversation)
+            }
+        }
+        sortConversations()
+        save()
+        return imported.count
+    }
+
+    /// Pinned conversations first, then most recently updated.
+    private func sortConversations() {
+        conversations.sort {
+            if $0.isPinned != $1.isPinned { return $0.isPinned }
+            return $0.updatedAt > $1.updatedAt
+        }
+    }
+
     private func load() {
         guard let data = try? Data(contentsOf: storageURL), !data.isEmpty else { return }
         do {
             conversations = try JSONDecoderValue.decode([Conversation].self, from: data)
-            conversations.sort { $0.updatedAt > $1.updatedAt }
+            sortConversations()
         } catch {
             conversations = []
         }

--- a/Sources/TurboFieldfareApp/Core/State/Conversation.swift
+++ b/Sources/TurboFieldfareApp/Core/State/Conversation.swift
@@ -46,6 +46,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
     public var isPinned: Bool
     /// Per-conversation max response length; nil means "use the global default".
     public var maxNewTokens: Int?
+    /// Id of the conversation this one was forked from, if any.
+    public var parentConversationID: UUID?
 
     /// The first user turn, or an empty string when there is none.
     public var firstPrompt: String {
@@ -68,7 +70,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                 stopReason: String? = nil,
                 attachments: [DocumentAttachment] = [],
                 isPinned: Bool = false,
-                maxNewTokens: Int? = nil) {
+                maxNewTokens: Int? = nil,
+                parentConversationID: UUID? = nil) {
         self.id = id
         self.title = title
         self.turns = [
@@ -85,6 +88,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.attachments = attachments
         self.isPinned = isPinned
         self.maxNewTokens = maxNewTokens
+        self.parentConversationID = parentConversationID
     }
 
     /// Creates a conversation with an explicit turn list (for multi-turn history).
@@ -98,7 +102,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                 stopReason: String? = nil,
                 attachments: [DocumentAttachment] = [],
                 isPinned: Bool = false,
-                maxNewTokens: Int? = nil) {
+                maxNewTokens: Int? = nil,
+                parentConversationID: UUID? = nil) {
         self.id = id
         self.title = title
         self.turns = turns
@@ -110,6 +115,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.attachments = attachments
         self.isPinned = isPinned
         self.maxNewTokens = maxNewTokens
+        self.parentConversationID = parentConversationID
     }
 
     /// Returns a copy with the given mutable fields replaced.
@@ -126,7 +132,8 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
                      stopReason: stopReason,
                      attachments: attachments,
                      isPinned: isPinned ?? self.isPinned,
-                     maxNewTokens: maxNewTokens)
+                     maxNewTokens: maxNewTokens,
+                     parentConversationID: parentConversationID)
     }
 
     /// Formats the full multi-turn history as a single prompt for generation.
@@ -167,6 +174,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         case id, title, createdAt, updatedAt
         case promptTokenCount, generatedTokenCount, stopReason
         case attachments, isPinned, maxNewTokens, turns
+        case parentConversationID
         // Legacy single-exchange keys, kept for backward decoding.
         case prompt, response
     }
@@ -183,6 +191,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         self.attachments = try container.decodeIfPresent([DocumentAttachment].self, forKey: .attachments) ?? []
         self.isPinned = try container.decodeIfPresent(Bool.self, forKey: .isPinned) ?? false
         self.maxNewTokens = try container.decodeIfPresent(Int.self, forKey: .maxNewTokens)
+        self.parentConversationID = try container.decodeIfPresent(UUID.self, forKey: .parentConversationID)
         // Newer files carry turns; legacy files used prompt/response fields.
         if let turns = try container.decodeIfPresent([Turn].self, forKey: .turns),
            !turns.isEmpty {
@@ -209,6 +218,7 @@ public struct Conversation: Identifiable, Codable, Equatable, Sendable {
         try container.encode(attachments, forKey: .attachments)
         try container.encode(isPinned, forKey: .isPinned)
         try container.encodeIfPresent(maxNewTokens, forKey: .maxNewTokens)
+        try container.encodeIfPresent(parentConversationID, forKey: .parentConversationID)
         try container.encode(turns, forKey: .turns)
     }
 

--- a/Sources/TurboFieldfareApp/Core/State/DocumentLibrary.swift
+++ b/Sources/TurboFieldfareApp/Core/State/DocumentLibrary.swift
@@ -1,0 +1,98 @@
+import Foundation
+import OSLog
+
+/// Persistent library of extracted documents, keyed by filename. Lets the
+/// same file be reused across conversations without re-extracting, and
+/// backs the retrieval path for large documents.
+@MainActor
+@Observable
+public final class DocumentLibrary {
+    private static let logger = Logger(
+        subsystem: "app.turbofieldfare",
+        category: "document-library")
+
+    public private(set) var documents: [DocumentAttachment] = []
+
+    private let storageURL: URL
+    private let fileManager: FileManager
+
+    public init(storageURL: URL? = nil,
+                fileManager: FileManager = .default) {
+        let base = storageURL ?? Self.defaultStorageURL()
+        self.storageURL = base
+        self.fileManager = fileManager
+        load()
+    }
+
+    public static func defaultStorageURL() -> URL {
+        let folder = ConversationStore.defaultStorageURL().deletingLastPathComponent()
+        return folder.appendingPathComponent("documents.json")
+    }
+
+    /// Adds or replaces the entry with the same filename.
+    public func upsert(_ attachment: DocumentAttachment) {
+        if let index = documents.firstIndex(where: { $0.filename == attachment.filename }) {
+            documents[index] = attachment
+        } else {
+            documents.append(attachment)
+        }
+        documents.sort { $0.filename.localizedCaseInsensitiveCompare($1.filename) == .orderedAscending }
+        save()
+    }
+
+    /// Removes an entry by id.
+    public func remove(_ attachment: DocumentAttachment) {
+        documents.removeAll { $0.id == attachment.id }
+        save()
+    }
+
+    public func clear() {
+        documents.removeAll()
+        save()
+    }
+
+    /// Looks up a stored document by filename.
+    public func document(named filename: String) -> DocumentAttachment? {
+        documents.first { $0.filename == filename }
+    }
+
+    private func load() {
+        guard let data = try? Data(contentsOf: storageURL), !data.isEmpty else { return }
+        do {
+            documents = try JSONDecoderValue.decode([DocumentAttachment].self, from: data)
+        } catch {
+            Self.logger.error("Failed to decode document library at \(self.storageURL.path): \(error)")
+            documents = []
+        }
+    }
+
+    private func save() {
+        do {
+            let folder = storageURL.deletingLastPathComponent()
+            try fileManager.createDirectory(at: folder, withIntermediateDirectories: true)
+            let data = try JSONEncoderValue.encode(documents)
+            try data.write(to: storageURL, options: .atomic)
+        } catch {
+            Self.logger.error("Failed to save document library at \(self.storageURL.path): \(error)")
+        }
+    }
+}
+
+// JSON helpers with ISO8601 dates (documents carry no dates today, but the
+// encoder/decoder pair is shared with the conversation store for symmetry).
+private enum JSONDecoderValue {
+    static func decode<T: Decodable>(_ type: T.Type, from data: Data) throws -> T {
+        let decoder = JSONDecoder()
+        decoder.dateDecodingStrategy = .iso8601
+        return try decoder.decode(T.self, from: data)
+    }
+}
+
+private enum JSONEncoderValue {
+    static func encode<T: Encodable>(_ value: T) throws -> Data {
+        let encoder = JSONEncoder()
+        encoder.dateEncodingStrategy = .iso8601
+        encoder.outputFormatting = .prettyPrinted
+        return try encoder.encode(value)
+    }
+}

--- a/Sources/TurboFieldfareApp/Mac/App/RootView.swift
+++ b/Sources/TurboFieldfareApp/Mac/App/RootView.swift
@@ -15,15 +15,15 @@ struct RootView: View {
             InspectorView(model: model)
                 .frame(width: 320)
                 .frame(maxHeight: .infinity)
-                .background(Color(nsColor: .windowBackgroundColor))
+                .background(TurboFieldfareAppearance.background)
         }
         .containerBackground(for: .window) {
             LinearGradient(
                 colors: [
-                    Color(nsColor: .windowBackgroundColor),
-                    Color(nsColor: .windowBackgroundColor).mix(
+                    TurboFieldfareAppearance.background,
+                    TurboFieldfareAppearance.background.mix(
                         with: TurboFieldfareMacTheme.accentColor,
-                        by: 0.04),
+                        by: 0.05),
                 ],
                 startPoint: .top,
                 endPoint: .bottom)

--- a/Sources/TurboFieldfareApp/Mac/App/RootView.swift
+++ b/Sources/TurboFieldfareApp/Mac/App/RootView.swift
@@ -7,12 +7,11 @@ struct RootView: View {
     @State private var conversationChromeHeight: CGFloat = 0
 
     var body: some View {
-        HStack(spacing: 0) {
+        NavigationSplitView {
+            ConversationSidebarView(model: model)
+        } content: {
             primaryContent
-                .frame(minWidth: 720, maxWidth: .infinity, maxHeight: .infinity)
-
-            Divider()
-
+        } detail: {
             InspectorView(model: model)
                 .frame(width: 320)
                 .frame(maxHeight: .infinity)

--- a/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
@@ -174,11 +174,16 @@ struct AttachmentRow: View {
     
     var body: some View {
         HStack(spacing: 10) {
-            // Document type icon
+            // Document type icon on a tinted tile
             Image(systemName: attachment.type.icon)
                 .font(.title3)
                 .foregroundStyle(TurboFieldfareMacTheme.accentColor)
-                .frame(width: 24)
+                .frame(width: 32, height: 32)
+                .background(
+                    TurboFieldfareMacTheme.accentColor.opacity(0.12),
+                    in: RoundedRectangle(cornerRadius: 8)
+                )
+                .accessibilityHidden(true)
             
             // File information
             VStack(alignment: .leading, spacing: 2) {
@@ -233,11 +238,14 @@ struct AttachmentRow: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 8)
         .background {
-            RoundedRectangle(cornerRadius: 10)
-                .fill(Color(nsColor: .controlBackgroundColor))
+            RoundedRectangle(cornerRadius: 12)
+                .fill(TurboFieldfareAppearance.surface)
                 .overlay {
-                    RoundedRectangle(cornerRadius: 10)
-                        .stroke(isHovering ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+                    RoundedRectangle(cornerRadius: 12)
+                        .stroke(isHovering
+                                ? AnyShapeStyle(TurboFieldfareMacTheme.accentColor.opacity(0.4))
+                                : AnyShapeStyle(.separator.opacity(0.35)),
+                                lineWidth: 1)
                 }
         }
         .onHover { hovering in

--- a/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
@@ -98,12 +98,7 @@ struct DocumentAttachmentView: View {
         ) { result in
             switch result {
             case .success(let urls):
-                // Enable secure access for sandboxed files
-                let accessibleURLs = urls.compactMap { url -> URL? in
-                    guard url.startAccessingSecurityScopedResource() else { return nil }
-                    return url
-                }
-                model.attachDocuments(from: accessibleURLs)
+                model.attachDocuments(from: urls)
             case .failure(let error):
                 model.attachmentError = .readFailed(error.localizedDescription)
             }

--- a/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
@@ -1,0 +1,277 @@
+import SwiftUI
+import UniformTypeIdentifiers
+import TurboFieldfareAppCore
+import TurboFieldfareMacPresentation
+
+/// View showing attached documents and allowing more to be added
+struct DocumentAttachmentView: View {
+    @Bindable var model: AppModel
+    @State private var isFileImporterPresented = false
+    @State private var isHovering = false
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            // Header with add button
+            HStack {
+                Label("Documents", systemImage: "doc.on.doc")
+                    .font(.callout.weight(.medium))
+                    .foregroundStyle(.secondary)
+                
+                Spacer()
+                
+                if !model.attachments.isEmpty {
+                    Text("\(model.attachments.count) file\(model.attachments.count > 1 ? "s" : "")")
+                        .font(.caption)
+                        .foregroundStyle(.tertiary)
+                }
+                
+                Button {
+                    isFileImporterPresented = true
+                } label: {
+                    Label("Add", systemImage: "plus.circle.fill")
+                        .labelStyle(.iconOnly)
+                        .font(.callout)
+                }
+                .buttonStyle(.borderless)
+                .help("Add a document (PDF, Word, TXT, MD, RTF)")
+                .disabled(model.isExtractingAttachment)
+            }
+            
+            // Loading indicator
+            if model.isExtractingAttachment {
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .scaleEffect(0.7)
+                    Text("Extracting text…")
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+            }
+            
+            // List of attached documents
+            if !model.attachments.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(model.attachments) { attachment in
+                        AttachmentRow(
+                            attachment: attachment,
+                            onRemove: { model.removeAttachment(attachment) }
+                        )
+                    }
+                }
+                
+                // Footer with total size
+                HStack {
+                    Text("Total size: \(formattedTotalSize)")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                    
+                    Spacer()
+                    
+                    Button("Clear all") {
+                        model.clearAttachments()
+                    }
+                    .font(.caption2)
+                    .buttonStyle(.borderless)
+                    .foregroundStyle(.secondary)
+                }
+            }
+            
+            // Error message
+            if let error = model.attachmentError {
+                HStack(alignment: .top, spacing: 6) {
+                    Image(systemName: "exclamationmark.triangle.fill")
+                        .foregroundStyle(.orange)
+                        .font(.caption)
+                    Text(error.localizedDescription)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+                .padding(8)
+                .background(Color.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
+            }
+        }
+        .fileImporter(
+            isPresented: $isFileImporterPresented,
+            allowedContentTypes: DocumentExtractor.supportedTypes,
+            allowsMultipleSelection: true
+        ) { result in
+            switch result {
+            case .success(let urls):
+                // Enable secure access for sandboxed files
+                let accessibleURLs = urls.compactMap { url -> URL? in
+                    guard url.startAccessingSecurityScopedResource() else { return nil }
+                    return url
+                }
+                model.attachDocuments(from: accessibleURLs)
+            case .failure(let error):
+                model.attachmentError = .readFailed(error.localizedDescription)
+            }
+        }
+        .onDrop(of: DocumentExtractor.supportedTypes, isTargeted: $isHovering) { providers in
+            handleDrop(providers: providers)
+        }
+        .overlay {
+            if isHovering {
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(TurboFieldfareMacTheme.accentColor, lineWidth: 2)
+                    .background(TurboFieldfareMacTheme.accentColor.opacity(0.1), in: RoundedRectangle(cornerRadius: 12))
+            }
+        }
+    }
+    
+    private var formattedTotalSize: String {
+        ByteCountFormatter.string(fromByteCount: Int64(model.totalAttachmentBytes), countStyle: .file)
+    }
+    
+    private func handleDrop(providers: [NSItemProvider]) -> Bool {
+        Task {
+            var urls: [URL] = []
+            for provider in providers {
+                if let url = await withCheckedContinuation({ continuation in
+                    _ = provider.loadObject(ofClass: URL.self) { url, _ in
+                        continuation.resume(returning: url)
+                    }
+                }) {
+                    urls.append(url)
+                }
+            }
+            if !urls.isEmpty {
+                await MainActor.run {
+                    model.attachDocuments(from: urls)
+                }
+            }
+        }
+        return true
+    }
+}
+
+/// Row displaying an attached document
+struct AttachmentRow: View {
+    let attachment: DocumentAttachment
+    let onRemove: () -> Void
+    @State private var isHovering = false
+    @State private var showingPreview = false
+    
+    var body: some View {
+        HStack(spacing: 10) {
+            // Document type icon
+            Image(systemName: attachment.type.icon)
+                .font(.title3)
+                .foregroundStyle(TurboFieldfareMacTheme.accentColor)
+                .frame(width: 24)
+            
+            // File information
+            VStack(alignment: .leading, spacing: 2) {
+                Text(attachment.filename)
+                    .font(.callout.weight(.medium))
+                    .lineLimit(1)
+                    .truncationMode(.middle)
+                
+                HStack(spacing: 6) {
+                    Text(attachment.formattedSize)
+                    if let pages = attachment.pageCount {
+                        Text("•")
+                        Text("\(pages) page\(pages > 1 ? "s" : "")")
+                    }
+                    if attachment.truncated {
+                        Text("•")
+                        Text("truncated")
+                            .foregroundStyle(.orange)
+                    }
+                    Text("•")
+                    Text("\(attachment.extractedText.count) characters")
+                }
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            }
+            
+            Spacer()
+            
+            // Action buttons
+            HStack(spacing: 4) {
+                Button {
+                    showingPreview.toggle()
+                } label: {
+                    Image(systemName: "eye")
+                        .font(.caption)
+                }
+                .buttonStyle(.borderless)
+                .help("Preview text")
+                
+                Button {
+                    onRemove()
+                } label: {
+                    Image(systemName: "xmark.circle.fill")
+                        .font(.caption)
+                        .symbolRenderingMode(.hierarchical)
+                }
+                .buttonStyle(.borderless)
+                .foregroundStyle(.secondary)
+                .help("Remove this document")
+            }
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 8)
+        .background {
+            RoundedRectangle(cornerRadius: 10)
+                .fill(Color(nsColor: .controlBackgroundColor))
+                .overlay {
+                    RoundedRectangle(cornerRadius: 10)
+                        .stroke(isHovering ? Color.accentColor.opacity(0.3) : Color.clear, lineWidth: 1)
+                }
+        }
+        .onHover { hovering in
+            isHovering = hovering
+        }
+        .popover(isPresented: $showingPreview, arrowEdge: .bottom) {
+            AttachmentPreview(attachment: attachment)
+        }
+    }
+}
+
+/// Preview of the text extracted from a document
+struct AttachmentPreview: View {
+    let attachment: DocumentAttachment
+    
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack {
+                Image(systemName: attachment.type.icon)
+                    .font(.title2)
+                VStack(alignment: .leading) {
+                    Text(attachment.filename)
+                        .font(.headline)
+                    Text(attachment.type.displayName)
+                        .font(.caption)
+                        .foregroundStyle(.secondary)
+                }
+                Spacer()
+            }
+            
+            Divider()
+            
+            ScrollView {
+                Text(attachment.preview(maxLength: 2000))
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+            .frame(minHeight: 200, maxHeight: 300)
+            
+            if attachment.truncated {
+                Label("Document truncated to \(DocumentExtractor.maximumTextLength / 1000)k characters", systemImage: "exclamationmark.triangle")
+                    .font(.caption)
+                    .foregroundStyle(.orange)
+            }
+        }
+        .padding()
+        .frame(width: 400)
+    }
+}
+
+#Preview {
+    DocumentAttachmentView(model: AppModel())
+        .frame(width: 500)
+        .padding()
+}

--- a/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
@@ -76,18 +76,23 @@ struct DocumentAttachmentView: View {
                 }
             }
             
-            // Error message
-            if let error = model.attachmentError {
-                HStack(alignment: .top, spacing: 6) {
-                    Image(systemName: "exclamationmark.triangle.fill")
-                        .foregroundStyle(.orange)
-                        .font(.caption)
-                    Text(error.localizedDescription)
-                        .font(.caption)
-                        .foregroundStyle(.secondary)
-                        .fixedSize(horizontal: false, vertical: true)
+            // Error messages
+            if !model.attachmentErrors.isEmpty {
+                VStack(alignment: .leading, spacing: 6) {
+                    ForEach(model.attachmentErrors, id: \.self) { message in
+                        HStack(alignment: .top, spacing: 6) {
+                            Image(systemName: "exclamationmark.triangle.fill")
+                                .foregroundStyle(.orange)
+                                .font(.caption)
+                            Text(message)
+                                .font(.caption)
+                                .foregroundStyle(.secondary)
+                                .fixedSize(horizontal: false, vertical: true)
+                        }
+                    }
                 }
                 .padding(8)
+                .frame(maxWidth: .infinity, alignment: .leading)
                 .background(Color.orange.opacity(0.1), in: RoundedRectangle(cornerRadius: 8))
             }
         }
@@ -100,7 +105,7 @@ struct DocumentAttachmentView: View {
             case .success(let urls):
                 model.attachDocuments(from: urls)
             case .failure(let error):
-                model.attachmentError = .readFailed(error.localizedDescription)
+                model.attachmentErrors = [error.localizedDescription]
             }
         }
         .onDrop(of: DocumentExtractor.supportedTypes, isTargeted: $isHovering) { providers in

--- a/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/DocumentAttachmentView.swift
@@ -79,15 +79,34 @@ struct DocumentAttachmentView: View {
             // Error messages
             if !model.attachmentErrors.isEmpty {
                 VStack(alignment: .leading, spacing: 6) {
-                    ForEach(model.attachmentErrors, id: \.self) { message in
+                    HStack {
+                        Label("Errors", systemImage: "exclamationmark.triangle.fill")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(.orange)
+                        Spacer()
+                        Button("Clear errors") {
+                            model.clearAttachmentErrors()
+                        }
+                        .font(.caption2)
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(.secondary)
+                    }
+                    ForEach(model.attachmentErrors.indices, id: \.self) { index in
                         HStack(alignment: .top, spacing: 6) {
-                            Image(systemName: "exclamationmark.triangle.fill")
-                                .foregroundStyle(.orange)
-                                .font(.caption)
-                            Text(message)
+                            Text(model.attachmentErrors[index])
                                 .font(.caption)
                                 .foregroundStyle(.secondary)
                                 .fixedSize(horizontal: false, vertical: true)
+                            Spacer(minLength: 4)
+                            Button {
+                                model.dismissAttachmentError(at: index)
+                            } label: {
+                                Image(systemName: "xmark.circle.fill")
+                                    .font(.caption)
+                                    .symbolRenderingMode(.hierarchical)
+                            }
+                            .buttonStyle(.borderless)
+                            .foregroundStyle(.secondary)
                         }
                     }
                 }

--- a/Sources/TurboFieldfareApp/Mac/Components/ErrorBanner.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/ErrorBanner.swift
@@ -30,7 +30,7 @@ struct ErrorBanner: View {
             .padding(.vertical, 8)
             .background {
                 Capsule()
-                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .fill(TurboFieldfareAppearance.surface)
                     .overlay {
                         Capsule().stroke(.red.opacity(0.55), lineWidth: 1)
                     }

--- a/Sources/TurboFieldfareApp/Mac/Components/ModelActionBanner.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/ModelActionBanner.swift
@@ -25,7 +25,7 @@ struct ModelActionBanner: View {
             .padding(.vertical, 8)
             .background {
                 RoundedRectangle(cornerRadius: 14)
-                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .fill(TurboFieldfareAppearance.surface)
                     .overlay {
                         RoundedRectangle(cornerRadius: 14)
                             .stroke(iconColor(for: action).opacity(0.5), lineWidth: 1)

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
@@ -11,6 +11,7 @@ struct InspectorView: View {
             memorySection
             generationSection
             runtimeSection
+            attachmentsSection
             RunnerDiagnosticsSection(diagnostics: model.diagnostics)
         }
         .formStyle(.grouped)
@@ -160,6 +161,35 @@ struct InspectorView: View {
                     .font(.caption)
                     .foregroundStyle(.secondary)
             }
+        }
+        .disabled(model.isRunning || model.loadState.isLoading)
+    }
+
+    private var attachmentsSection: some View {
+        Section("Attachments") {
+            LabeledContent("Max file size") {
+                Picker("Max file size", selection: $model.maxAttachmentFileSize) {
+                    ForEach([10, 25, 50, 100, 250, 500], id: \.self) { megabytes in
+                        Text("\(megabytes) MB").tag(UInt64(megabytes) * 1_048_576)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .fixedSize()
+            }
+            LabeledContent("Max text length") {
+                Picker("Max text length", selection: $model.maxAttachmentTextLength) {
+                    ForEach([100_000, 250_000, 500_000, 1_000_000], id: \.self) { length in
+                        Text("\(length / 1_000)k chars").tag(length)
+                    }
+                }
+                .pickerStyle(.menu)
+                .labelsHidden()
+                .fixedSize()
+            }
+            Text("Limits apply to newly attached documents and are saved with your settings.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
         }
         .disabled(model.isRunning || model.loadState.isLoading)
     }

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
@@ -16,7 +16,7 @@ struct InspectorView: View {
         }
         .formStyle(.grouped)
         .scrollContentBackground(.hidden)
-        .background(Color(nsColor: .windowBackgroundColor))
+        .background(TurboFieldfareAppearance.background)
     }
 
     private var modelSection: some View {

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
@@ -156,6 +156,11 @@ struct InspectorView: View {
             Text("RDADVISE is experimental. It may speed up short decodes but slow down long decodes.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
+            Toggle("Cognitive mode", isOn: $model.cognitiveModeEnabled)
+                .toggleStyle(.switch)
+            Text("Runs four passes: plan, draft, critique, and final revision. Each pass generates up to the full response limit, so runs are slower.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
             if model.hasStaleLoadedRuntime {
                 Text("Reload required")
                     .font(.caption)

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/StatusHUDView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/StatusHUDView.swift
@@ -29,7 +29,7 @@ struct StatusHUDView: View {
         .padding(.vertical, 10)
         .background {
             Capsule()
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .fill(TurboFieldfareAppearance.surface)
                 .overlay {
                     Capsule().stroke(.separator.opacity(0.5), lineWidth: 0.5)
                 }

--- a/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
@@ -1,0 +1,143 @@
+import SwiftUI
+import TurboFieldfareAppCore
+
+/// Sidebar showing the conversation history.
+struct ConversationSidebarView: View {
+    @Bindable var model: AppModel
+    @State private var searchText: String = ""
+    @State private var showingClearConfirmation = false
+
+    private var filteredConversations: [Conversation] {
+        let items = model.conversationStore.conversations
+        guard !searchText.isEmpty else { return items }
+        let query = searchText.lowercased()
+        return items.filter {
+            $0.title.lowercased().contains(query)
+                || $0.prompt.lowercased().contains(query)
+                || $0.response.lowercased().contains(query)
+        }
+    }
+
+    var body: some View {
+        VStack(spacing: 0) {
+            // Toolbar: new conversation + search
+            VStack(spacing: 8) {
+                HStack {
+                    Button {
+                        model.newConversation()
+                    } label: {
+                        Label("New", systemImage: "square.and.pencil")
+                            .font(.callout.weight(.medium))
+                    }
+                    .buttonStyle(.borderless)
+                    .disabled(model.isRunning)
+
+                    Spacer()
+
+                    if !model.conversationStore.conversations.isEmpty {
+                        Button(role: .destructive) {
+                            showingClearConfirmation = true
+                        } label: {
+                            Label("Clear all", systemImage: "trash")
+                                .labelStyle(.iconOnly)
+                        }
+                        .buttonStyle(.borderless)
+                        .help("Clear all history")
+                    }
+                }
+
+                TextField("Search…", text: $searchText)
+                    .textFieldStyle(.roundedBorder)
+                    .font(.callout)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+
+            Divider()
+
+            // Conversation list
+            if filteredConversations.isEmpty {
+                ContentUnavailableView(
+                    searchText.isEmpty ? "No conversations" : "No results",
+                    systemImage: "bubble.left.and.bubble.right",
+                    description: Text(
+                        searchText.isEmpty
+                            ? "Run a generation to create your first conversation."
+                            : "No conversations match “\(searchText)”."
+                    )
+                )
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+            } else {
+                List(selection: .constant(model.activeConversationID)) {
+                    ForEach(filteredConversations) { conversation in
+                        ConversationRowView(conversation: conversation,
+                                            isActive: model.activeConversationID == conversation.id,
+                                            onSelect: { model.loadConversation(conversation) },
+                                            onDelete: { model.deleteConversation(conversation) })
+                    }
+                }
+                .listStyle(.sidebar)
+                .scrollContentBackground(.hidden)
+            }
+        }
+        .alert("Clear all history?", isPresented: $showingClearConfirmation) {
+            Button("Cancel", role: .cancel) {}
+            Button("Clear", role: .destructive) {
+                model.conversationStore.clearAll()
+                model.newConversation()
+            }
+        } message: {
+            Text("This action cannot be undone.")
+        }
+    }
+}
+
+/// A row in the conversation list.
+struct ConversationRowView: View {
+    let conversation: Conversation
+    let isActive: Bool
+    let onSelect: () -> Void
+    let onDelete: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 4) {
+                HStack {
+                    Text(conversation.title)
+                        .font(.callout.weight(isActive ? .semibold : .regular))
+                        .lineLimit(1)
+                    Spacer()
+                    Text(conversation.updatedAt, style: .relative)
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                }
+                Text(conversation.responsePreview)
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                    .lineLimit(2)
+                if let tokens = conversation.generatedTokenCount {
+                    Text("\(tokens) tokens")
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                }
+            }
+            .padding(.vertical, 2)
+        }
+        .buttonStyle(.plain)
+        .contextMenu {
+            Button("Open", action: onSelect)
+            Divider()
+            Button("Delete", role: .destructive, action: onDelete)
+        }
+        .swipeActions(edge: .trailing, allowsFullSwipe: true) {
+            Button(role: .destructive, action: onDelete) {
+                Label("Delete", systemImage: "trash")
+            }
+        }
+    }
+}
+
+#Preview {
+    ConversationSidebarView(model: AppModel())
+        .frame(width: 260, height: 400)
+}

--- a/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
@@ -1,4 +1,5 @@
 import SwiftUI
+import UniformTypeIdentifiers
 import TurboFieldfareAppCore
 
 /// Sidebar showing the conversation history.
@@ -6,6 +7,12 @@ struct ConversationSidebarView: View {
     @Bindable var model: AppModel
     @State private var searchText: String = ""
     @State private var showingClearConfirmation = false
+    @State private var exportDocument: ConversationsExportDocument?
+    @State private var showingExporter = false
+    @State private var showingImporter = false
+    @State private var importError: String?
+    @State private var importedCount: Int?
+    @FocusState private var searchFocused: Bool
 
     private var filteredConversations: [Conversation] {
         let items = model.conversationStore.conversations
@@ -20,7 +27,7 @@ struct ConversationSidebarView: View {
 
     var body: some View {
         VStack(spacing: 0) {
-            // Toolbar: new conversation + search
+            // Toolbar: new conversation + search + export/import
             VStack(spacing: 8) {
                 HStack {
                     Button {
@@ -31,24 +38,33 @@ struct ConversationSidebarView: View {
                     }
                     .buttonStyle(.borderless)
                     .disabled(model.isRunning)
+                    .keyboardShortcut("n", modifiers: .command)
 
                     Spacer()
 
                     if !model.conversationStore.conversations.isEmpty {
-                        Button(role: .destructive) {
-                            showingClearConfirmation = true
+                        Menu {
+                            Button("Export…") { prepareExport() }
+                            Button("Import…") { showingImporter = true }
+                            Divider()
+                            Button("Clear all", role: .destructive) {
+                                showingClearConfirmation = true
+                            }
                         } label: {
-                            Label("Clear all", systemImage: "trash")
+                            Label("More", systemImage: "ellipsis.circle")
                                 .labelStyle(.iconOnly)
                         }
-                        .buttonStyle(.borderless)
-                        .help("Clear all history")
+                        .menuStyle(.borderlessButton)
+                        .menuIndicator(.hidden)
+                        .fixedSize()
+                        .help("Export, import, or clear history")
                     }
                 }
 
                 TextField("Search…", text: $searchText)
                     .textFieldStyle(.roundedBorder)
                     .font(.callout)
+                    .focused($searchFocused)
             }
             .padding(.horizontal, 12)
             .padding(.vertical, 10)
@@ -70,15 +86,27 @@ struct ConversationSidebarView: View {
             } else {
                 List(selection: .constant(model.activeConversationID)) {
                     ForEach(filteredConversations) { conversation in
-                        ConversationRowView(conversation: conversation,
-                                            isActive: model.activeConversationID == conversation.id,
-                                            onSelect: { model.loadConversation(conversation) },
-                                            onDelete: { model.deleteConversation(conversation) })
+                        ConversationRowView(
+                            conversation: conversation,
+                            isActive: model.activeConversationID == conversation.id,
+                            onSelect: { model.loadConversation(conversation) },
+                            onDelete: { model.deleteConversation(conversation) },
+                            onRename: { model.renameConversation(conversation, title: $0) },
+                            onTogglePin: { model.togglePin(conversation) }
+                        )
                     }
                 }
                 .listStyle(.sidebar)
                 .scrollContentBackground(.hidden)
             }
+        }
+        .background {
+            // Hidden command: focus the search field (⌘F).
+            Button("") { searchFocused = true }
+                .keyboardShortcut("f", modifiers: .command)
+                .opacity(0)
+                .frame(width: 0, height: 0)
+                .accessibilityHidden(true)
         }
         .alert("Clear all history?", isPresented: $showingClearConfirmation) {
             Button("Cancel", role: .cancel) {}
@@ -89,6 +117,70 @@ struct ConversationSidebarView: View {
         } message: {
             Text("This action cannot be undone.")
         }
+        .alert("Import failed", isPresented: .init(
+            get: { importError != nil },
+            set: { if !$0 { importError = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text(importError ?? "")
+        }
+        .alert("Import complete", isPresented: .init(
+            get: { importedCount != nil },
+            set: { if !$0 { importedCount = nil } }
+        )) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("Imported \(importedCount ?? 0) conversation(s).")
+        }
+        .fileExporter(
+            isPresented: $showingExporter,
+            document: exportDocument,
+            contentType: .json,
+            defaultFilename: "turbofieldfare-conversations"
+        ) { _ in
+            exportDocument = nil
+        }
+        .fileImporter(
+            isPresented: $showingImporter,
+            allowedContentTypes: [.json]
+        ) { result in
+            switch result {
+            case .success(let url):
+                do {
+                    importedCount = try model.importConversations(from: url)
+                } catch {
+                    importError = error.localizedDescription
+                }
+            case .failure(let error):
+                importError = error.localizedDescription
+            }
+        }
+    }
+
+    private func prepareExport() {
+        guard let data = try? model.conversationStore.exportJSON() else { return }
+        exportDocument = ConversationsExportDocument(data: data)
+        showingExporter = true
+    }
+}
+
+/// JSON document backing the export sheet.
+struct ConversationsExportDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.json] }
+
+    var data: Data
+
+    init(data: Data) {
+        self.data = data
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        data = configuration.file.regularFileContents ?? Data()
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: data)
     }
 }
 
@@ -98,34 +190,56 @@ struct ConversationRowView: View {
     let isActive: Bool
     let onSelect: () -> Void
     let onDelete: () -> Void
+    let onRename: (String) -> Void
+    let onTogglePin: () -> Void
+    @State private var isRenaming = false
+    @State private var draftTitle = ""
 
     var body: some View {
-        Button(action: onSelect) {
-            VStack(alignment: .leading, spacing: 4) {
-                HStack {
-                    Text(conversation.title)
-                        .font(.callout.weight(isActive ? .semibold : .regular))
-                        .lineLimit(1)
-                    Spacer()
-                    Text(conversation.updatedAt, style: .relative)
-                        .font(.caption2)
+        HStack(spacing: 6) {
+            Button(action: onSelect) {
+                VStack(alignment: .leading, spacing: 4) {
+                    HStack {
+                        if conversation.isPinned {
+                            Image(systemName: "pin.fill")
+                                .font(.caption2)
+                                .foregroundStyle(.secondary)
+                        }
+                        if isRenaming {
+                            TextField("Title", text: $draftTitle)
+                                .textFieldStyle(.roundedBorder)
+                                .font(.callout.weight(.semibold))
+                                .onSubmit { commitRename() }
+                                .onExitCommand { isRenaming = false }
+                        } else {
+                            Text(conversation.title)
+                                .font(.callout.weight(isActive ? .semibold : .regular))
+                                .lineLimit(1)
+                                .onTapGesture(count: 2) { beginRename() }
+                        }
+                        Spacer()
+                        Text(conversation.updatedAt, style: .relative)
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                    }
+                    Text(conversation.responsePreview)
+                        .font(.caption)
                         .foregroundStyle(.secondary)
+                        .lineLimit(2)
+                    if let tokens = conversation.generatedTokenCount {
+                        Text("\(tokens) tokens")
+                            .font(.caption2)
+                            .foregroundStyle(.tertiary)
+                    }
                 }
-                Text(conversation.responsePreview)
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                    .lineLimit(2)
-                if let tokens = conversation.generatedTokenCount {
-                    Text("\(tokens) tokens")
-                        .font(.caption2)
-                        .foregroundStyle(.tertiary)
-                }
+                .padding(.vertical, 2)
             }
-            .padding(.vertical, 2)
+            .buttonStyle(.plain)
         }
-        .buttonStyle(.plain)
         .contextMenu {
             Button("Open", action: onSelect)
+            Button(conversation.isPinned ? "Unpin" : "Pin", action: onTogglePin)
+            Button("Rename", action: beginRename)
             Divider()
             Button("Delete", role: .destructive, action: onDelete)
         }
@@ -134,6 +248,16 @@ struct ConversationRowView: View {
                 Label("Delete", systemImage: "trash")
             }
         }
+    }
+
+    private func beginRename() {
+        draftTitle = conversation.title
+        isRenaming = true
+    }
+
+    private func commitRename() {
+        isRenaming = false
+        onRename(draftTitle)
     }
 }
 

--- a/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
@@ -1,6 +1,7 @@
 import SwiftUI
 import UniformTypeIdentifiers
 import TurboFieldfareAppCore
+import TurboFieldfareMacPresentation
 
 /// Sidebar showing the conversation history.
 struct ConversationSidebarView: View {
@@ -17,11 +18,23 @@ struct ConversationSidebarView: View {
     @State private var markdownDocument: MarkdownExportDocument?
     @State private var showingMarkdownExporter = false
     @State private var markdownFilename = "conversation"
+    @State private var showingTemplatesOnly = false
+    @State private var editingTagsConversation: Conversation?
+    @State private var tagsDraft = ""
 
     private var filteredConversations: [Conversation] {
-        let items = model.conversationStore.conversations
+        var items = model.conversationStore.conversations
+        if showingTemplatesOnly {
+            items = items.filter(\.isTemplate)
+        }
         guard !searchText.isEmpty else { return items }
         let query = searchText.lowercased()
+        if query.hasPrefix("#") {
+            let tag = String(query.dropFirst())
+            return items.filter { conversation in
+                conversation.tags.contains { $0.lowercased().contains(tag) }
+            }
+        }
         return items.filter {
             $0.title.lowercased().contains(query)
                 || $0.turns.contains { turn in
@@ -46,6 +59,22 @@ struct ConversationSidebarView: View {
                     .keyboardShortcut("n", modifiers: .command)
 
                     Spacer()
+
+                    if model.conversationStore.conversations.contains(where: \.isTemplate) {
+                        Button {
+                            showingTemplatesOnly.toggle()
+                        } label: {
+                            Label("Templates", systemImage: "square.stack.3d.up")
+                                .labelStyle(.iconOnly)
+                        }
+                        .buttonStyle(.borderless)
+                        .foregroundStyle(showingTemplatesOnly
+                                         ? TurboFieldfareMacTheme.accentColor
+                                         : Color.secondary)
+                        .help(showingTemplatesOnly
+                              ? "Show all conversations"
+                              : "Show templates only")
+                    }
 
                     if !model.conversationStore.conversations.isEmpty {
                         Menu {
@@ -99,6 +128,14 @@ struct ConversationSidebarView: View {
                             onRename: { model.renameConversation(conversation, title: $0) },
                             onTogglePin: { model.togglePin(conversation) },
                             onFork: { model.forkConversation(conversation) },
+                            onToggleTemplate: {
+                                model.setTemplate(conversation,
+                                                  isTemplate: !conversation.isTemplate)
+                            },
+                            onEditTags: {
+                                tagsDraft = conversation.tags.joined(separator: ", ")
+                                editingTagsConversation = conversation
+                            },
                             onExportMarkdown: {
                                 markdownFilename = Self.safeFilename(conversation.title)
                                 markdownDocument = MarkdownExportDocument(
@@ -138,6 +175,25 @@ struct ConversationSidebarView: View {
             }
         } message: {
             Text("This action cannot be undone.")
+        }
+        .alert("Edit tags", isPresented: .init(
+            get: { editingTagsConversation != nil },
+            set: { if !$0 { editingTagsConversation = nil } }
+        )) {
+            TextField("Tags (comma separated)", text: $tagsDraft)
+            Button("Save") {
+                if let conversation = editingTagsConversation {
+                    let tags = tagsDraft.split(separator: ",")
+                        .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                    model.setTags(conversation, tags: tags)
+                }
+                editingTagsConversation = nil
+            }
+            Button("Cancel", role: .cancel) {
+                editingTagsConversation = nil
+            }
+        } message: {
+            Text("Tags are used to filter the history (search #tag).")
         }
         .alert("Import failed", isPresented: .init(
             get: { importError != nil },
@@ -251,6 +307,8 @@ struct ConversationRowView: View {
     let onRename: (String) -> Void
     let onTogglePin: () -> Void
     let onFork: () -> Void
+    let onToggleTemplate: () -> Void
+    let onEditTags: () -> Void
     let onExportMarkdown: () -> Void
     @State private var isRenaming = false
     @State private var draftTitle = ""
@@ -299,6 +357,9 @@ struct ConversationRowView: View {
         .contextMenu {
             Button("Open", action: onSelect)
             Button(conversation.isPinned ? "Unpin" : "Pin", action: onTogglePin)
+            Button(conversation.isTemplate ? "Remove template" : "Save as template",
+                   action: onToggleTemplate)
+            Button("Edit Tags…", action: onEditTags)
             Button("Rename", action: beginRename)
             Button("Fork", action: onFork)
             Divider()

--- a/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
@@ -21,6 +21,7 @@ struct ConversationSidebarView: View {
     @State private var showingTemplatesOnly = false
     @State private var editingTagsConversation: Conversation?
     @State private var tagsDraft = ""
+    @State private var comparison: ComparisonPair?
 
     private var filteredConversations: [Conversation] {
         var items = model.conversationStore.conversations
@@ -136,6 +137,16 @@ struct ConversationSidebarView: View {
                                 tagsDraft = conversation.tags.joined(separator: ", ")
                                 editingTagsConversation = conversation
                             },
+                            onCompare: {
+                                guard let other = model
+                                    .conversationsSharingPrompt(with: conversation).first else {
+                                    return
+                                }
+                                comparison = ComparisonPair(a: conversation, b: other)
+                            },
+                            onSummarize: {
+                                model.beginSummary(of: conversation)
+                            },
                             onExportMarkdown: {
                                 markdownFilename = Self.safeFilename(conversation.title)
                                 markdownDocument = MarkdownExportDocument(
@@ -156,6 +167,9 @@ struct ConversationSidebarView: View {
                 .opacity(0)
                 .frame(width: 0, height: 0)
                 .accessibilityHidden(true)
+        }
+        .sheet(item: $comparison) { pair in
+            ComparisonView(a: pair.a, b: pair.b)
         }
         .onAppear {
             if model.conversationStore.didLoadFromCorrupted {
@@ -309,6 +323,8 @@ struct ConversationRowView: View {
     let onFork: () -> Void
     let onToggleTemplate: () -> Void
     let onEditTags: () -> Void
+    let onCompare: () -> Void
+    let onSummarize: () -> Void
     let onExportMarkdown: () -> Void
     @State private var isRenaming = false
     @State private var draftTitle = ""
@@ -362,6 +378,8 @@ struct ConversationRowView: View {
             Button("Edit Tags…", action: onEditTags)
             Button("Rename", action: beginRename)
             Button("Fork", action: onFork)
+            Button("Compare with latest run", action: onCompare)
+            Button("Summarize", action: onSummarize)
             Divider()
             Button("Export Markdown…", action: onExportMarkdown)
             Divider()
@@ -382,6 +400,50 @@ struct ConversationRowView: View {
     private func commitRename() {
         isRenaming = false
         onRename(draftTitle)
+    }
+}
+
+/// A conversation pair backing the comparison sheet.
+struct ComparisonPair: Identifiable {
+    let a: Conversation
+    let b: Conversation
+    var id: UUID { a.id }
+}
+
+/// Side-by-side view of two runs of the same prompt.
+struct ComparisonView: View {
+    let a: Conversation
+    let b: Conversation
+
+    var body: some View {
+        HStack(spacing: 0) {
+            column(a)
+            Divider()
+            column(b)
+        }
+        .frame(width: 760, height: 460)
+    }
+
+    private func column(_ conversation: Conversation) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text(conversation.title)
+                .font(.headline)
+                .lineLimit(1)
+            Text(conversation.updatedAt, style: .relative)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            Text(conversation.lastResponse)
+                .font(.caption)
+                .textSelection(.enabled)
+                .frame(maxWidth: .infinity, maxHeight: .infinity,
+                       alignment: .topLeading)
+            if let tokens = conversation.generatedTokenCount {
+                Text("\(tokens) tokens")
+                    .font(.caption2)
+                    .foregroundStyle(.tertiary)
+            }
+        }
+        .padding(16)
     }
 }
 

--- a/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
@@ -333,11 +333,18 @@ struct ConversationRowView: View {
         HStack(spacing: 6) {
             Button(action: onSelect) {
                 VStack(alignment: .leading, spacing: 4) {
-                    HStack {
+                    HStack(spacing: 4) {
                         if conversation.isPinned {
                             Image(systemName: "pin.fill")
-                                .font(.caption2)
-                                .foregroundStyle(.secondary)
+                                .font(.system(size: 9))
+                                .foregroundStyle(TurboFieldfareMacTheme.accentColor)
+                                .accessibilityHidden(true)
+                        }
+                        if conversation.isTemplate {
+                            Image(systemName: "square.stack.3d.up")
+                                .font(.system(size: 9))
+                                .foregroundStyle(.orange)
+                                .accessibilityHidden(true)
                         }
                         if isRenaming {
                             TextField("Title", text: $draftTitle)
@@ -351,7 +358,7 @@ struct ConversationRowView: View {
                                 .lineLimit(1)
                                 .onTapGesture(count: 2) { beginRename() }
                         }
-                        Spacer()
+                        Spacer(minLength: 4)
                         Text(conversation.updatedAt, style: .relative)
                             .font(.caption2)
                             .foregroundStyle(.secondary)
@@ -360,10 +367,14 @@ struct ConversationRowView: View {
                         .font(.caption)
                         .foregroundStyle(.secondary)
                         .lineLimit(2)
-                    if let tokens = conversation.generatedTokenCount {
-                        Text("\(tokens) tokens")
-                            .font(.caption2)
-                            .foregroundStyle(.tertiary)
+                    HStack(spacing: 6) {
+                        if let tokens = conversation.generatedTokenCount {
+                            Text("\(tokens) tok")
+                                .font(.caption2)
+                                .foregroundStyle(.tertiary)
+                        }
+                        tagBadges
+                        Spacer(minLength: 0)
                     }
                 }
                 .padding(.vertical, 2)
@@ -400,6 +411,26 @@ struct ConversationRowView: View {
     private func commitRename() {
         isRenaming = false
         onRename(draftTitle)
+    }
+
+    /// Compact tag badges (first two + an overflow count).
+    @ViewBuilder
+    private var tagBadges: some View {
+        let visible = conversation.tags.prefix(2)
+        ForEach(Array(visible.enumerated()), id: \.offset) { _, tag in
+            Text("#\(tag)")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.secondary)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 1)
+                .background(.quaternary.opacity(0.3), in: Capsule())
+                .lineLimit(1)
+        }
+        if conversation.tags.count > 2 {
+            Text("+\(conversation.tags.count - 2)")
+                .font(.system(size: 9, weight: .medium))
+                .foregroundStyle(.tertiary)
+        }
     }
 }
 

--- a/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
@@ -14,6 +14,9 @@ struct ConversationSidebarView: View {
     @State private var importedCount: Int?
     @FocusState private var searchFocused: Bool
     @State private var showingCorruptionWarning = false
+    @State private var markdownDocument: MarkdownExportDocument?
+    @State private var showingMarkdownExporter = false
+    @State private var markdownFilename = "conversation"
 
     private var filteredConversations: [Conversation] {
         let items = model.conversationStore.conversations
@@ -94,7 +97,14 @@ struct ConversationSidebarView: View {
                             onSelect: { model.loadConversation(conversation) },
                             onDelete: { model.deleteConversation(conversation) },
                             onRename: { model.renameConversation(conversation, title: $0) },
-                            onTogglePin: { model.togglePin(conversation) }
+                            onTogglePin: { model.togglePin(conversation) },
+                            onFork: { model.forkConversation(conversation) },
+                            onExportMarkdown: {
+                                markdownFilename = Self.safeFilename(conversation.title)
+                                markdownDocument = MarkdownExportDocument(
+                                    text: model.exportConversationMarkdown(conversation))
+                                showingMarkdownExporter = true
+                            }
                         )
                     }
                 }
@@ -153,6 +163,14 @@ struct ConversationSidebarView: View {
         ) { _ in
             exportDocument = nil
         }
+        .fileExporter(
+            isPresented: $showingMarkdownExporter,
+            document: markdownDocument,
+            contentType: .plainText,
+            defaultFilename: markdownFilename
+        ) { _ in
+            markdownDocument = nil
+        }
         .fileImporter(
             isPresented: $showingImporter,
             allowedContentTypes: [.json]
@@ -174,6 +192,34 @@ struct ConversationSidebarView: View {
         guard let data = try? model.conversationStore.exportJSON() else { return }
         exportDocument = ConversationsExportDocument(data: data)
         showingExporter = true
+    }
+
+    /// Builds a filesystem-safe filename from a conversation title.
+    static func safeFilename(_ title: String) -> String {
+        let invalid = CharacterSet(charactersIn: "/\\:?%*|\"<>")
+        let cleaned = title.components(separatedBy: invalid).joined()
+        let trimmed = cleaned.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "conversation" : trimmed
+    }
+}
+
+/// Markdown document backing the per-conversation export sheet.
+struct MarkdownExportDocument: FileDocument {
+    static var readableContentTypes: [UTType] { [.plainText] }
+
+    var text: String
+
+    init(text: String) {
+        self.text = text
+    }
+
+    init(configuration: ReadConfiguration) throws {
+        text = String(data: configuration.file.regularFileContents ?? Data(),
+                      encoding: .utf8) ?? ""
+    }
+
+    func fileWrapper(configuration: WriteConfiguration) throws -> FileWrapper {
+        FileWrapper(regularFileWithContents: Data(text.utf8))
     }
 }
 
@@ -204,6 +250,8 @@ struct ConversationRowView: View {
     let onDelete: () -> Void
     let onRename: (String) -> Void
     let onTogglePin: () -> Void
+    let onFork: () -> Void
+    let onExportMarkdown: () -> Void
     @State private var isRenaming = false
     @State private var draftTitle = ""
 
@@ -252,6 +300,9 @@ struct ConversationRowView: View {
             Button("Open", action: onSelect)
             Button(conversation.isPinned ? "Unpin" : "Pin", action: onTogglePin)
             Button("Rename", action: beginRename)
+            Button("Fork", action: onFork)
+            Divider()
+            Button("Export Markdown…", action: onExportMarkdown)
             Divider()
             Button("Delete", role: .destructive, action: onDelete)
         }

--- a/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
@@ -13,6 +13,7 @@ struct ConversationSidebarView: View {
     @State private var importError: String?
     @State private var importedCount: Int?
     @FocusState private var searchFocused: Bool
+    @State private var showingCorruptionWarning = false
 
     private var filteredConversations: [Conversation] {
         let items = model.conversationStore.conversations
@@ -107,6 +108,16 @@ struct ConversationSidebarView: View {
                 .opacity(0)
                 .frame(width: 0, height: 0)
                 .accessibilityHidden(true)
+        }
+        .onAppear {
+            if model.conversationStore.didLoadFromCorrupted {
+                showingCorruptionWarning = true
+            }
+        }
+        .alert("History file unreadable", isPresented: $showingCorruptionWarning) {
+            Button("OK", role: .cancel) {}
+        } message: {
+            Text("The previous history file was corrupted and was moved aside; a fresh empty history was started. The unreadable file was renamed to conversations.json.corrupted.")
         }
         .alert("Clear all history?", isPresented: $showingClearConfirmation) {
             Button("Cancel", role: .cancel) {}

--- a/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/ConversationSidebarView.swift
@@ -21,8 +21,9 @@ struct ConversationSidebarView: View {
         let query = searchText.lowercased()
         return items.filter {
             $0.title.lowercased().contains(query)
-                || $0.prompt.lowercased().contains(query)
-                || $0.response.lowercased().contains(query)
+                || $0.turns.contains { turn in
+                    turn.text.lowercased().contains(query)
+                }
         }
     }
 

--- a/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
@@ -1,4 +1,5 @@
 import AppKit
+import TurboFieldfare
 import TurboFieldfareAppCore
 import TurboFieldfareMacPresentation
 import SwiftUI
@@ -58,23 +59,31 @@ struct OutputPaneView: View {
         .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
 
+    @ViewBuilder
     private var transcript: some View {
-        IncrementalTranscriptView(
-            prompt: model.outputPromptText,
-            output: model.outputText,
-            mailbox: model.generationTranscriptMailbox,
-            isTerminal: !model.isRunning,
-            showsPrefillPlaceholder: model.isRunning
-                && model.outputResponsePlainText.isEmpty)
-            .frame(maxWidth: .infinity, maxHeight: .infinity)
-            .overlay(alignment: .topTrailing) {
-                if !model.isRunning && !model.outputResponsePlainText.isEmpty {
-                    copyResponseButton
-                        .padding(8)
+        if !model.cognitiveTranscript.isEmpty && !model.isRunning {
+            CognitiveTranscriptView(segments: model.cognitiveTranscript)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 20)
+        } else {
+            IncrementalTranscriptView(
+                prompt: model.outputPromptText,
+                output: model.outputText,
+                mailbox: model.generationTranscriptMailbox,
+                isTerminal: !model.isRunning,
+                showsPrefillPlaceholder: model.isRunning
+                    && model.outputResponsePlainText.isEmpty)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .overlay(alignment: .topTrailing) {
+                    if !model.isRunning && !model.outputResponsePlainText.isEmpty {
+                        copyResponseButton
+                            .padding(8)
+                    }
                 }
-            }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 20)
+                .padding(.horizontal, 24)
+                .padding(.vertical, 20)
+        }
     }
 
     private var copyResponseButton: some View {
@@ -457,6 +466,53 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
         coordinator.invalidate()
+    }
+}
+
+/// Collapsible per-pass view of a completed cognitive cycle.
+private struct CognitiveTranscriptView: View {
+    let segments: [CognitivePassSegment]
+    @State private var expanded = Set<CognitiveStepKind>()
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 12) {
+                ForEach(segments) { segment in
+                    DisclosureGroup(isExpanded: binding(for: segment.kind)) {
+                        Text(segment.text)
+                            .font(.system(.caption, design: .monospaced))
+                            .textSelection(.enabled)
+                            .frame(maxWidth: .infinity, alignment: .leading)
+                            .padding(.top, 4)
+                    } label: {
+                        Label(segment.kind.header, systemImage: icon(for: segment.kind))
+                            .font(.callout.weight(.semibold))
+                    }
+                }
+            }
+            .padding(16)
+        }
+    }
+
+    private func binding(for kind: CognitiveStepKind) -> Binding<Bool> {
+        Binding(
+            get: { expanded.contains(kind) },
+            set: { isExpanded in
+                if isExpanded {
+                    expanded.insert(kind)
+                } else {
+                    expanded.remove(kind)
+                }
+            })
+    }
+
+    private func icon(for kind: CognitiveStepKind) -> String {
+        switch kind {
+        case .plan: return "list.bullet"
+        case .draft: return "doc.text"
+        case .critique: return "exclamationmark.triangle"
+        case .final: return "checkmark.seal"
+        }
     }
 }
 

--- a/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
@@ -476,34 +476,69 @@ private struct CognitiveTranscriptView: View {
 
     var body: some View {
         ScrollView {
-            VStack(alignment: .leading, spacing: 12) {
+            VStack(alignment: .leading, spacing: 14) {
                 ForEach(segments) { segment in
-                    DisclosureGroup(isExpanded: binding(for: segment.kind)) {
-                        Text(segment.text)
-                            .font(.system(.caption, design: .monospaced))
-                            .textSelection(.enabled)
-                            .frame(maxWidth: .infinity, alignment: .leading)
-                            .padding(.top, 4)
-                    } label: {
-                        Label(segment.kind.header, systemImage: icon(for: segment.kind))
-                            .font(.callout.weight(.semibold))
-                    }
+                    passCard(segment)
                 }
             }
             .padding(16)
+            .frame(maxWidth: .infinity, alignment: .leading)
         }
     }
 
-    private func binding(for kind: CognitiveStepKind) -> Binding<Bool> {
-        Binding(
-            get: { expanded.contains(kind) },
-            set: { isExpanded in
-                if isExpanded {
-                    expanded.insert(kind)
-                } else {
-                    expanded.remove(kind)
+    private func passCard(_ segment: CognitivePassSegment) -> some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Button {
+                toggle(segment.kind)
+            } label: {
+                HStack(spacing: 8) {
+                    Image(systemName: icon(for: segment.kind))
+                        .font(.caption)
+                        .foregroundStyle(tint(for: segment.kind))
+                    Text(segment.kind.header)
+                        .font(.callout.weight(.semibold))
+                    Spacer()
+                    Image(systemName: expanded.contains(segment.kind)
+                          ? "chevron.up" : "chevron.down")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
                 }
-            })
+            }
+            .buttonStyle(.plain)
+
+            if expanded.contains(segment.kind) {
+                Text(segment.text)
+                    .font(.system(.caption, design: .monospaced))
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(12)
+        .background {
+            RoundedRectangle(cornerRadius: TurboFieldfareAppearance.cornerRadius)
+                .fill(tint(for: segment.kind).opacity(0.07))
+                .overlay {
+                    RoundedRectangle(cornerRadius: TurboFieldfareAppearance.cornerRadius)
+                        .stroke(tint(for: segment.kind).opacity(0.25), lineWidth: 1)
+                }
+        }
+    }
+
+    private func toggle(_ kind: CognitiveStepKind) {
+        if expanded.contains(kind) {
+            expanded.remove(kind)
+        } else {
+            expanded.insert(kind)
+        }
+    }
+
+    private func tint(for kind: CognitiveStepKind) -> Color {
+        switch kind {
+        case .plan: return TurboFieldfareMacTheme.accentColor
+        case .draft: return .blue
+        case .critique: return .orange
+        case .final: return TurboFieldfareMacTheme.accentColor
+        }
     }
 
     private func icon(for kind: CognitiveStepKind) -> String {

--- a/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
@@ -66,21 +66,28 @@ struct OutputPaneView: View {
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .padding(.horizontal, 24)
                 .padding(.vertical, 20)
+        } else if !model.isRunning {
+            // Terminal state: render the answer as formatted Markdown.
+            MarkdownTranscriptView(
+                prompt: model.outputPromptText,
+                response: model.outputResponsePlainText)
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .overlay(alignment: .topTrailing) {
+                    if !model.outputResponsePlainText.isEmpty {
+                        copyResponseButton
+                            .padding(8)
+                    }
+                }
+                .padding(.horizontal, 24)
+                .padding(.vertical, 20)
         } else {
             IncrementalTranscriptView(
                 prompt: model.outputPromptText,
                 output: model.outputText,
                 mailbox: model.generationTranscriptMailbox,
-                isTerminal: !model.isRunning,
-                showsPrefillPlaceholder: model.isRunning
-                    && model.outputResponsePlainText.isEmpty)
+                isTerminal: false,
+                showsPrefillPlaceholder: model.outputResponsePlainText.isEmpty)
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
-                .overlay(alignment: .topTrailing) {
-                    if !model.isRunning && !model.outputResponsePlainText.isEmpty {
-                        copyResponseButton
-                            .padding(8)
-                    }
-                }
                 .padding(.horizontal, 24)
                 .padding(.vertical, 20)
         }
@@ -466,6 +473,47 @@ private struct IncrementalTranscriptView: NSViewRepresentable {
 
     static func dismantleNSView(_ nsView: NSScrollView, coordinator: Coordinator) {
         coordinator.invalidate()
+    }
+}
+
+/// Terminal transcript rendered as formatted Markdown: prompt above,
+/// generated answer below.
+private struct MarkdownTranscriptView: View {
+    let prompt: String
+    let response: String
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 18) {
+                if !prompt.isEmpty {
+                    Text(prompt)
+                        .font(.callout)
+                        .italic()
+                        .foregroundStyle(.secondary)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+                if !response.isEmpty {
+                    Text(rendered)
+                        .font(.body)
+                        .textSelection(.enabled)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                }
+            }
+            .padding(4)
+            .frame(maxWidth: .infinity, alignment: .leading)
+        }
+    }
+
+    /// Parses Markdown leniently, falling back to plain text when the model
+    /// produced something the parser cannot handle.
+    private var rendered: AttributedString {
+        (try? AttributedString(
+            markdown: response,
+            options: AttributedString.MarkdownParsingOptions(
+                interpretedSyntax: .full,
+                failurePolicy: .returnPartiallyParsedIfPossible)))
+            ?? AttributedString(response)
     }
 }
 

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
@@ -74,9 +74,37 @@ struct PromptComposerView: View {
             
             HStack(spacing: 10) {
                 promptTips
+                estimatedContextHint
                 Spacer()
                 clearAction
                 GenerateControl(model: model)
+            }
+        }
+    }
+
+    private var estimatedContextHint: some View {
+        Group {
+            if model.estimatedPromptTokenCount > 0 {
+                Label {
+                    Text("≈ \(model.estimatedPromptTokenCount) tokens")
+                } icon: {
+                    Image(systemName: "text.magnifyingglass")
+                }
+                .font(.caption)
+                .foregroundStyle(model.estimatedPromptExceedsContext
+                                 ? AnyShapeStyle(Color.orange)
+                                 : AnyShapeStyle(.tertiary))
+                .help(model.estimatedPromptExceedsContext
+                      ? "Estimated prompt exceeds the \(model.maxContextTokens)-token context window; tokens beyond the window would be cut."
+                      : "Estimated prompt length, including attached documents.")
+                .padding(.horizontal, 8)
+                .padding(.vertical, 3)
+                .background {
+                    Capsule()
+                        .fill(model.estimatedPromptExceedsContext
+                              ? Color.orange.opacity(0.12)
+                              : Color.secondary.opacity(0.08))
+                }
             }
         }
     }

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
@@ -16,12 +16,16 @@ struct PromptComposerView: View {
         .padding(14)
         .background {
             RoundedRectangle(cornerRadius: 22)
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .fill(TurboFieldfareAppearance.surface)
                 .overlay {
                     RoundedRectangle(cornerRadius: 22)
-                        .stroke(.separator.opacity(0.5), lineWidth: 0.5)
+                        .stroke(promptFocused
+                                ? AnyShapeStyle(TurboFieldfareMacTheme.accentColor.opacity(0.7))
+                                : AnyShapeStyle(.separator.opacity(0.5)),
+                                lineWidth: promptFocused ? 1.2 : 0.5)
                 }
         }
+        .animation(.smooth(duration: 0.18), value: promptFocused)
     }
 
     private var editor: some View {
@@ -51,13 +55,19 @@ struct PromptComposerView: View {
                 if model.promptText.isEmpty {
                     // Matches the NSTextView text origin: 5pt line fragment
                     // padding, no vertical inset.
-                    Text(model.activeConversationTurns.isEmpty
-                         ? "Prompt"
-                         : "Continue the conversation…")
-                        .font(.body)
-                        .foregroundStyle(.tertiary)
-                        .padding(.leading, 5)
-                        .allowsHitTesting(false)
+                    HStack(spacing: 8) {
+                        Image(systemName: model.activeConversationTurns.isEmpty
+                              ? "text.cursor"
+                              : "arrow.up.and.down.text.horizontal")
+                            .foregroundStyle(.tertiary)
+                        Text(model.activeConversationTurns.isEmpty
+                             ? "Prompt"
+                             : "Continue the conversation…")
+                            .foregroundStyle(.tertiary)
+                    }
+                    .font(.body)
+                    .padding(.leading, 5)
+                    .allowsHitTesting(false)
                 }
             }
     }

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
@@ -69,11 +69,15 @@ struct PromptComposerView: View {
     }
 
     private var footer: some View {
-        HStack(spacing: 10) {
-            promptTips
-            Spacer()
-            clearAction
-            GenerateControl(model: model)
+        VStack(alignment: .leading, spacing: 10) {
+            DocumentAttachmentView(model: model)
+            
+            HStack(spacing: 10) {
+                promptTips
+                Spacer()
+                clearAction
+                GenerateControl(model: model)
+            }
         }
     }
 

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
@@ -51,7 +51,9 @@ struct PromptComposerView: View {
                 if model.promptText.isEmpty {
                     // Matches the NSTextView text origin: 5pt line fragment
                     // padding, no vertical inset.
-                    Text("Prompt")
+                    Text(model.activeConversationTurns.isEmpty
+                         ? "Prompt"
+                         : "Continue the conversation…")
                         .font(.body)
                         .foregroundStyle(.tertiary)
                         .padding(.leading, 5)

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptExamplesView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptExamplesView.swift
@@ -1,8 +1,10 @@
 import TurboFieldfareAppCore
+import TurboFieldfareMacPresentation
 import SwiftUI
 
 struct PromptExamplesView: View {
     let select: (AppPromptPreset) -> Void
+    @State private var hoveredPresetID: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 12) {
@@ -38,34 +40,13 @@ struct PromptExamplesView: View {
     @ViewBuilder
     private var primaryCards: some View {
         ForEach(AppPromptPreset.primary) { preset in
-            Button {
-                select(preset)
-            } label: {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(preset.title)
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(.primary)
-                        .lineLimit(2)
-                    Text(preset.prompt)
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .multilineTextAlignment(.leading)
-                        .lineLimit(3)
-                    Spacer(minLength: 0)
-                }
-                .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
-                .padding(10)
-                .contentShape(.rect)
-            }
-            .buttonStyle(.plain)
-            .background(.quaternary.opacity(0.25), in: .rect(cornerRadius: 12))
-            .overlay {
-                RoundedRectangle(cornerRadius: 12)
-                    .stroke(.separator.opacity(0.35), lineWidth: 0.5)
-            }
-            .accessibilityLabel(preset.title)
-            .accessibilityValue(preset.prompt)
-            .accessibilityHint("Copies this prompt into the prompt editor")
+            PromptPresetCard(
+                preset: preset,
+                isHovered: hoveredPresetID == preset.id,
+                select: { select(preset) },
+                onHover: { hovering in
+                    hoveredPresetID = hovering ? preset.id : nil
+                })
         }
     }
 
@@ -89,5 +70,74 @@ struct PromptExamplesView: View {
         .menuStyle(.borderlessButton)
         .fixedSize()
         .accessibilityHint("Shows additional prompts")
+    }
+
+    private func fillStyle(hovered: Bool) -> AnyShapeStyle {
+        if hovered {
+            return AnyShapeStyle(TurboFieldfareMacTheme.accentColor.opacity(0.12))
+        }
+        return AnyShapeStyle(.quaternary.opacity(0.25))
+    }
+
+    private func strokeStyle(hovered: Bool) -> AnyShapeStyle {
+        if hovered {
+            return AnyShapeStyle(TurboFieldfareMacTheme.accentColor.opacity(0.45))
+        }
+        return AnyShapeStyle(.separator.opacity(0.35))
+    }
+}
+
+/// A tappable prompt example card with a hover state.
+private struct PromptPresetCard: View {
+    let preset: AppPromptPreset
+    let isHovered: Bool
+    let select: () -> Void
+    let onHover: (Bool) -> Void
+
+    var body: some View {
+        Button(action: select) {
+            VStack(alignment: .leading, spacing: 6) {
+                Text(preset.title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.primary)
+                    .lineLimit(2)
+                Text(preset.prompt)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .multilineTextAlignment(.leading)
+                    .lineLimit(3)
+                Spacer(minLength: 0)
+            }
+            .frame(maxWidth: .infinity, minHeight: 96, alignment: .topLeading)
+            .padding(10)
+            .contentShape(.rect)
+        }
+        .buttonStyle(.plain)
+        .background(
+            fillStyle,
+            in: RoundedRectangle(cornerRadius: 12)
+        )
+        .overlay {
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(strokeStyle, lineWidth: 1)
+        }
+        .onHover(perform: onHover)
+        .accessibilityLabel(preset.title)
+        .accessibilityValue(preset.prompt)
+        .accessibilityHint("Copies this prompt into the prompt editor")
+    }
+
+    private var fillStyle: AnyShapeStyle {
+        if isHovered {
+            return AnyShapeStyle(TurboFieldfareMacTheme.accentColor.opacity(0.12))
+        }
+        return AnyShapeStyle(.quaternary.opacity(0.25))
+    }
+
+    private var strokeStyle: AnyShapeStyle {
+        if isHovered {
+            return AnyShapeStyle(TurboFieldfareMacTheme.accentColor.opacity(0.45))
+        }
+        return AnyShapeStyle(.separator.opacity(0.35))
     }
 }

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptExamplesView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptExamplesView.swift
@@ -25,7 +25,7 @@ struct PromptExamplesView: View {
         .padding(14)
         .background {
             RoundedRectangle(cornerRadius: 18)
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .fill(TurboFieldfareAppearance.surface)
                 .overlay {
                     RoundedRectangle(cornerRadius: 18)
                         .stroke(.separator.opacity(0.5), lineWidth: 0.5)

--- a/Sources/TurboFieldfareApp/Mac/Installation/ModelInstallView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Installation/ModelInstallView.swift
@@ -82,7 +82,7 @@ struct ModelInstallView: View {
         .padding(18)
         .background {
             RoundedRectangle(cornerRadius: 20)
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .fill(TurboFieldfareAppearance.surface)
                 .overlay {
                     RoundedRectangle(cornerRadius: 20)
                         .stroke(.separator.opacity(0.5), lineWidth: 0.5)
@@ -112,6 +112,7 @@ struct ModelInstallView: View {
                    let downloaded = model.installDownloadedBytes,
                    let total = model.installTotalBytes {
                     ProgressView(value: fraction)
+                        .tint(TurboFieldfareMacTheme.accentColor)
                         .accessibilityLabel("Model download")
                         .accessibilityValue(Text(accessibleProgressValue(fraction: fraction)))
                     HStack {

--- a/Sources/TurboFieldfareCLI/Args.swift
+++ b/Sources/TurboFieldfareCLI/Args.swift
@@ -11,6 +11,7 @@ public struct Args: Equatable, Sendable {
     public var seed: UInt64?
     public var stops: [String]
     public var quiet: Bool
+    public var cognitiveMode: Bool
 
     public init(model: String,
                 prompt: String? = nil,
@@ -23,7 +24,8 @@ public struct Args: Equatable, Sendable {
                 repetitionPenalty: Float = 1.0,
                 seed: UInt64? = nil,
                 stops: [String] = [],
-                quiet: Bool = false) {
+                quiet: Bool = false,
+                cognitiveMode: Bool = false) {
         self.model = model
         self.prompt = prompt
         self.messagesFile = messagesFile
@@ -36,6 +38,7 @@ public struct Args: Equatable, Sendable {
         self.seed = seed
         self.stops = stops
         self.quiet = quiet
+        self.cognitiveMode = cognitiveMode
     }
 }
 
@@ -82,6 +85,8 @@ extension Args {
       --seed <uint64>           Deterministic sampling seed (default off).
       --stop <string>           Stop substring (repeatable).
       --quiet                   Suppress the timing footer.
+      --cognitive-mode          Run the advanced cognitive cycle (plan, draft,
+                                critique, final revision) for each request.
       --help                    Show this message.
     """
 
@@ -98,6 +103,7 @@ extension Args {
         var seed: UInt64?
         var stops: [String] = []
         var quiet = false
+        var cognitiveMode = false
 
         var index = 0
         while index < argv.count {
@@ -158,6 +164,9 @@ extension Args {
                 seed = parsed
             case "--stop":
                 stops.append(try takeValue(argv, &index, flag: flag))
+            case "--cognitive-mode":
+                cognitiveMode = true
+                index += 1
             default:
                 throw ArgsError.unknownFlag(flag)
             }
@@ -184,7 +193,8 @@ extension Args {
                     repetitionPenalty: repetitionPenalty,
                     seed: seed,
                     stops: stops,
-                    quiet: quiet)
+                    quiet: quiet,
+                    cognitiveMode: cognitiveMode)
     }
 
     private static func takeValue(_ argv: [String],

--- a/Sources/TurboFieldfareCLI/Args.swift
+++ b/Sources/TurboFieldfareCLI/Args.swift
@@ -12,6 +12,7 @@ public struct Args: Equatable, Sendable {
     public var stops: [String]
     public var quiet: Bool
     public var cognitiveMode: Bool
+    public var exportConversations: String?
 
     public init(model: String,
                 prompt: String? = nil,
@@ -25,7 +26,8 @@ public struct Args: Equatable, Sendable {
                 seed: UInt64? = nil,
                 stops: [String] = [],
                 quiet: Bool = false,
-                cognitiveMode: Bool = false) {
+                cognitiveMode: Bool = false,
+                exportConversations: String? = nil) {
         self.model = model
         self.prompt = prompt
         self.messagesFile = messagesFile
@@ -39,6 +41,7 @@ public struct Args: Equatable, Sendable {
         self.stops = stops
         self.quiet = quiet
         self.cognitiveMode = cognitiveMode
+        self.exportConversations = exportConversations
     }
 }
 
@@ -87,6 +90,8 @@ extension Args {
       --quiet                   Suppress the timing footer.
       --cognitive-mode          Run the advanced cognitive cycle (plan, draft,
                                 critique, final revision) for each request.
+      --export-conversations    Copy the app conversation history JSON to the
+                                given path and exit (no model needed).
       --help                    Show this message.
     """
 
@@ -104,6 +109,7 @@ extension Args {
         var stops: [String] = []
         var quiet = false
         var cognitiveMode = false
+        var exportConversations: String?
 
         var index = 0
         while index < argv.count {
@@ -167,11 +173,30 @@ extension Args {
             case "--cognitive-mode":
                 cognitiveMode = true
                 index += 1
+            case "--export-conversations":
+                exportConversations = try takeValue(argv, &index, flag: flag)
             default:
                 throw ArgsError.unknownFlag(flag)
             }
         }
 
+        // The export utility needs neither a model nor a generation mode.
+        if exportConversations != nil {
+            return Args(model: model ?? "",
+                        prompt: prompt,
+                        messagesFile: messagesFile,
+                        maxNew: maxNew,
+                        maxContext: maxContext,
+                        temperature: temperature,
+                        topK: topK,
+                        topP: topP,
+                        repetitionPenalty: repetitionPenalty,
+                        seed: seed,
+                        stops: stops,
+                        quiet: quiet,
+                        cognitiveMode: cognitiveMode,
+                        exportConversations: exportConversations)
+        }
         guard let model else { throw ArgsError.requiredMissing("--model") }
         if prompt != nil && messagesFile != nil {
             throw ArgsError.mutuallyExclusive("--prompt", "--messages-file")
@@ -194,7 +219,8 @@ extension Args {
                     seed: seed,
                     stops: stops,
                     quiet: quiet,
-                    cognitiveMode: cognitiveMode)
+                    cognitiveMode: cognitiveMode,
+                    exportConversations: exportConversations)
     }
 
     private static func takeValue(_ argv: [String],

--- a/Sources/TurboFieldfareCLI/Run.swift
+++ b/Sources/TurboFieldfareCLI/Run.swift
@@ -18,6 +18,100 @@ public func run(args: Args,
     do {
         let modelURL = URL(fileURLWithPath: args.model)
         let tokenizer = try await GFTokenizer.load(forModelDirectory: modelURL)
+
+        guard MTLCreateSystemDefaultDevice() != nil else {
+            return errored(stderr, "no Metal device", 1)
+        }
+        let context = try MetalContext()
+        let model = try Model.load(
+            directoryURL: modelURL,
+            device: context.device,
+            streamingMode: .pread(slotCount: RuntimeConfiguration().expertCacheSlots),
+            expertCachePolicy: RuntimeConfiguration().modelExpertCachePolicy,
+            integrityPolicy: .fullSha256)
+        let runner = try RealForwardRunner(
+            model: model,
+            context: context,
+            maxContext: args.maxContext,
+            runtimeConfiguration: RuntimeConfiguration())
+        let scratch = try RawCompletionScratch(context: context,
+                                               vocab: model.config.vocabSize)
+
+        if args.cognitiveMode {
+            let basePrompt: String
+            if let messagesFile = args.messagesFile {
+                let data = try Data(contentsOf: URL(fileURLWithPath: messagesFile),
+                                    options: [.mappedIfSafe])
+                let rows = try JSONDecoder().decode([MessageJSON].self, from: data)
+                let messages = try rows.map { row in
+                    guard let role = GFTokenizer.Role(rawValue: row.role) else {
+                        throw GFTokenizerError.invalidChatTemplate("unsupported role \(row.role)")
+                    }
+                    return GFTokenizer.Message(role: role, content: row.content)
+                }
+                basePrompt = try tokenizer.applyChatTemplate(messages)
+            } else {
+                guard let raw = args.prompt else {
+                    return errored(stderr, "missing prompt for cognitive mode", 2)
+                }
+                basePrompt = raw
+            }
+
+            var engine = CognitiveCycleEngine(userPrompt: basePrompt)
+            var totalNew = 0
+            var finalSeconds = 0.0
+
+            while let step = engine.nextStep() {
+                try Task.checkCancellation()
+                let ids = tokenizer.encode(step.prompt, addBOS: false)
+                stderr.write(Data("\n[cognitive pass: \(step.kind.header)]\n".utf8))
+
+                let config = GenerationConfig(
+                    maxNewTokens: min(args.maxNew, args.maxContext),
+                    temperature: args.temperature,
+                    topK: args.topK,
+                    topP: args.topP,
+                    repetitionPenalty: args.repetitionPenalty,
+                    seed: args.seed,
+                    stopStrings: args.stops,
+                    extraStopTokens: [])
+                let runtime = RuntimeConfiguration(
+                    forceLogitsHead: !config.isPureGreedy)
+
+                var passText = ""
+                let stats = try await runRawCompletion(
+                    producer: runner,
+                    tokenizer: tokenizer,
+                    promptIds: ids,
+                    config: config,
+                    context: context,
+                    scratch: scratch,
+                    prefillConfig: runtime.prefillConfig) { progress in
+                        switch progress {
+                        case .prefill:
+                            break
+                        case .token(_, _, let delta):
+                            passText += delta
+                            if !delta.isEmpty { stdout.write(Data(delta.utf8)) }
+                        case .tail(let tail):
+                            passText += tail
+                            stdout.write(Data(tail.utf8))
+                        }
+                    }
+                engine.record(output: passText)
+                totalNew += stats.newTokens
+                finalSeconds += stats.decodeSeconds
+            }
+
+            if !args.quiet {
+                let tokPerSec = finalSeconds > 0 ? Double(totalNew) / finalSeconds : 0
+                let footer = "\n[cognitive passes=4 new=\(totalNew)tok decode=\(String(format: "%.2f", finalSeconds))s tok/s=\(String(format: "%.3f", tokPerSec))]\n"
+                stderr.write(Data(footer.utf8))
+            }
+            return RunResult(exitCode: 0)
+        }
+
+        // Standard single-pass generation.
         let promptIds: [Int32]
         if let rawPrompt = args.prompt {
             promptIds = tokenizer.encode(rawPrompt, addBOS: true)
@@ -56,23 +150,6 @@ public func run(args: Args,
         let runtime = RuntimeConfiguration(
             forceLogitsHead: !config.isPureGreedy)
 
-        guard MTLCreateSystemDefaultDevice() != nil else {
-            return errored(stderr, "no Metal device", 1)
-        }
-        let context = try MetalContext()
-        let model = try Model.load(
-            directoryURL: modelURL,
-            device: context.device,
-            streamingMode: .pread(slotCount: runtime.expertCacheSlots),
-            expertCachePolicy: runtime.modelExpertCachePolicy,
-            integrityPolicy: .fullSha256)
-        let runner = try RealForwardRunner(
-            model: model,
-            context: context,
-            maxContext: args.maxContext,
-            runtimeConfiguration: runtime)
-        let scratch = try RawCompletionScratch(context: context,
-                                               vocab: model.config.vocabSize)
         let stats = try await runRawCompletion(
             producer: runner,
             tokenizer: tokenizer,

--- a/Sources/TurboFieldfareCLI/Run.swift
+++ b/Sources/TurboFieldfareCLI/Run.swift
@@ -15,6 +15,27 @@ public struct RunResult: Equatable, Sendable {
 public func run(args: Args,
                 stdout: FileHandle = .standardOutput,
                 stderr: FileHandle = .standardError) async -> RunResult {
+    // Utility mode: export the app conversation history without a model.
+    if let outputPath = args.exportConversations {
+        do {
+            let source = conversationsFileURL()
+            guard FileManager.default.fileExists(atPath: source.path) else {
+                return errored(stderr,
+                               "no conversation history at \(source.path); run the app once first",
+                               2)
+            }
+            let data = try Data(contentsOf: source)
+            guard JSONSerialization.isValidJSONObject(
+                try JSONSerialization.jsonObject(with: data)) else {
+                return errored(stderr, "conversation history is not valid JSON", 2)
+            }
+            try data.write(to: URL(fileURLWithPath: outputPath), options: .atomic)
+            stdout.write(Data("exported conversation history to \(outputPath)\n".utf8))
+            return RunResult(exitCode: 0)
+        } catch {
+            return errored(stderr, "export failed: \(error)", 1)
+        }
+    }
     do {
         let modelURL = URL(fileURLWithPath: args.model)
         let tokenizer = try await GFTokenizer.load(forModelDirectory: modelURL)
@@ -187,4 +208,14 @@ public func run(args: Args,
 private func errored(_ stderr: FileHandle, _ message: String, _ code: Int32) -> RunResult {
     stderr.write(Data("error: \(message)\n".utf8))
     return RunResult(exitCode: code)
+}
+
+/// Location of the app's conversation history file.
+private func conversationsFileURL() -> URL {
+    let applicationSupport = FileManager.default.urls(
+        for: .applicationSupportDirectory, in: .userDomainMask).first
+        ?? URL(fileURLWithPath: NSHomeDirectory())
+    return applicationSupport
+        .appendingPathComponent("TurboFieldfare", isDirectory: true)
+        .appendingPathComponent("conversations.json")
 }

--- a/Sources/TurboFieldfareServer/Command/main.swift
+++ b/Sources/TurboFieldfareServer/Command/main.swift
@@ -24,8 +24,8 @@ do {
         modelID: arguments.modelID,
         queueLimit: arguments.queueLimit,
         backend: backend)
-    _ = try await server.start(port: arguments.port)
-    print("TurboFieldfareServer ready at http://127.0.0.1:\(arguments.port) model=\(arguments.modelID) context=\(arguments.maxContext) prompt_cache=\(arguments.promptCacheMode.rawValue)")
+    _ = try await server.start(host: arguments.host, port: arguments.port)
+    print("TurboFieldfareServer ready at http://\(arguments.host):\(arguments.port) model=\(arguments.modelID) context=\(arguments.maxContext) prompt_cache=\(arguments.promptCacheMode.rawValue)\(arguments.allowRemote ? " allow_remote=true" : "")")
 
     _ = await signals.wait()
     try await server.shutdown()

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -122,6 +122,8 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
     private var body = ByteBuffer()
     private var oversized = false
     private var activeTask: Task<Void, Never>?
+    private var completionRequestCount = 0
+    private let startDate = Date()
 
     init(modelID: String,
          backend: any ServerInferenceBackend,
@@ -175,6 +177,8 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         switch (head.method, path) {
         case (.GET, "/health"):
             writeJSON(context, status: .ok, object: ["status": "ok"])
+        case (.GET, "/metrics"):
+            writeMetrics(context)
         case (.GET, "/v1/models"):
             let response = OpenAIModelList(
                 object: "list",
@@ -184,6 +188,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                              ownedBy: "turbofieldfare")])
             writeCodable(context, status: .ok, response)
         case (.POST, "/v1/chat/completions"):
+            completionRequestCount += 1
             guard head.headers.first(name: "content-type")?
                 .lowercased().hasPrefix("application/json") == true else {
                 writeError(context, status: .unsupportedMediaType,
@@ -192,7 +197,7 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                 return
             }
             handleCompletion(body: body, context: context)
-        case (_, "/health"), (_, "/v1/models"), (_, "/v1/chat/completions"):
+        case (_, "/health"), (_, "/metrics"), (_, "/v1/models"), (_, "/v1/chat/completions"):
             writeError(context, status: .methodNotAllowed,
                        OpenAIErrorEnvelope(message: "method not allowed",
                                            code: "method_not_allowed"))
@@ -524,13 +529,38 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         writeData(context, status: status, data: data)
     }
 
+    private func writeMetrics(_ context: ChannelHandlerContext) {
+        let uptime = Int(Date().timeIntervalSince(startDate))
+        let metrics = """
+        # HELP turbofieldfare_requests_total Chat completions requests served.
+        # TYPE turbofieldfare_requests_total counter
+        turbofieldfare_requests_total \(completionRequestCount)
+        # HELP turbofieldfare_uptime_seconds Server uptime.
+        # TYPE turbofieldfare_uptime_seconds gauge
+        turbofieldfare_uptime_seconds \(uptime)
+        # HELP turbofieldfare_model_info Model identifier.
+        # TYPE turbofieldfare_model_info gauge
+        turbofieldfare_model_info{model="\(modelID)"} 1
+        """
+        writeText(context, status: .ok, text: metrics)
+    }
+
+    private func writeText(_ context: ChannelHandlerContext,
+                           status: HTTPResponseStatus,
+                           text: String,
+                           contentType: String = "text/plain; charset=utf-8") {
+        writeData(context, status: status, data: Data(text.utf8),
+                  contentType: contentType)
+    }
+
     private func writeData(_ context: ChannelHandlerContext,
                            status: HTTPResponseStatus,
-                           data: Data) {
+                           data: Data,
+                           contentType: String = "application/json") {
         let contextBox = SendableContext(context)
         context.eventLoop.execute {
             var headers = HTTPHeaders()
-            headers.add(name: "content-type", value: "application/json")
+            headers.add(name: "content-type", value: contentType)
             headers.add(name: "content-length", value: "\(data.count)")
             contextBox.value.write(self.wrapOutboundOut(.head(
                 HTTPResponseHead(version: .http1_1, status: status, headers: headers))),

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -29,7 +29,7 @@ public actor TurboFieldfareHTTPServer {
         self.heartbeatInterval = heartbeatInterval
     }
 
-    public func start(port: Int) async throws -> Channel {
+    public func start(host: String = "127.0.0.1", port: Int) async throws -> Channel {
         let modelID = self.modelID
         let backend = self.backend
         let coordinator = self.coordinator
@@ -53,7 +53,7 @@ public actor TurboFieldfareHTTPServer {
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-        let channel = try await bootstrap.bind(host: "127.0.0.1", port: port).get()
+        let channel = try await bootstrap.bind(host: host, port: port).get()
         self.channel = channel
         return channel
     }

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -187,6 +187,8 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                              created: 0,
                              ownedBy: "turbofieldfare")])
             writeCodable(context, status: .ok, response)
+        case (.GET, "/v1/conversations"):
+            writeConversations(context)
         case (.POST, "/v1/chat/completions"):
             completionRequestCount += 1
             guard head.headers.first(name: "content-type")?
@@ -197,7 +199,8 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
                 return
             }
             handleCompletion(body: body, context: context)
-        case (_, "/health"), (_, "/metrics"), (_, "/v1/models"), (_, "/v1/chat/completions"):
+        case (_, "/health"), (_, "/metrics"), (_, "/v1/models"),
+             (_, "/v1/conversations"), (_, "/v1/chat/completions"):
             writeError(context, status: .methodNotAllowed,
                        OpenAIErrorEnvelope(message: "method not allowed",
                                            code: "method_not_allowed"))
@@ -529,8 +532,23 @@ private final class ServerHTTPHandler: ChannelInboundHandler, @unchecked Sendabl
         writeData(context, status: status, data: data)
     }
 
-    private func writeMetrics(_ context: ChannelHandlerContext) {
-        let uptime = Int(Date().timeIntervalSince(startDate))
+    /// Serves the app's conversation history JSON (read-only). Empty when
+    /// the app has not produced a history file on this machine.
+    private func writeConversations(_ context: ChannelHandlerContext) {
+        let applicationSupport = FileManager.default.urls(
+            for: .applicationSupportDirectory, in: .userDomainMask).first
+            ?? URL(fileURLWithPath: NSHomeDirectory())
+        let url = applicationSupport
+            .appendingPathComponent("TurboFieldfare", isDirectory: true)
+            .appendingPathComponent("conversations.json")
+        if let data = try? Data(contentsOf: url), !data.isEmpty {
+            writeData(context, status: .ok, data: data)
+        } else {
+            writeJSON(context, status: .ok, object: [])
+        }
+    }
+
+    private func writeMetrics(_ context: ChannelHandlerContext) {        let uptime = Int(Date().timeIntervalSince(startDate))
         let metrics = """
         # HELP turbofieldfare_requests_total Chat completions requests served.
         # TYPE turbofieldfare_requests_total counter

--- a/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
+++ b/Sources/TurboFieldfareServer/Core/OpenAIModels.swift
@@ -62,6 +62,100 @@ public enum OpenAIMessageContent: Codable, Equatable, Sendable {
     }
 }
 
+/// Optional reference to a document attached to a chat message.
+public struct ServerDocumentReference: Codable, Equatable, Sendable {
+    /// Absolute path to a text file on the server host.
+    public let path: String?
+    /// Base64-encoded file content (UTF-8 or UTF-16 text).
+    public let base64: String?
+    /// Display name used in the injected context marker.
+    public let filename: String?
+    /// Already-extracted text (skips file access entirely).
+    public let text: String?
+
+    public init(path: String? = nil,
+                base64: String? = nil,
+                filename: String? = nil,
+                text: String? = nil) {
+        self.path = path
+        self.base64 = base64
+        self.filename = filename
+        self.text = text
+    }
+}
+
+/// Extracts plain text from document references for the loopback server.
+/// Text-only formats (txt, md, rtf, json) are supported; binary formats
+/// such as PDF or DOCX are refused with a clear error.
+public enum ServerDocumentExtractor {
+    public enum ExtractionError: Error, CustomStringConvertible {
+        case nothingProvided
+        case multipleSources
+        case unsupportedBinary(String)
+        case readFailed(String)
+        case empty
+
+        public var description: String {
+            switch self {
+            case .nothingProvided:
+                return "document reference requires one of text, path, or base64"
+            case .multipleSources:
+                return "document reference must provide exactly one of text, path, or base64"
+            case .unsupportedBinary(let name):
+                return "document '\(name)' is a binary format; extract its text before sending"
+            case .readFailed(let reason):
+                return "could not read document: \(reason)"
+            case .empty:
+                return "document contains no extractable text"
+            }
+        }
+    }
+
+    public static func text(for reference: ServerDocumentReference) throws -> String {
+        let provided = [reference.text, reference.path, reference.base64]
+            .compactMap { $0 }.count
+        guard provided > 0 else { throw ExtractionError.nothingProvided }
+        guard provided == 1 else { throw ExtractionError.multipleSources }
+
+        if let text = reference.text {
+            let trimmed = text.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw ExtractionError.empty
+            }
+            return trimmed
+        }
+        if let path = reference.path {
+            let url = URL(fileURLWithPath: path)
+            let ext = url.pathExtension.lowercased()
+            guard !["pdf", "docx", "doc", "xlsx"].contains(ext) else {
+                throw ExtractionError.unsupportedBinary(url.lastPathComponent)
+            }
+            guard let data = try? Data(contentsOf: url) else {
+                throw ExtractionError.readFailed(url.path)
+            }
+            return try decode(data)
+        }
+        if let base64 = reference.base64 {
+            guard let data = Data(base64Encoded: base64) else {
+                throw ExtractionError.readFailed("invalid base64")
+            }
+            return try decode(data)
+        }
+        throw ExtractionError.nothingProvided
+    }
+
+    private static func decode(_ data: Data) throws -> String {
+        guard let text = String(data: data, encoding: .utf8)
+                ?? String(data: data, encoding: .utf16) else {
+            throw ExtractionError.readFailed("unrecognized text encoding")
+        }
+        guard !text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty else {
+            throw ExtractionError.empty
+        }
+        return text
+    }
+}
+
 public struct OpenAIFunctionCall: Codable, Equatable, Sendable {
     public let name: String
     public let arguments: String
@@ -79,11 +173,13 @@ public struct OpenAIChatMessage: Codable, Equatable, Sendable {
     public let toolCalls: [OpenAIToolCall]?
     public let toolCallID: String?
     public let name: String?
+    public let document: ServerDocumentReference?
 
     enum CodingKeys: String, CodingKey {
         case role, content, name
         case toolCalls = "tool_calls"
         case toolCallID = "tool_call_id"
+        case document
     }
 }
 
@@ -407,6 +503,21 @@ public enum OpenAIRequestValidator {
                 sawConversationMessage = true
             }
             let content = try message.content?.textValue()
+            // I.1: attach documents to user messages; the extracted text is
+            // injected before the message content.
+            let effectiveContent: String?
+            if let document = message.document {
+                guard role == .user || role == .developer else {
+                    throw invalid("documents are only supported on user or developer messages",
+                                  "messages", "invalid_message")
+                }
+                let documentText = try ServerDocumentExtractor.text(for: document)
+                let label = document.filename ?? "document"
+                effectiveContent = "[Document: \(label)]\n\(documentText)"
+                    + (content.map { "\n\n\($0)" } ?? "")
+            } else {
+                effectiveContent = content
+            }
             let calls: [GFTokenizer.HistoricalToolCall] = try (message.toolCalls ?? []).map { call in
                 guard role == .assistant, call.type == "function",
                       !call.id.isEmpty, knownCalls[call.id] == nil,
@@ -440,16 +551,16 @@ public enum OpenAIRequestValidator {
                                   "messages", "invalid_tool_result")
                 }
                 knownCalls[id] = (call.name, true)
-                guard content != nil else {
+                guard effectiveContent != nil else {
                     throw invalid("tool result content is required",
                                   "messages", "invalid_tool_result")
                 }
-            } else if content == nil && calls.isEmpty {
+            } else if effectiveContent == nil && calls.isEmpty {
                 throw invalid("message content is required",
                               "messages", "invalid_message")
             }
             result.append(GFTokenizer.Message(role: role,
-                                              content: content,
+                                              content: effectiveContent,
                                               toolCalls: calls,
                                               toolCallID: message.toolCallID,
                                               name: message.name))

--- a/Sources/TurboFieldfareServer/Core/ServerArguments.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerArguments.swift
@@ -3,16 +3,27 @@ import Foundation
 public struct ServerArguments: Equatable, Sendable {
     public let model: String
     public let port: Int
+    public let host: String
+    public let allowRemote: Bool
     public let modelID: String
     public let maxContext: Int
     public let queueLimit: Int
     public let promptCacheMode: ServerPromptCacheMode
 
+    /// Hosts that are always safe because they never leave the local machine.
+    /// Any other host requires `--allow-remote` to start.
+    static let loopbackHosts: Set<String> = ["127.0.0.1", "::1", "localhost"]
+
     public static let usage = """
     usage: TurboFieldfareServer --model <completed .gturbo directory> [options]
 
       --model <dir>          Required model directory.
-      --port <1...65535>     Loopback port (default 8080).
+      --port <1...65535>     Listening port (default 8080).
+      --host <addr>          Bind address (default 127.0.0.1). Non-loopback hosts
+                             require --allow-remote.
+      --allow-remote         Permit binding to a non-loopback host. The server has
+                             no authentication or TLS, so only enable this on a
+                             trusted isolated network.
       --model-id <id>        API model identifier (default gemma-4-26b-a4b-it).
       --max-context <tokens> 4096, 8192, 16384, 32768, or 65536 (default 16384).
       --queue-limit <count>  Maximum queued requests (default 4).
@@ -24,6 +35,8 @@ public struct ServerArguments: Equatable, Sendable {
     public static func parse(_ input: [String]) throws -> ServerArguments {
         var model: String?
         var port = 8080
+        var host = "127.0.0.1"
+        var allowRemote = false
         var modelID = "gemma-4-26b-a4b-it"
         var maxContext = 16_384
         var queueLimit = 4
@@ -32,6 +45,14 @@ public struct ServerArguments: Equatable, Sendable {
         while index < input.count {
             let flag = input[index]
             if flag == "--help" || flag == "-h" { throw ServerArgumentError.help }
+            switch flag {
+            case "--allow-remote":
+                allowRemote = true
+                index += 1
+                continue
+            default:
+                break
+            }
             guard index + 1 < input.count else {
                 throw ServerArgumentError.invalid("\(flag) requires a value")
             }
@@ -45,6 +66,12 @@ public struct ServerArguments: Equatable, Sendable {
                     throw ServerArgumentError.invalid("--port must be between 1 and 65535")
                 }
                 port = parsed
+            case "--host":
+                let trimmed = value.trimmingCharacters(in: .whitespaces)
+                guard !trimmed.isEmpty else {
+                    throw ServerArgumentError.invalid("--host must not be empty")
+                }
+                host = trimmed
             case "--model-id":
                 guard !value.isEmpty else {
                     throw ServerArgumentError.invalid("--model-id must not be empty")
@@ -72,8 +99,18 @@ public struct ServerArguments: Equatable, Sendable {
             }
         }
         guard let model else { throw ServerArgumentError.invalid("--model is required") }
+        let isLoopback = Self.loopbackHosts.contains(host.lowercased())
+        guard isLoopback || allowRemote else {
+            throw ServerArgumentError.invalid("""
+                --host \(host) is non-loopback. The server has no authentication or TLS; \
+                binding a non-loopback host exposes the model to the network. \
+                To permit this, pass --allow-remote and use only a trusted isolated network.
+                """)
+        }
         return ServerArguments(model: model,
                                port: port,
+                               host: host,
+                               allowRemote: allowRemote,
                                modelID: modelID,
                                maxContext: maxContext,
                                queueLimit: queueLimit,

--- a/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
+++ b/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
@@ -64,7 +64,7 @@ import Testing
         let expected: Set<String> = [
             "--model", "--prompt", "--messages-file", "--max-new", "--max-context",
             "--temperature", "--top-k", "--top-p", "--repetition-penalty",
-            "--seed", "--stop", "--quiet", "--help",
+            "--seed", "--stop", "--quiet", "--help", "--cognitive-mode",
         ]
         let words = Args.usage.split { $0.isWhitespace || $0 == "(" || $0 == ")" }
         let options = Set(words.map(String.init).filter { $0.hasPrefix("--") })

--- a/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
+++ b/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
@@ -65,6 +65,7 @@ import Testing
             "--model", "--prompt", "--messages-file", "--max-new", "--max-context",
             "--temperature", "--top-k", "--top-p", "--repetition-penalty",
             "--seed", "--stop", "--quiet", "--help", "--cognitive-mode",
+            "--export-conversations",
         ]
         let words = Args.usage.split { $0.isWhitespace || $0 == "(" || $0 == ")" }
         let options = Set(words.map(String.init).filter { $0.hasPrefix("--") })

--- a/Tests/TurboFieldfare/Core/Runtime/Inference/CognitiveCycleEngineTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Inference/CognitiveCycleEngineTests.swift
@@ -120,4 +120,24 @@ import Testing
 
         #expect(seen == [.plan, .draft, .critique, .final])
     }
+
+    // MARK: - Stop policy (H.2)
+
+    @Test func stopPolicySkipsEmptyCritique() {
+        #expect(CognitiveStopPolicy.shouldSkipFinal(critique: ""))
+        #expect(CognitiveStopPolicy.shouldSkipFinal(critique: "   \n "))
+    }
+
+    @Test func stopPolicySkipsPositiveCritique() {
+        #expect(CognitiveStopPolicy.shouldSkipFinal(critique: "The draft has no issues."))
+        #expect(CognitiveStopPolicy.shouldSkipFinal(critique: "No errors found, looks good."))
+        #expect(CognitiveStopPolicy.shouldSkipFinal(critique: "Nothing to fix in the draft."))
+    }
+
+    @Test func stopPolicyKeepsFinalForActionableCritique() {
+        #expect(!CognitiveStopPolicy.shouldSkipFinal(
+            critique: "The second paragraph is inaccurate and the example is outdated."))
+        #expect(!CognitiveStopPolicy.shouldSkipFinal(
+            critique: "Add a worked example and cite a source."))
+    }
 }

--- a/Tests/TurboFieldfare/Core/Runtime/Inference/CognitiveCycleEngineTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Inference/CognitiveCycleEngineTests.swift
@@ -1,6 +1,6 @@
 import Foundation
 import Testing
-@testable import TurboFieldfareAppCore
+@testable import TurboFieldfare
 
 @Suite struct CognitiveCycleEngineTests {
     @Test func nextStepReturnsPlanThenDraftThenCritiqueThenFinal() {

--- a/Tests/TurboFieldfareApp/Core/Inference/CognitiveCycleEngineTests.swift
+++ b/Tests/TurboFieldfareApp/Core/Inference/CognitiveCycleEngineTests.swift
@@ -1,0 +1,123 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite struct CognitiveCycleEngineTests {
+    @Test func nextStepReturnsPlanThenDraftThenCritiqueThenFinal() {
+        var engine = CognitiveCycleEngine(userPrompt: "Explain Metal")
+
+        #expect(engine.nextStep()?.kind == .plan)
+        engine.record(output: "plan")
+        #expect(engine.nextStep()?.kind == .draft)
+        engine.record(output: "draft")
+        #expect(engine.nextStep()?.kind == .critique)
+        engine.record(output: "critique")
+        #expect(engine.nextStep()?.kind == .final)
+        engine.record(output: "final")
+        #expect(engine.nextStep() == nil)
+    }
+
+    @Test func nextStepIsIdempotentUntilRecord() {
+        // Calling nextStep twice without recording returns the same step.
+        var engine = CognitiveCycleEngine(userPrompt: "p")
+        #expect(engine.nextStep()?.kind == .plan)
+        #expect(engine.nextStep()?.kind == .plan)
+    }
+
+    @Test func planPromptContainsUserPrompt() {
+        var engine = CognitiveCycleEngine(userPrompt: "Explain Metal")
+        let plan = engine.nextStep()
+
+        #expect(plan?.kind == .plan)
+        #expect(plan?.prompt.contains("Explain Metal") == true)
+        #expect(plan?.prompt.contains("Plan your answer") == true)
+    }
+
+    @Test func draftPromptEmbedsPlanOutput() {
+        var engine = CognitiveCycleEngine(userPrompt: "Explain Metal")
+        _ = engine.nextStep()  // plan
+        engine.record(output: "1. History\n2. Architecture")
+
+        let draft = engine.nextStep()
+
+        #expect(draft?.kind == .draft)
+        #expect(draft?.prompt.contains("1. History") == true)
+        #expect(draft?.prompt.contains("2. Architecture") == true)
+    }
+
+    @Test func critiquePromptEmbedsDraftOutput() {
+        var engine = CognitiveCycleEngine(userPrompt: "Explain Metal")
+        _ = engine.nextStep()  // plan
+        engine.record(output: "plan text")
+        _ = engine.nextStep()  // draft
+        engine.record(output: "draft text")
+
+        let critique = engine.nextStep()
+
+        #expect(critique?.kind == .critique)
+        #expect(critique?.prompt.contains("draft text") == true)
+        #expect(critique?.prompt.contains("Critique") == true)
+    }
+
+    @Test func finalPromptEmbedsDraftAndCritique() {
+        var engine = CognitiveCycleEngine(userPrompt: "Explain Metal")
+        _ = engine.nextStep()  // plan
+        engine.record(output: "plan text")
+        _ = engine.nextStep()  // draft
+        engine.record(output: "draft text")
+        _ = engine.nextStep()  // critique
+        engine.record(output: "critique text")
+
+        let final = engine.nextStep()
+
+        #expect(final?.kind == .final)
+        #expect(final?.prompt.contains("draft text") == true)
+        #expect(final?.prompt.contains("critique text") == true)
+        #expect(final?.prompt.contains("Output only the final") == true)
+    }
+
+    @Test func engineFinishesAfterAllFourOutputs() {
+        var engine = CognitiveCycleEngine(userPrompt: "p")
+        for _ in 0..<4 {
+            guard let step = engine.nextStep() else {
+                Issue.record("Expected four steps")
+                return
+            }
+            engine.record(output: "output for \(step.kind.rawValue)")
+        }
+
+        #expect(engine.isFinished)
+        #expect(engine.nextStep() == nil)
+        #expect(engine.outputs.count == 4)
+    }
+
+    @Test func recordFillsTheNextExpectedPass() {
+        // record assigns to the next step the engine would emit, so an
+        // orchestrator can record even before the first nextStep call.
+        var engine = CognitiveCycleEngine(userPrompt: "p")
+        engine.record(output: "orphan")
+
+        #expect(engine.outputs[.plan] == "orphan")
+        #expect(!engine.isFinished)
+        #expect(engine.nextStep()?.kind == .draft)
+    }
+
+    @Test func headersMatchPassKind() {
+        #expect(CognitiveStepKind.plan.header == "Plan")
+        #expect(CognitiveStepKind.draft.header == "Draft")
+        #expect(CognitiveStepKind.critique.header == "Critique")
+        #expect(CognitiveStepKind.final.header == "Final answer")
+    }
+
+    @Test func cycleIteratesWithoutDroppingOutputs() {
+        var engine = CognitiveCycleEngine(userPrompt: "p")
+        var seen: [CognitiveStepKind] = []
+
+        while let step = engine.nextStep() {
+            seen.append(step.kind)
+            engine.record(output: "text \(step.kind.rawValue)")
+        }
+
+        #expect(seen == [.plan, .draft, .critique, .final])
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/Inference/DocumentAttachmentTests.swift
+++ b/Tests/TurboFieldfareApp/Core/Inference/DocumentAttachmentTests.swift
@@ -1,0 +1,203 @@
+import AppKit
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite struct DocumentAttachmentTests {
+    private let extractor = DocumentExtractor()
+
+    /// Writes a file to a unique temporary location.
+    private func temporaryFile(named name: String, data: Data) throws -> URL {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent(name)
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try data.write(to: url)
+        return url
+    }
+
+    private func temporaryFile(named name: String, text: String) throws -> URL {
+        try temporaryFile(named: name, data: Data(text.utf8))
+    }
+
+    // MARK: - Extraction
+
+    @Test func extractsPlainText() throws {
+        let url = try temporaryFile(named: "notes.txt", text: "Hello TurboFieldfare\nSecond line.")
+        let attachment = try extractor.extract(from: url)
+
+        #expect(attachment.type == .txt)
+        #expect(attachment.extractedText == "Hello TurboFieldfare\nSecond line.")
+        #expect(attachment.pageCount == nil)
+        #expect(!attachment.truncated)
+        #expect(attachment.originalLength == attachment.extractedText.count)
+        #expect(attachment.filename == "notes.txt")
+    }
+
+    @Test func extractsMarkdown() throws {
+        let url = try temporaryFile(named: "README.md", text: "# Title\n\nSome *markdown*.")
+        let attachment = try extractor.extract(from: url)
+
+        #expect(attachment.type == .md)
+        #expect(attachment.extractedText.contains("# Title"))
+        #expect(attachment.extractedText.contains("markdown"))
+    }
+
+    @Test func extractsRTF() throws {
+        let attributed = NSAttributedString(string: "RTF content here")
+        let data = try attributed.data(from: NSRange(location: 0, length: attributed.length),
+                                       documentAttributes: [.documentType: NSAttributedString.DocumentType.rtf])
+        let url = try temporaryFile(named: "notes.rtf", data: data)
+
+        let attachment = try extractor.extract(from: url)
+
+        #expect(attachment.type == .rtf)
+        #expect(attachment.extractedText.contains("RTF content here"))
+    }
+
+    @Test func extractsDOCX() throws {
+        let attributed = NSAttributedString(string: "Word document body")
+        let data = try attributed.data(from: NSRange(location: 0, length: attributed.length),
+                                       documentAttributes: [.documentType: NSAttributedString.DocumentType.officeOpenXML])
+        let url = try temporaryFile(named: "notes.docx", data: data)
+
+        let attachment = try extractor.extract(from: url)
+
+        #expect(attachment.type == .docx)
+        #expect(attachment.extractedText.contains("Word document body"))
+    }
+
+    @MainActor
+    @Test func extractsPDF() throws {
+        let text = "PDF extraction works"
+        let textView = NSTextView(frame: NSRect(x: 0, y: 0, width: 300, height: 120))
+        textView.string = text
+        textView.layoutManager?.ensureLayout(for: textView.textContainer!)
+        let data = textView.dataWithPDF(inside: textView.bounds)
+        let url = try temporaryFile(named: "notes.pdf", data: data)
+
+        let attachment = try extractor.extract(from: url)
+
+        #expect(attachment.type == .pdf)
+        #expect(attachment.pageCount != nil)
+        #expect(attachment.extractedText.contains("PDF extraction works"))
+    }
+
+    // MARK: - Errors
+
+    @Test func rejectsUnsupportedFormat() throws {
+        let url = try temporaryFile(named: "notes.xyz", text: "ignored")
+
+        #expect(throws: DocumentError.self) {
+            try extractor.extract(from: url)
+        }
+    }
+
+    @Test func rejectsOversizedFile() throws {
+        // Sparse file: logical size exceeds the limit without consuming disk space.
+        let url = try temporaryFile(named: "big.txt", data: Data())
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.seek(toOffset: DocumentExtractor.maximumFileSize + 1)
+        try handle.write(contentsOf: Data([0]))
+        try handle.close()
+
+        do {
+            _ = try extractor.extract(from: url)
+            Issue.record("Expected fileTooLarge error")
+        } catch let error as DocumentError {
+            guard case .fileTooLarge = error else {
+                Issue.record("Unexpected error: \(error)")
+                return
+            }
+        }
+    }
+
+    @Test func rejectsEmptyDocument() throws {
+        let url = try temporaryFile(named: "blank.txt", text: "   \n\t ")
+
+        do {
+            _ = try extractor.extract(from: url)
+            Issue.record("Expected emptyDocument error")
+        } catch let error as DocumentError {
+            guard case .emptyDocument = error else {
+                Issue.record("Unexpected error: \(error)")
+                return
+            }
+        }
+    }
+
+    // MARK: - Truncation
+
+    @Test func truncatesVeryLongText() throws {
+        let longText = String(repeating: "a", count: DocumentExtractor.maximumTextLength + 1)
+        let url = try temporaryFile(named: "long.txt", text: longText)
+
+        let attachment = try extractor.extract(from: url)
+
+        #expect(attachment.truncated)
+        #expect(attachment.extractedText.count == DocumentExtractor.maximumTextLength)
+        #expect(attachment.originalLength == DocumentExtractor.maximumTextLength + 1)
+    }
+
+    // MARK: - Attachment presentation
+
+    @Test func promptContextWrapsDocument() {
+        let attachment = DocumentAttachment(filename: "notes.txt",
+                                            type: .txt,
+                                            fileSize: 100,
+                                            extractedText: "body text")
+
+        let context = attachment.promptContext()
+
+        #expect(context.contains("[Document: notes.txt]"))
+        #expect(context.contains("body text"))
+        #expect(context.contains("[End of document]"))
+    }
+
+    @Test func promptContextMarksTruncation() {
+        let attachment = DocumentAttachment(filename: "long.txt",
+                                            type: .txt,
+                                            fileSize: 100,
+                                            extractedText: "body",
+                                            truncated: true,
+                                            originalLength: 500_001)
+
+        #expect(attachment.promptContext().contains("document truncated"))
+    }
+
+    @Test func previewTruncatesLongText() {
+        let long = String(repeating: "x", count: 500)
+        let attachment = DocumentAttachment(filename: "f.txt",
+                                            type: .txt,
+                                            fileSize: 1,
+                                            extractedText: long)
+
+        let preview = attachment.preview(maxLength: 200)
+        #expect(preview.count == 201)
+        #expect(preview.hasSuffix("…"))
+    }
+
+    @Test func previewKeepsShortText() {
+        let attachment = DocumentAttachment(filename: "f.txt",
+                                            type: .txt,
+                                            fileSize: 1,
+                                            extractedText: "short")
+        #expect(attachment.preview(maxLength: 200) == "short")
+    }
+
+    @Test func formattedSizeUsesFileStyle() {
+        let attachment = DocumentAttachment(filename: "f.txt",
+                                            type: .txt,
+                                            fileSize: 1_048_576,
+                                            extractedText: "")
+        #expect(attachment.formattedSize == "1 MB")
+    }
+
+    @Test func supportedTypesCoverAllDocumentCases() {
+        #expect(DocumentExtractor.supportedTypes.count == DocumentType.allCases.count)
+        for type in DocumentType.allCases {
+            #expect(DocumentExtractor.supportedTypes.contains(type.utType))
+        }
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/Inference/DocumentAttachmentTests.swift
+++ b/Tests/TurboFieldfareApp/Core/Inference/DocumentAttachmentTests.swift
@@ -140,6 +140,39 @@ import Testing
         #expect(attachment.originalLength == DocumentExtractor.maximumTextLength + 1)
     }
 
+    // MARK: - Configurable limits
+
+    @Test func customTextLimitTruncates() throws {
+        let url = try temporaryFile(named: "custom.txt", text: "0123456789ABCDEF")
+        let custom = DocumentExtractor(maximumTextLength: 10)
+
+        let attachment = try custom.extract(from: url)
+
+        #expect(attachment.truncated)
+        #expect(attachment.extractedText == "0123456789")
+        #expect(attachment.originalLength == 16)
+    }
+
+    @Test func customFileSizeLimitRejects() throws {
+        // Sparse file of 1 KB with a 512-byte limit.
+        let url = try temporaryFile(named: "big.txt", data: Data())
+        let handle = try FileHandle(forWritingTo: url)
+        try handle.seek(toOffset: 1024)
+        try handle.write(contentsOf: Data([0]))
+        try handle.close()
+
+        let custom = DocumentExtractor(maximumFileSize: 512)
+        do {
+            _ = try custom.extract(from: url)
+            Issue.record("Expected fileTooLarge error")
+        } catch let error as DocumentError {
+            guard case .fileTooLarge = error else {
+                Issue.record("Unexpected error: \(error)")
+                return
+            }
+        }
+    }
+
     // MARK: - Attachment presentation
 
     @Test func promptContextWrapsDocument() {

--- a/Tests/TurboFieldfareApp/Core/Inference/RetrievalTests.swift
+++ b/Tests/TurboFieldfareApp/Core/Inference/RetrievalTests.swift
@@ -1,0 +1,61 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite struct RetrievalTests {
+    private let documentID = UUID()
+
+    private func words(_ count: Int, seed: String = "word") -> String {
+        (0..<count).map { "\(seed)\($0)" }.joined(separator: " ")
+    }
+
+    @Test func shortTextProducesSingleChunk() {
+        let text = "A short document with just a few words to keep it small."
+        let chunks = DocumentChunker.chunk(text, documentID: documentID)
+
+        #expect(chunks.count == 1)
+        #expect(chunks[0].text == text)
+    }
+
+    @Test func longTextProducesOverlappingChunks() {
+        // 1500 words with a 600-word target produces 3 chunks.
+        let text = words(1_500)
+        let chunks = DocumentChunker.chunk(text, documentID: documentID)
+
+        #expect(chunks.count == 3)
+        // Overlap: the second chunk starts 540 words in, not at 600.
+        #expect(chunks[1].text.hasPrefix("word540 "))
+        // Every chunk belongs to the source document.
+        #expect(chunks.allSatisfy { $0.sourceDocumentID == documentID })
+    }
+
+    @Test func retrieverRanksRelevantChunkFirst() {
+        let text = """
+        \(words(600, seed: "irrelevant"))
+        metal compute pipeline shaders kernels
+        \(words(600, seed: "noise"))
+        """
+        let chunks = DocumentChunker.chunk(text, documentID: documentID)
+
+        let top = TfIdfRetriever.topChunks(chunks, query: "metal compute shaders", limit: 1)
+
+        #expect(top.count == 1)
+        #expect(top[0].text.contains("metal compute pipeline"))
+    }
+
+    @Test func retrieverFallsBackWhenQueryEmpty() {
+        let chunks = [
+            DocumentChunk(sourceDocumentID: documentID, text: "first"),
+            DocumentChunk(sourceDocumentID: documentID, text: "second"),
+        ]
+
+        let top = TfIdfRetriever.topChunks(chunks, query: "   ", limit: 1)
+
+        #expect(top.count == 1)
+    }
+
+    @Test func retrieverIgnoresEmptyChunks() {
+        let top = TfIdfRetriever.topChunks([], query: "anything", limit: 5)
+        #expect(top.isEmpty)
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/State/AppModelAttachmentTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelAttachmentTests.swift
@@ -1,0 +1,138 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite @MainActor struct AppModelAttachmentTests {
+    private func attachment(filename: String = "notes.txt",
+                            text: String = "body text",
+                            size: UInt64 = 100) -> DocumentAttachment {
+        DocumentAttachment(filename: filename,
+                           type: .txt,
+                           fileSize: size,
+                           extractedText: text)
+    }
+
+    @Test
+    func attachDocumentsExtractsText() async throws {
+        let model = AppModel()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("notes.txt")
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data("extracted via attach".utf8).write(to: url)
+
+        model.attachDocuments(from: [url])
+        await waitForExtraction(model)
+
+        #expect(!model.isExtractingAttachment)
+        #expect(model.attachments.count == 1)
+        #expect(model.attachments[0].filename == "notes.txt")
+        #expect(model.attachments[0].extractedText == "extracted via attach")
+        #expect(model.attachmentError == nil)
+    }
+
+    
+    @Test func attachDocumentsSurfacesErrors() async throws {
+        let model = AppModel()
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("notes.xyz")
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data("ignored".utf8).write(to: url)
+
+        model.attachDocuments(from: [url])
+        await waitForExtraction(model)
+
+        #expect(model.attachments.isEmpty)
+        #expect(model.attachmentError != nil)
+    }
+
+    
+    @Test func hasAttachmentsReflectsCollection() {
+        let model = AppModel()
+        #expect(!model.hasAttachments)
+
+        model.attachments = [attachment()]
+        #expect(model.hasAttachments)
+    }
+
+    
+    @Test func promptWithAttachmentsAppendsContext() {
+        let model = AppModel()
+        model.promptText = "Summarize this file"
+        model.attachments = [attachment()]
+
+        let composed = model.promptWithAttachments
+
+        #expect(composed.hasPrefix("Summarize this file"))
+        #expect(composed.contains("[Document: notes.txt]"))
+        #expect(composed.contains("body text"))
+    }
+
+    
+    @Test func promptWithAttachmentsFallsBackToPrompt() {
+        let model = AppModel()
+        model.promptText = "No attachments"
+        #expect(model.promptWithAttachments == "No attachments")
+    }
+
+    
+    @Test func totalAttachmentBytesSumsSizes() {
+        let model = AppModel()
+        model.attachments = [
+            attachment(size: 100),
+            attachment(filename: "second.txt", size: 250),
+        ]
+        #expect(model.totalAttachmentBytes == 350)
+    }
+
+    
+    @Test func makeRequestInjectsAttachmentContext() throws {
+        let model = AppModel()
+        model.modelPathText = FileManager.default.temporaryDirectory.path
+        model.promptText = "Analyze"
+        model.attachments = [attachment()]
+
+        let request = try model.makeRequest()
+
+        #expect(request.prompt.contains("[Document: notes.txt]"))
+        #expect(request.prompt.hasPrefix("Analyze"))
+    }
+
+    
+    @Test func removeAttachmentRemovesOnlyMatching() {
+        let model = AppModel()
+        let first = attachment()
+        let second = attachment(filename: "second.txt")
+        model.attachments = [first, second]
+
+        model.removeAttachment(first)
+
+        #expect(model.attachments == [second])
+    }
+
+    
+    @Test func clearAttachmentsClearsErrorToo() {
+        let model = AppModel()
+        model.attachments = [attachment()]
+        model.attachmentError = .readFailed("boom")
+
+        model.clearAttachments()
+
+        #expect(model.attachments.isEmpty)
+        #expect(model.attachmentError == nil)
+    }
+
+    /// Polls until the detached extraction task publishes its result.
+    
+    private func waitForExtraction(_ model: AppModel, timeoutMilliseconds: Int = 5_000) async {
+        let stepMilliseconds = 20
+        var waited = 0
+        while model.isExtractingAttachment && waited < timeoutMilliseconds {
+            try? await Task.sleep(for: .milliseconds(stepMilliseconds))
+            waited += stepMilliseconds
+        }
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/State/AppModelAttachmentTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelAttachmentTests.swift
@@ -29,7 +29,7 @@ import Testing
         #expect(model.attachments.count == 1)
         #expect(model.attachments[0].filename == "notes.txt")
         #expect(model.attachments[0].extractedText == "extracted via attach")
-        #expect(model.attachmentError == nil)
+        #expect(model.attachmentErrors.isEmpty)
     }
 
     
@@ -46,7 +46,8 @@ import Testing
         await waitForExtraction(model)
 
         #expect(model.attachments.isEmpty)
-        #expect(model.attachmentError != nil)
+        #expect(model.attachmentErrors.count == 1)
+        #expect(model.attachmentErrors[0].contains("notes.xyz"))
     }
 
     
@@ -114,15 +115,15 @@ import Testing
     }
 
     
-    @Test func clearAttachmentsClearsErrorToo() {
+    @Test func clearAttachmentsClearsErrorsToo() {
         let model = AppModel()
         model.attachments = [attachment()]
-        model.attachmentError = .readFailed("boom")
+        model.attachmentErrors = ["boom"]
 
         model.clearAttachments()
 
         #expect(model.attachments.isEmpty)
-        #expect(model.attachmentError == nil)
+        #expect(model.attachmentErrors.isEmpty)
     }
 
     /// Polls until the detached extraction task publishes its result.

--- a/Tests/TurboFieldfareApp/Core/State/AppModelAttachmentTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelAttachmentTests.swift
@@ -126,6 +126,37 @@ import Testing
         #expect(model.attachmentErrors.isEmpty)
     }
 
+    @Test
+    func estimatedPromptTokenCountIncludesAttachments() {
+        let model = AppModel()
+        model.promptText = "abcd"
+        let expectedWithoutDocs = (model.promptText.count + 3) / 4
+        #expect(model.estimatedPromptTokenCount == expectedWithoutDocs)
+
+        model.attachments = [attachment(text: "efghijklmnopqrst")]
+        let expectedWithDocs = (model.promptWithAttachments.count + 3) / 4
+
+        #expect(model.estimatedPromptTokenCount == expectedWithDocs)
+        #expect(expectedWithDocs > expectedWithoutDocs)
+    }
+
+    @Test
+    func estimatedPromptTokenCountIsZeroForEmptyPrompt() {
+        let model = AppModel()
+        #expect(model.estimatedPromptTokenCount == 0)
+    }
+
+    @Test
+    func estimatedPromptExceedsContextFlags() {
+        let model = AppModel()
+        model.promptText = String(repeating: "a", count: 10_000)
+        model.maxContextTokens = 1_024
+        #expect(model.estimatedPromptExceedsContext)
+
+        model.maxContextTokens = 100_000
+        #expect(!model.estimatedPromptExceedsContext)
+    }
+
     /// Polls until the detached extraction task publishes its result.
     
     private func waitForExtraction(_ model: AppModel, timeoutMilliseconds: Int = 5_000) async {

--- a/Tests/TurboFieldfareApp/Core/State/AppModelCognitiveCycleTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelCognitiveCycleTests.swift
@@ -57,8 +57,8 @@ import Testing
         #expect(model.conversationStore.conversations.count == 1)
         let saved = model.conversationStore.conversations[0]
         // History stores the final revision, not the whole cycle transcript.
-        #expect(!saved.response.contains("— Plan —"))
-        #expect(saved.response.contains("revision text"))
+        #expect(!saved.lastResponse.contains("— Plan —"))
+        #expect(saved.lastResponse.contains("revision text"))
     }
 
     @Test

--- a/Tests/TurboFieldfareApp/Core/State/AppModelCognitiveCycleTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelCognitiveCycleTests.swift
@@ -1,0 +1,98 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite @MainActor struct AppModelCognitiveCycleTests {
+    private func makeModel(client: AppInferenceClient) -> AppModel {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("cognitive-\(UUID().uuidString).json")
+        let model = AppModel(client: client,
+                             conversationStore: ConversationStore(storageURL: url))
+        model.modelPathText = FileManager.default.temporaryDirectory.path
+        model.loadState = .ready(modelDirectory: FileManager.default.temporaryDirectory,
+                                 loadSeconds: 1)
+        return model
+    }
+
+    private func waitUntilIdle(_ model: AppModel, timeoutMilliseconds: Int = 15_000) async {
+        var waited = 0
+        while model.runState == .running && waited < timeoutMilliseconds {
+            try? await Task.sleep(for: .milliseconds(20))
+            waited += 20
+        }
+    }
+
+    @Test
+    func cognitiveCycleRunsFourPasses() async throws {
+        let mock = MockInferenceClient(response: "pass output",
+                                       tokenDelayNanos: 1_000_000)
+        let model = makeModel(client: mock)
+        model.promptText = "Explain Metal"
+        model.cognitiveModeEnabled = true
+
+        model.run()
+        await waitUntilIdle(model)
+
+        #expect(model.runState == .idle)
+        #expect(model.error == nil)
+        #expect(model.outputText.contains("— Plan —"))
+        #expect(model.outputText.contains("— Draft —"))
+        #expect(model.outputText.contains("— Critique —"))
+        #expect(model.outputText.contains("— Final answer —"))
+        // Four passes, each echoing the pass prompt back through the mock.
+        #expect(model.outputText.contains("Plan your answer"))
+    }
+
+    @Test
+    func cognitiveCycleStoresFinalRevisionInHistory() async throws {
+        let mock = MockInferenceClient(response: "revision text",
+                                       tokenDelayNanos: 1_000_000)
+        let model = makeModel(client: mock)
+        model.promptText = "Explain Metal"
+        model.cognitiveModeEnabled = true
+
+        model.run()
+        await waitUntilIdle(model)
+
+        #expect(model.conversationStore.conversations.count == 1)
+        let saved = model.conversationStore.conversations[0]
+        // History stores the final revision, not the whole cycle transcript.
+        #expect(!saved.response.contains("— Plan —"))
+        #expect(saved.response.contains("revision text"))
+    }
+
+    @Test
+    func standardGenerationRunsWhenCognitiveDisabled() async throws {
+        let mock = MockInferenceClient(response: "plain answer",
+                                       tokenDelayNanos: 1_000_000)
+        let model = makeModel(client: mock)
+        model.promptText = "Explain Metal"
+
+        model.run()
+        await waitUntilIdle(model)
+
+        #expect(model.error == nil)
+        #expect(!model.outputText.contains("— Plan —"))
+        #expect(model.outputText.contains("plain answer"))
+    }
+
+    @Test
+    func cognitiveCycleStopsOnCancel() async throws {
+        // Long response so cancellation lands mid-pass.
+        let longResponse = String(repeating: "word ", count: 300)
+        let mock = MockInferenceClient(response: longResponse,
+                                       tokenDelayNanos: 2_000_000)
+        let model = makeModel(client: mock)
+        model.promptText = "Explain Metal"
+        model.cognitiveModeEnabled = true
+
+        model.run()
+        try? await Task.sleep(for: .milliseconds(80))
+        model.cancel()
+        await waitUntilIdle(model)
+
+        #expect(model.runState == .idle)
+        #expect(model.error == .cancelled)
+        #expect(!model.outputText.contains("— Final answer —"))
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/State/AppModelConversationTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelConversationTests.swift
@@ -1,0 +1,214 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite @MainActor struct AppModelConversationTests {
+    /// Creates an AppModel backed by a store on a unique temporary file,
+    /// so history tests never touch the real Application Support data.
+    private func makeModel() -> (AppModel, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("history-\(UUID().uuidString).json")
+        let store = ConversationStore(storageURL: url)
+        return (AppModel(conversationStore: store), url)
+    }
+
+    private func attachment(filename: String = "notes.txt") -> DocumentAttachment {
+        DocumentAttachment(filename: filename,
+                           type: .txt,
+                           fileSize: 10,
+                           extractedText: "document body")
+    }
+
+    @Test
+    func saveStoresConversationWithDiagnostics() {
+        let (model, _) = makeModel()
+        model.promptText = "Explain Metal"
+        model.outputText = "Metal is a GPU API."
+
+        model.saveCurrentConversation(diagnostic: makeDiagnostics())
+
+        let saved = model.conversationStore.conversations[0]
+        #expect(saved.prompt == "Explain Metal")
+        #expect(saved.response == "Metal is a GPU API.")
+        #expect(saved.promptTokenCount == 12)
+        #expect(saved.generatedTokenCount == 34)
+        #expect(saved.stopReason == "maxTokens")
+        #expect(model.activeConversationID == saved.id)
+    }
+
+    @Test
+    func saveIgnoresEmptyPrompt() {
+        let (model, _) = makeModel()
+        model.promptText = "   "
+        model.outputText = "ignored"
+
+        model.saveCurrentConversation()
+
+        #expect(model.conversationStore.conversations.isEmpty)
+        #expect(model.activeConversationID == nil)
+    }
+
+    @Test
+    func regeneratingSamePromptUpdatesActiveConversation() {
+        let (model, _) = makeModel()
+        model.promptText = "same prompt"
+        model.outputText = "first response"
+        model.saveCurrentConversation()
+        let firstID = model.activeConversationID
+        let firstCreatedAt = model.conversationStore.conversations[0].createdAt
+
+        // Regenerate the same prompt: same entry, updated response, no duplicate.
+        model.outputText = "second response"
+        model.saveCurrentConversation()
+
+        #expect(model.activeConversationID == firstID)
+        #expect(model.conversationStore.conversations.count == 1)
+        #expect(model.conversationStore.conversations[0].response == "second response")
+        #expect(model.conversationStore.conversations[0].createdAt == firstCreatedAt)
+        #expect(model.conversationStore.conversations[0].updatedAt >= firstCreatedAt)
+    }
+
+    @Test
+    func differentPromptCreatesNewConversation() {
+        let (model, _) = makeModel()
+        model.promptText = "first prompt"
+        model.saveCurrentConversation()
+        let firstID = model.activeConversationID
+
+        model.promptText = "second prompt"
+        model.saveCurrentConversation()
+
+        #expect(model.activeConversationID != firstID)
+        #expect(model.conversationStore.conversations.count == 2)
+    }
+
+    @Test
+    func saveStoresAttachmentsWithConversation() {
+        let (model, _) = makeModel()
+        model.promptText = "Summarize this"
+        model.attachments = [attachment()]
+
+        model.saveCurrentConversation()
+
+        let saved = model.conversationStore.conversations[0]
+        #expect(saved.attachments.count == 1)
+        #expect(saved.attachments[0].extractedText == "document body")
+    }
+
+    @Test
+    func loadRestoresPromptResponseAndAttachments() {
+        let (model, _) = makeModel()
+        let stored = Conversation(title: "t",
+                                  prompt: "original prompt",
+                                  response: "original response",
+                                  attachments: [attachment()])
+        model.conversationStore.upsert(stored)
+
+        model.loadConversation(stored)
+
+        #expect(model.activeConversationID == stored.id)
+        #expect(model.promptText == "original prompt")
+        #expect(model.outputText == "original response")
+        #expect(model.attachments == stored.attachments)
+        #expect(model.diagnostics == nil)
+        #expect(model.error == nil)
+    }
+
+    @Test
+    func loadIsIgnoredWhileRunning() {
+        let (model, _) = makeModel()
+        let stored = Conversation(title: "t", prompt: "p", response: "r")
+        model.conversationStore.upsert(stored)
+        model.promptText = "in-progress text"
+        model.runState = .running
+
+        model.loadConversation(stored)
+
+        // The running prompt must not be clobbered.
+        #expect(model.promptText == "in-progress text")
+    }
+
+    @Test
+    func newConversationClearsEverything() {
+        let (model, _) = makeModel()
+        model.promptText = "old prompt"
+        model.outputText = "old response"
+        model.attachments = [attachment()]
+        model.saveCurrentConversation()
+        #expect(model.activeConversationID != nil)
+
+        model.newConversation()
+
+        #expect(model.activeConversationID == nil)
+        #expect(model.promptText.isEmpty)
+        #expect(model.outputPromptText.isEmpty)
+        #expect(model.outputText.isEmpty)
+        #expect(model.attachments.isEmpty)
+    }
+
+    @Test
+    func deleteConversationRemovesAndResetsWhenActive() {
+        let (model, _) = makeModel()
+        model.promptText = "to delete"
+        model.outputText = "response"
+        model.saveCurrentConversation()
+        let saved = model.conversationStore.conversations[0]
+
+        model.deleteConversation(saved)
+
+        #expect(model.conversationStore.conversations.isEmpty)
+        #expect(model.activeConversationID == nil)
+        #expect(model.promptText.isEmpty)
+    }
+
+    @Test
+    func deleteInactiveConversationKeepsCurrent() {
+        let (model, _) = makeModel()
+        model.promptText = "active"
+        model.outputText = "r"
+        model.saveCurrentConversation()
+        let active = model.conversationStore.conversations[0]
+
+        let other = Conversation(title: "other", prompt: "other", response: "r")
+        model.conversationStore.upsert(other)
+        model.deleteConversation(other)
+
+        #expect(model.conversationStore.conversations == [active])
+        #expect(model.activeConversationID == active.id)
+        #expect(model.promptText == "active")
+    }
+
+    @Test
+    func historySurvivesModelRecreation() throws {
+        let (model, url) = makeModel()
+        model.promptText = "persisted prompt"
+        model.outputText = "persisted response"
+        model.attachments = [attachment(filename: "report.txt")]
+        model.saveCurrentConversation()
+
+        // A fresh model over the same store file must restore the history,
+        // including attachments, and load them back into the composer.
+        let reloadedStore = ConversationStore(storageURL: url)
+        let reloaded = AppModel(conversationStore: reloadedStore)
+        #expect(reloaded.conversationStore.conversations.count == 1)
+        let restored = reloaded.conversationStore.conversations[0]
+        #expect(restored.prompt == "persisted prompt")
+        #expect(restored.attachments.count == 1)
+
+        reloaded.loadConversation(restored)
+        #expect(reloaded.promptText == "persisted prompt")
+        #expect(reloaded.attachments[0].filename == "report.txt")
+    }
+
+    /// Minimal diagnostics for token-count assertions.
+    private func makeDiagnostics() -> AppDiagnostics {
+        AppDiagnostics(generatedTokens: 34,
+                       stopReason: .maxTokens,
+                       promptTokenCount: 12,
+                       timeToFirstTokenSeconds: 0,
+                       decodeSeconds: 0,
+                       tokensPerSecond: 0,
+                       peakMemoryBytes: nil,
+                       runtimeOptions: AppRuntimeOptions())
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/State/AppModelConversationTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelConversationTests.swift
@@ -28,8 +28,8 @@ import Testing
         model.saveCurrentConversation(diagnostic: makeDiagnostics())
 
         let saved = model.conversationStore.conversations[0]
-        #expect(saved.prompt == "Explain Metal")
-        #expect(saved.response == "Metal is a GPU API.")
+        #expect(saved.firstPrompt == "Explain Metal")
+        #expect(saved.lastResponse == "Metal is a GPU API.")
         #expect(saved.promptTokenCount == 12)
         #expect(saved.generatedTokenCount == 34)
         #expect(saved.stopReason == "maxTokens")
@@ -63,23 +63,28 @@ import Testing
 
         #expect(model.activeConversationID == firstID)
         #expect(model.conversationStore.conversations.count == 1)
-        #expect(model.conversationStore.conversations[0].response == "second response")
+        #expect(model.conversationStore.conversations[0].lastResponse == "second response")
         #expect(model.conversationStore.conversations[0].createdAt == firstCreatedAt)
         #expect(model.conversationStore.conversations[0].updatedAt >= firstCreatedAt)
     }
 
     @Test
-    func differentPromptCreatesNewConversation() {
+    func differentPromptContinuesSameConversation() {
         let (model, _) = makeModel()
         model.promptText = "first prompt"
+        model.outputText = "first answer"
         model.saveCurrentConversation()
         let firstID = model.activeConversationID
 
+        // A new prompt on the active conversation extends its history.
         model.promptText = "second prompt"
+        model.outputText = "second answer"
         model.saveCurrentConversation()
 
-        #expect(model.activeConversationID != firstID)
-        #expect(model.conversationStore.conversations.count == 2)
+        #expect(model.activeConversationID == firstID)
+        #expect(model.conversationStore.conversations.count == 1)
+        #expect(model.conversationStore.conversations[0].turns.count == 4)
+        #expect(model.conversationStore.conversations[0].lastResponse == "second answer")
     }
 
     @Test
@@ -107,8 +112,11 @@ import Testing
         model.loadConversation(stored)
 
         #expect(model.activeConversationID == stored.id)
-        #expect(model.promptText == "original prompt")
-        #expect(model.outputText == "original response")
+        #expect(model.activeConversationTurns == stored.turns)
+        // The composer is empty so the user can continue the dialogue.
+        #expect(model.promptText.isEmpty)
+        #expect(model.outputText.contains("original prompt"))
+        #expect(model.outputText.contains("original response"))
         #expect(model.attachments == stored.attachments)
         #expect(model.diagnostics == nil)
         #expect(model.error == nil)
@@ -192,12 +200,14 @@ import Testing
         let reloaded = AppModel(conversationStore: reloadedStore)
         #expect(reloaded.conversationStore.conversations.count == 1)
         let restored = reloaded.conversationStore.conversations[0]
-        #expect(restored.prompt == "persisted prompt")
+        #expect(restored.firstPrompt == "persisted prompt")
         #expect(restored.attachments.count == 1)
 
         reloaded.loadConversation(restored)
-        #expect(reloaded.promptText == "persisted prompt")
+        // Composer is cleared for continuation; the turns carry the history.
+        #expect(reloaded.activeConversationTurns.count == 2)
         #expect(reloaded.attachments[0].filename == "report.txt")
+        #expect(reloaded.outputText.contains("persisted response"))
     }
 
     @Test
@@ -258,7 +268,7 @@ import Testing
         let count = try otherModel.importConversations(from: url)
 
         #expect(count == 1)
-        #expect(otherModel.conversationStore.conversations[0].prompt == "export me")
+        #expect(otherModel.conversationStore.conversations[0].firstPrompt == "export me")
     }
 
     /// Minimal diagnostics for token-count assertions.

--- a/Tests/TurboFieldfareApp/Core/State/AppModelConversationTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelConversationTests.swift
@@ -200,6 +200,67 @@ import Testing
         #expect(reloaded.attachments[0].filename == "report.txt")
     }
 
+    @Test
+    func renameUpdatesTitle() {
+        let (model, _) = makeModel()
+        model.promptText = "prompt"
+        model.outputText = "response"
+        model.saveCurrentConversation()
+        let saved = model.conversationStore.conversations[0]
+
+        model.renameConversation(saved, title: "  Custom title  ")
+
+        #expect(model.conversationStore.conversations[0].title == "Custom title")
+        #expect(model.conversationStore.conversations[0].id == saved.id)
+    }
+
+    @Test
+    func renameIgnoresBlankTitle() {
+        let (model, _) = makeModel()
+        model.promptText = "prompt"
+        model.outputText = "response"
+        model.saveCurrentConversation()
+        let saved = model.conversationStore.conversations[0]
+
+        model.renameConversation(saved, title: "   ")
+
+        #expect(model.conversationStore.conversations[0].title == "prompt")
+    }
+
+    @Test
+    func togglePinFlipsConversation() {
+        let (model, _) = makeModel()
+        model.promptText = "p"
+        model.outputText = "r"
+        model.saveCurrentConversation()
+        let saved = model.conversationStore.conversations[0]
+        #expect(!saved.isPinned)
+
+        model.togglePin(saved)
+        #expect(model.conversationStore.conversations[0].isPinned)
+
+        model.togglePin(model.conversationStore.conversations[0])
+        #expect(!model.conversationStore.conversations[0].isPinned)
+    }
+
+    @Test
+    func exportAndImportThroughModel() throws {
+        let (model, _) = makeModel()
+        model.promptText = "export me"
+        model.outputText = "done"
+        model.saveCurrentConversation()
+
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("export-\(UUID().uuidString).json")
+        try model.exportConversations(to: url)
+
+        let (otherModel, _) = makeModel()
+        let count = try otherModel.importConversations(from: url)
+
+        #expect(count == 1)
+        #expect(otherModel.conversationStore.conversations[0].prompt == "export me")
+    }
+
     /// Minimal diagnostics for token-count assertions.
     private func makeDiagnostics() -> AppDiagnostics {
         AppDiagnostics(generatedTokens: 34,

--- a/Tests/TurboFieldfareApp/Core/State/AppModelMaxNewTokensTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelMaxNewTokensTests.swift
@@ -1,0 +1,50 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite @MainActor struct AppModelMaxNewTokensTests {
+    private func makeModel() -> AppModel {
+        AppModel(conversationStore: ConversationStore(storageURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("tokens-\(UUID().uuidString).json")))
+    }
+
+    @Test func saveStoresMaxNewTokens() {
+        let model = makeModel()
+        model.promptText = "prompt"
+        model.outputText = "response"
+        model.maxNewTokensOverride = 256
+        model.saveCurrentConversation()
+        #expect(model.conversationStore.conversations[0].maxNewTokens == 256)
+    }
+
+    @Test func loadRestoresMaxNewTokens() {
+        let model = makeModel()
+        let stored = Conversation(title: "t", prompt: "p", response: "r", maxNewTokens: 512)
+        model.conversationStore.upsert(stored)
+
+        model.loadConversation(stored)
+        #expect(model.maxNewTokensOverride == 512)
+    }
+
+    @Test func clearAttachmentErrorsClearsAll() {
+        let model = AppModel()
+        model.attachmentErrors = ["a", "b"]
+        model.clearAttachmentErrors()
+        #expect(model.attachmentErrors.isEmpty)
+    }
+
+    @Test func dismissAttachmentErrorRemovesOnlySelected() {
+        let model = AppModel()
+        model.attachmentErrors = ["a", "b", "c"]
+        model.dismissAttachmentError(at: 1)
+        #expect(model.attachmentErrors == ["a", "c"])
+    }
+
+    @Test func cognitiveTranscriptIsEmptyForStandardRun() async throws {
+        let model = makeModel()
+        model.promptText = "plain prompt"
+        model.outputText = "plain answer"
+        // Standard run does not populate the cognitive transcript.
+        #expect(model.cognitiveTranscript.isEmpty)
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/State/AppModelMultiTurnTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelMultiTurnTests.swift
@@ -1,0 +1,152 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite @MainActor struct AppModelMultiTurnTests {
+    private func makeModel() -> AppModel {
+        AppModel(conversationStore: ConversationStore(storageURL: FileManager.default.temporaryDirectory
+            .appendingPathComponent("multiturn-\(UUID().uuidString).json")))
+    }
+
+    @Test func conversationAsPromptFormatsTurns() {
+        let conversation = Conversation(title: "t",
+                                        turns: [
+                                            Turn(role: .user, text: "first"),
+                                            Turn(role: .model, text: "answer"),
+                                            Turn(role: .user, text: "second"),
+                                        ])
+
+        let prompt = conversation.asPrompt()
+
+        #expect(prompt.contains("User:\nfirst"))
+        #expect(prompt.contains("Model:\nanswer"))
+        #expect(prompt.contains("User:\nsecond"))
+        #expect(prompt.hasSuffix("Model:"))
+    }
+
+    @Test func displayTranscriptLabelsTurns() {
+        let conversation = Conversation(title: "t",
+                                        turns: [
+                                            Turn(role: .user, text: "hello"),
+                                            Turn(role: .model, text: "hi there"),
+                                        ])
+
+        let transcript = conversation.displayTranscript
+
+        #expect(transcript.contains("You:\nhello"))
+        #expect(transcript.contains("Answer:\nhi there"))
+    }
+
+    @Test
+    func continuationPromptIncludesHistoryAndNewMessage() {
+        let model = makeModel()
+        let stored = Conversation(title: "t",
+                                  turns: [
+                                      Turn(role: .user, text: "first"),
+                                      Turn(role: .model, text: "answer"),
+                                  ])
+        model.loadConversation(stored)
+        model.promptText = "second"
+
+        let prompt = model.continuationPromptText
+
+        #expect(prompt.contains("User:\nfirst"))
+        #expect(prompt.contains("Model:\nanswer"))
+        #expect(prompt.hasSuffix("User:\nsecond"))
+    }
+
+    @Test
+    func continuationAddsAttachmentsToNewMessage() {
+        let model = makeModel()
+        let stored = Conversation(title: "t",
+                                  turns: [Turn(role: .user, text: "hi", createdAt: Date())])
+        model.loadConversation(stored)
+        model.promptText = "summarize"
+        model.attachments = [DocumentAttachment(filename: "f.txt",
+                                                type: .txt,
+                                                fileSize: 10,
+                                                extractedText: "body")]
+
+        let prompt = model.continuationPromptText
+
+        #expect(prompt.contains("[Document: f.txt]"))
+        #expect(prompt.contains("body"))
+    }
+
+    @Test
+    func makeRequestUsesContinuationWhenConversationActive() throws {
+        let model = makeModel()
+        model.modelPathText = FileManager.default.temporaryDirectory.path
+        let stored = Conversation(title: "t",
+                                  turns: [Turn(role: .user, text: "old", createdAt: Date())])
+        model.loadConversation(stored)
+        model.promptText = "new question"
+
+        let request = try model.makeRequest()
+
+        #expect(request.prompt.contains("User:\nold"))
+        #expect(request.prompt.hasSuffix("User:\nnew question"))
+    }
+
+    @Test
+    func legacySingleExchangeFileDecodesIntoTurns() throws {
+        // A history file written before multi-turn support.
+        let json = """
+        [{
+          "id": "\(UUID().uuidString)",
+          "title": "legacy",
+          "prompt": "old prompt",
+          "response": "old answer",
+          "createdAt": "2026-01-01T10:00:00Z",
+          "updatedAt": "2026-01-01T10:00:00Z"
+        }]
+        """.data(using: .utf8)!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("legacy-mt-\(UUID().uuidString).json")
+        try json.write(to: url)
+
+        let store = ConversationStore(storageURL: url)
+
+        #expect(store.conversations.count == 1)
+        #expect(store.conversations[0].turns.count == 2)
+        #expect(store.conversations[0].firstPrompt == "old prompt")
+        #expect(store.conversations[0].lastResponse == "old answer")
+    }
+
+    @Test
+    func savingAfterContinuationAppendsTurns() {
+        let model = makeModel()
+        model.promptText = "turn one"
+        model.outputText = "answer one"
+        model.saveCurrentConversation()
+        let id = model.activeConversationID
+        #expect(model.conversationStore.conversations[0].turns.count == 2)
+
+        // Continue the same conversation with a new message.
+        model.promptText = "turn two"
+        model.outputText = "answer two"
+        model.saveCurrentConversation()
+
+        #expect(model.activeConversationID == id)
+        #expect(model.conversationStore.conversations.count == 1)
+        let turns = model.conversationStore.conversations[0].turns
+        #expect(turns.count == 4)
+        #expect(turns[2].text == "turn two")
+        #expect(turns[3].text == "answer two")
+    }
+
+    @Test
+    func regeneratingLastPromptReplacesModelAnswer() {
+        let model = makeModel()
+        model.promptText = "same"
+        model.outputText = "answer one"
+        model.saveCurrentConversation()
+
+        model.outputText = "answer two"
+        model.saveCurrentConversation()
+
+        let turns = model.conversationStore.conversations[0].turns
+        #expect(turns.count == 2)
+        #expect(turns[1].text == "answer two")
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/State/AppModelMultiTurnTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelMultiTurnTests.swift
@@ -207,6 +207,53 @@ import Testing
         #expect(markdown.contains("## User\n\nhello"))
         #expect(markdown.contains("## Assistant\n\nhi"))
     }
+
+    // MARK: - Templates & tags
+
+    @Test
+    func setTemplateMarksConversation() {
+        let (model, _) = AppModelConversationTestsHelper.makeModel()
+        let conversation = Conversation(title: "t", prompt: "p", response: "r")
+        model.conversationStore.upsert(conversation)
+
+        model.setTemplate(conversation, isTemplate: true)
+
+        #expect(model.conversationStore.conversations[0].isTemplate)
+
+        model.setTemplate(model.conversationStore.conversations[0], isTemplate: false)
+        #expect(!model.conversationStore.conversations[0].isTemplate)
+    }
+
+    @Test
+    func setTagsNormalizesAndDeduplicates() {
+        let (model, _) = AppModelConversationTestsHelper.makeModel()
+        let conversation = Conversation(title: "t", prompt: "p", response: "r")
+        model.conversationStore.upsert(conversation)
+
+        model.setTags(conversation, tags: [" work ", "code", "work", "  "])
+
+        #expect(model.conversationStore.conversations[0].tags == ["work", "code"])
+    }
+
+    @Test
+    func savingActiveConversationPreservesTemplateAndTags() {
+        let (model, _) = AppModelConversationTestsHelper.makeModel()
+        model.promptText = "prompt"
+        model.outputText = "answer"
+        model.saveCurrentConversation()
+        let saved = model.conversationStore.conversations[0]
+        model.setTemplate(saved, isTemplate: true)
+        model.setTags(saved, tags: ["meta"])
+
+        // Regenerate the same prompt: the flags must survive the upsert.
+        model.outputText = "answer two"
+        model.saveCurrentConversation()
+
+        let updated = model.conversationStore.conversations[0]
+        #expect(updated.isTemplate)
+        #expect(updated.tags == ["meta"])
+        #expect(updated.lastResponse == "answer two")
+    }
 }
 
 /// Test helper sharing the isolated-store model factory.

--- a/Tests/TurboFieldfareApp/Core/State/AppModelMultiTurnTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelMultiTurnTests.swift
@@ -254,6 +254,60 @@ import Testing
         #expect(updated.tags == ["meta"])
         #expect(updated.lastResponse == "answer two")
     }
+
+    // MARK: - Comparison (H.3)
+
+    @Test
+    func conversationsSharingPromptFiltersByFirstTurn() {
+        let (model, _) = AppModelConversationTestsHelper.makeModel()
+        let first = Conversation(title: "a", prompt: "same", response: "r1")
+        let second = Conversation(title: "b", prompt: "same", response: "r2")
+        let different = Conversation(title: "c", prompt: "other", response: "r3")
+        model.conversationStore.upsert(first)
+        model.conversationStore.upsert(second)
+        model.conversationStore.upsert(different)
+
+        let candidates = model.conversationsSharingPrompt(with: first)
+
+        #expect(candidates.count == 1)
+        #expect(candidates[0].id == second.id)
+    }
+
+    // MARK: - Summary (H.1)
+
+    @Test
+    func beginSummaryLaunchesSummaryConversation() async throws {
+        let mock = MockInferenceClient(response: "concise summary",
+                                       tokenDelayNanos: 1_000_000)
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("summary-\(UUID().uuidString).json")
+        let model = AppModel(client: mock,
+                             conversationStore: ConversationStore(storageURL: url))
+        model.modelPathText = FileManager.default.temporaryDirectory.path
+        model.loadState = .ready(modelDirectory: FileManager.default.temporaryDirectory,
+                                 loadSeconds: 1)
+        let source = Conversation(title: "s",
+                                  turns: [
+                                      Turn(role: .user, text: "hello"),
+                                      Turn(role: .model, text: "hi there"),
+                                  ])
+
+        model.beginSummary(of: source)
+        await waitUntilIdle(model)
+
+        #expect(model.conversationStore.conversations.count == 1)
+        let saved = model.conversationStore.conversations[0]
+        #expect(saved.firstPrompt.contains("Summarize the conversation"))
+        #expect(saved.lastResponse.contains("concise summary"))
+    }
+
+    private func waitUntilIdle(_ model: AppModel, timeoutMilliseconds: Int = 15_000) async {
+        var waited = 0
+        while model.runState == .running && waited < timeoutMilliseconds {
+            try? await Task.sleep(for: .milliseconds(20))
+            waited += 20
+        }
+    }
 }
 
 /// Test helper sharing the isolated-store model factory.

--- a/Tests/TurboFieldfareApp/Core/State/AppModelMultiTurnTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelMultiTurnTests.swift
@@ -149,4 +149,72 @@ import Testing
         #expect(turns.count == 2)
         #expect(turns[1].text == "answer two")
     }
+
+    // MARK: - Fork
+
+    @Test
+    func forkCreatesLinkedCopyAsActiveConversation() {
+        let (model, _) = AppModelConversationTestsHelper.makeModel()
+        model.promptText = "original"
+        model.outputText = "answer"
+        model.saveCurrentConversation()
+        let source = model.conversationStore.conversations[0]
+
+        model.forkConversation(source)
+
+        #expect(model.conversationStore.conversations.count == 2)
+        let fork = model.conversationStore.conversations[0]
+        #expect(fork.id != source.id)
+        #expect(fork.parentConversationID == source.id)
+        #expect(fork.title == "Fork of \(source.title)")
+        #expect(fork.turns == source.turns)
+        #expect(model.activeConversationID == fork.id)
+    }
+
+    @Test
+    func forkUpToTurnTruncatesHistory() {
+        let (model, _) = AppModelConversationTestsHelper.makeModel()
+        model.promptText = "one"
+        model.outputText = "answer one"
+        model.saveCurrentConversation()
+        model.promptText = "two"
+        model.outputText = "answer two"
+        model.saveCurrentConversation()
+        let source = model.conversationStore.conversations[0]
+        let secondUserTurn = source.turns[2]
+
+        model.forkConversation(source, upTo: secondUserTurn)
+
+        let fork = model.conversationStore.conversations[0]
+        #expect(fork.turns.count == 3)
+        #expect(fork.turns.last?.text == "two")
+    }
+
+    // MARK: - Markdown export
+
+    @Test
+    func exportMarkdownRendersTurns() {
+        let (model, _) = AppModelConversationTestsHelper.makeModel()
+        let conversation = Conversation(title: "My chat",
+                                        turns: [
+                                            Turn(role: .user, text: "hello"),
+                                            Turn(role: .model, text: "hi"),
+                                        ])
+
+        let markdown = model.exportConversationMarkdown(conversation)
+
+        #expect(markdown.hasPrefix("# My chat"))
+        #expect(markdown.contains("## User\n\nhello"))
+        #expect(markdown.contains("## Assistant\n\nhi"))
+    }
+}
+
+/// Test helper sharing the isolated-store model factory.
+enum AppModelConversationTestsHelper {
+    @MainActor
+    static func makeModel() -> (AppModel, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("helper-\(UUID().uuidString).json")
+        return (AppModel(conversationStore: ConversationStore(storageURL: url)), url)
+    }
 }

--- a/Tests/TurboFieldfareApp/Core/State/ConversationStoreNewTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/ConversationStoreNewTests.swift
@@ -1,0 +1,57 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite @MainActor struct ConversationStoreNewTests {
+    private struct TestAttachment: Codable {
+        let filename: String
+    }
+
+    private func makeStore(fileName: String = "conversations-\(UUID().uuidString).json") -> (ConversationStore, URL) {
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent(fileName)
+        return (ConversationStore(storageURL: url), url)
+    }
+
+    @Test func persistsMaxNewTokensAcrossInstances() {
+        let (store, url) = makeStore()
+        store.upsert(Conversation(title: "t", prompt: "p", response: "r", maxNewTokens: 128))
+
+        let reloaded = ConversationStore(storageURL: url)
+        #expect(reloaded.conversations[0].maxNewTokens == 128)
+    }
+
+    @Test func corruptedFileIsPreservedAndFlagSet() throws {
+        let (store, url) = makeStore()
+        store.upsert(Conversation(title: "t", prompt: "p", response: "r"))
+
+        try "!not json".data(using: .utf8)!.write(to: url)
+
+        let recovered = ConversationStore(storageURL: url)
+        #expect(recovered.didLoadFromCorrupted)
+        #expect(recovered.conversations.isEmpty)
+        #expect(FileManager.default.fileExists(atPath: url.appendingPathExtension("corrupted").path))
+    }
+
+    @Test func preservedCorruptedFileVisible() throws {
+        let (store, url) = makeStore()
+        _ = store
+        try "!corrupt".data(using: .utf8)!.write(to: url)
+        let recovered = ConversationStore(storageURL: url)
+        // The .corrupted backup exists so the original data is not lost.
+        #expect(recovered.didLoadFromCorrupted)
+        #expect(FileManager.default.fileExists(atPath: url.appendingPathExtension("corrupted").path))
+    }
+
+    @Test func fractionalDatesLoad() throws {
+        let json = """
+        [{"id": "\(UUID().uuidString)", "title": "t", "prompt": "p", "response": "r",
+          "createdAt": "2026-01-01T10:00:00.123Z", "updatedAt": "2026-01-01T10:00:00Z"}]
+        """.data(using: .utf8)!
+        let url = FileManager.default.temporaryDirectory.appendingPathComponent("fractional-\(UUID().uuidString).json")
+        try json.write(to: url)
+
+        let store = ConversationStore(storageURL: url)
+        #expect(store.conversations.count == 1)
+        #expect(store.conversations[0].title == "t")
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
@@ -37,6 +37,51 @@ import Testing
         #expect(store.conversations.map(\.title) == ["newer", "older"])
     }
 
+    @Test func pinnedConversationsSortFirst() {
+        let (store, _) = makeStore()
+        let olderPinned = conversation(title: "pinned old",
+                                       updatedAt: Date().addingTimeInterval(-3600))
+            .replacing(isPinned: true)
+        let recent = conversation(title: "recent", updatedAt: Date())
+
+        store.upsert(recent)
+        store.upsert(olderPinned)
+
+        #expect(store.conversations.map(\.title) == ["pinned old", "recent"])
+    }
+
+    @Test func exportAndImportRoundTrip() throws {
+        let (store, _) = makeStore()
+        store.upsert(conversation(title: "a", promptTokenCount: 1))
+        store.upsert(conversation(title: "b"))
+
+        let data = try store.exportJSON()
+
+        let (otherStore, _) = makeStore()
+        let count = try otherStore.importJSON(data)
+
+        #expect(count == 2)
+        #expect(otherStore.conversations.map(\.title) == store.conversations.map(\.title))
+        #expect(otherStore.conversations.first { $0.title == "a" }?.promptTokenCount == 1)
+    }
+
+    @Test func importReplacesSameId() throws {
+        let (store, _) = makeStore()
+        store.upsert(conversation(title: "original"))
+
+        // An exported file with the same id but a renamed title.
+        let renamed = store.conversations[0].replacing(title: "renamed")
+        let (otherStore, _) = makeStore()
+        otherStore.upsert(renamed)
+        let data = try otherStore.exportJSON()
+
+        let count = try store.importJSON(data)
+
+        #expect(count == 1)
+        #expect(store.conversations.count == 1)
+        #expect(store.conversations[0].title == "renamed")
+    }
+
     @Test func upsertReplacesExistingConversation() {
         let (store, _) = makeStore()
         let id = UUID()

--- a/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
@@ -94,8 +94,8 @@ import Testing
 
         #expect(store.conversations.count == 1)
         #expect(store.conversations.first?.title == "second")
-        #expect(store.conversations.first?.prompt == "p2")
-        #expect(store.conversations.first?.response == "r2")
+        #expect(store.conversations.first?.firstPrompt == "p2")
+        #expect(store.conversations.first?.lastResponse == "r2")
     }
 
     @Test func deleteRemovesConversation() {
@@ -135,8 +135,8 @@ import Testing
         let restored = reloaded.conversations[0]
         #expect(restored.id == saved.id)
         #expect(restored.title == "persisted")
-        #expect(restored.prompt == "Prompt for persisted")
-        #expect(restored.response == "Response for persisted")
+        #expect(restored.firstPrompt == "Prompt for persisted")
+        #expect(restored.lastResponse == "Response for persisted")
         #expect(restored.promptTokenCount == 12)
         #expect(restored.generatedTokenCount == 34)
         #expect(restored.stopReason == "length")

--- a/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
@@ -104,6 +104,57 @@ import Testing
         #expect(store.conversations.isEmpty)
     }
 
+    @Test func decodesLegacyFileWithoutAttachments() throws {
+        // History files written before document attachments existed have no
+        // "attachments" key; they must still load with an empty list.
+        let legacyJSON = """
+        [
+          {
+            "id": "\(UUID().uuidString)",
+            "title": "legacy",
+            "prompt": "old prompt",
+            "response": "old response",
+            "createdAt": "2026-01-01T10:00:00Z",
+            "updatedAt": "2026-01-01T10:00:00Z"
+          }
+        ]
+        """.data(using: .utf8)!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("legacy-\(UUID().uuidString).json")
+        try legacyJSON.write(to: url)
+
+        let store = ConversationStore(storageURL: url)
+
+        #expect(store.conversations.count == 1)
+        #expect(store.conversations[0].title == "legacy")
+        #expect(store.conversations[0].attachments.isEmpty)
+    }
+
+    @Test func persistsAttachmentsAcrossStoreInstances() {
+        let (store, url) = makeStore()
+        let attachment = DocumentAttachment(filename: "report.pdf",
+                                            type: .pdf,
+                                            fileSize: 2048,
+                                            extractedText: "report body",
+                                            pageCount: 3,
+                                            truncated: false,
+                                            originalLength: 11)
+        store.upsert(Conversation(title: "with docs",
+                                  prompt: "p",
+                                  response: "r",
+                                  attachments: [attachment]))
+
+        let reloaded = ConversationStore(storageURL: url)
+
+        #expect(reloaded.conversations.count == 1)
+        let restored = reloaded.conversations[0].attachments
+        #expect(restored.count == 1)
+        #expect(restored[0].filename == "report.pdf")
+        #expect(restored[0].type == .pdf)
+        #expect(restored[0].pageCount == 3)
+        #expect(restored[0].extractedText == "report body")
+    }
+
     @Test func titleFromEmptyPromptUsesPlaceholder() {
         #expect(Conversation.title(from: "   \n  ") == "New conversation")
     }

--- a/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
@@ -1,0 +1,134 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite @MainActor struct ConversationStoreTests {
+    /// Creates an isolated store backed by a unique temporary file.
+    private func makeStore() -> (ConversationStore, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("conversations-\(UUID().uuidString).json")
+        return (ConversationStore(storageURL: url), url)
+    }
+
+    private func conversation(title: String,
+                              updatedAt: Date = Date(),
+                              promptTokenCount: Int? = nil,
+                              generatedTokenCount: Int? = nil,
+                              stopReason: String? = nil) -> Conversation {
+        Conversation(id: UUID(),
+                     title: title,
+                     prompt: "Prompt for \(title)",
+                     response: "Response for \(title)",
+                     updatedAt: updatedAt,
+                     promptTokenCount: promptTokenCount,
+                     generatedTokenCount: generatedTokenCount,
+                     stopReason: stopReason)
+    }
+
+    @Test func insertsNewConversationAtTop() {
+        let (store, _) = makeStore()
+        let older = conversation(title: "older", updatedAt: Date().addingTimeInterval(-60))
+        let newer = conversation(title: "newer", updatedAt: Date())
+
+        store.upsert(older)
+        store.upsert(newer)
+
+        #expect(store.conversations.count == 2)
+        #expect(store.conversations.map(\.title) == ["newer", "older"])
+    }
+
+    @Test func upsertReplacesExistingConversation() {
+        let (store, _) = makeStore()
+        let id = UUID()
+        let first = Conversation(id: id, title: "first", prompt: "p1", response: "r1")
+        store.upsert(first)
+
+        let second = Conversation(id: id, title: "second", prompt: "p2", response: "r2",
+                                  updatedAt: Date().addingTimeInterval(10))
+        store.upsert(second)
+
+        #expect(store.conversations.count == 1)
+        #expect(store.conversations.first?.title == "second")
+        #expect(store.conversations.first?.prompt == "p2")
+        #expect(store.conversations.first?.response == "r2")
+    }
+
+    @Test func deleteRemovesConversation() {
+        let (store, _) = makeStore()
+        let a = conversation(title: "a")
+        let b = conversation(title: "b")
+        store.upsert(a)
+        store.upsert(b)
+
+        store.delete(a)
+
+        #expect(store.conversations.count == 1)
+        #expect(store.conversations.first?.title == "b")
+    }
+
+    @Test func clearAllEmptiesStore() {
+        let (store, _) = makeStore()
+        store.upsert(conversation(title: "a"))
+        store.upsert(conversation(title: "b"))
+
+        store.clearAll()
+
+        #expect(store.conversations.isEmpty)
+    }
+
+    @Test func persistsAcrossStoreInstances() {
+        let (store, url) = makeStore()
+        let saved = conversation(title: "persisted",
+                                 promptTokenCount: 12,
+                                 generatedTokenCount: 34,
+                                 stopReason: "length")
+        store.upsert(saved)
+
+        // A fresh store over the same file must reload the conversation.
+        let reloaded = ConversationStore(storageURL: url)
+        #expect(reloaded.conversations.count == 1)
+        let restored = reloaded.conversations[0]
+        #expect(restored.id == saved.id)
+        #expect(restored.title == "persisted")
+        #expect(restored.prompt == "Prompt for persisted")
+        #expect(restored.response == "Response for persisted")
+        #expect(restored.promptTokenCount == 12)
+        #expect(restored.generatedTokenCount == 34)
+        #expect(restored.stopReason == "length")
+    }
+
+    @Test func missingFileLoadsEmptyStore() {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("does-not-exist-\(UUID().uuidString).json")
+        let store = ConversationStore(storageURL: url)
+        #expect(store.conversations.isEmpty)
+    }
+
+    @Test func titleFromEmptyPromptUsesPlaceholder() {
+        #expect(Conversation.title(from: "   \n  ") == "New conversation")
+    }
+
+    @Test func titleKeepsShortPrompt() {
+        #expect(Conversation.title(from: "The capital of France") == "The capital of France")
+    }
+
+    @Test func titleTruncatesLongPrompt() {
+        let long = String(repeating: "x", count: 120)
+        let title = Conversation.title(from: long)
+        #expect(title.count == 61)  // 60 characters + ellipsis
+        #expect(title.hasSuffix("…"))
+        #expect(title.dropLast() == String(repeating: "x", count: 60))
+    }
+
+    @Test func responsePreviewTruncatesLongResponse() {
+        let long = String(repeating: "y", count: 250)
+        let preview = Conversation(title: "t", prompt: "p", response: long).responsePreview
+        #expect(preview.count == 101)  // 100 characters + ellipsis
+        #expect(preview.hasSuffix("…"))
+    }
+
+    @Test func responsePreviewKeepsShortResponse() {
+        let preview = Conversation(title: "t", prompt: "p", response: "short").responsePreview
+        #expect(preview == "short")
+    }
+}

--- a/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/ConversationStoreTests.swift
@@ -175,6 +175,31 @@ import Testing
         #expect(store.conversations[0].attachments.isEmpty)
     }
 
+    @Test func decodesFractionalSecondDates() throws {
+        // Files written by other tools may use fractional-second timestamps;
+        // they must still load (whole-second ones are produced by the app).
+        let json = """
+        [
+          {
+            "id": "\(UUID().uuidString)",
+            "title": "fractional",
+            "prompt": "p",
+            "response": "r",
+            "createdAt": "2026-01-01T10:00:00.123Z",
+            "updatedAt": "2026-01-01T10:00:00Z"
+          }
+        ]
+        """.data(using: .utf8)!
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("fractional-\(UUID().uuidString).json")
+        try json.write(to: url)
+
+        let store = ConversationStore(storageURL: url)
+
+        #expect(store.conversations.count == 1)
+        #expect(store.conversations[0].title == "fractional")
+    }
+
     @Test func persistsAttachmentsAcrossStoreInstances() {
         let (store, url) = makeStore()
         let attachment = DocumentAttachment(filename: "report.pdf",

--- a/Tests/TurboFieldfareApp/Core/State/DocumentLibraryTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/DocumentLibraryTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite @MainActor struct DocumentLibraryTests {
+    private func makeLibrary() -> (DocumentLibrary, URL) {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent("documents-\(UUID().uuidString).json")
+        return (DocumentLibrary(storageURL: url), url)
+    }
+
+    private func attachment(filename: String, text: String = "body") -> DocumentAttachment {
+        DocumentAttachment(filename: filename,
+                           type: .txt,
+                           fileSize: 10,
+                           extractedText: text)
+    }
+
+    @Test func upsertReplacesByFilename() {
+        let (library, _) = makeLibrary()
+        library.upsert(attachment(filename: "a.txt"))
+        library.upsert(attachment(filename: "b.txt"))
+
+        #expect(library.documents.count == 2)
+
+        library.upsert(attachment(filename: "a.txt", text: "updated"))
+        #expect(library.documents.count == 2)
+        #expect(library.document(named: "a.txt")?.extractedText == "updated")
+    }
+
+    @Test func lookupByName() {
+        let (library, _) = makeLibrary()
+        library.upsert(attachment(filename: "report.pdf"))
+
+        #expect(library.document(named: "report.pdf") != nil)
+        #expect(library.document(named: "missing.pdf") == nil)
+    }
+
+    @Test func persistsAcrossInstances() {
+        let (library, url) = makeLibrary()
+        library.upsert(attachment(filename: "notes.txt"))
+
+        let reloaded = DocumentLibrary(storageURL: url)
+        #expect(reloaded.documents.count == 1)
+        #expect(reloaded.document(named: "notes.txt")?.extractedText == "body")
+    }
+
+    @Test func removeAndClear() {
+        let (library, _) = makeLibrary()
+        let first = attachment(filename: "a.txt")
+        library.upsert(first)
+        library.upsert(attachment(filename: "b.txt"))
+
+        library.remove(first)
+        #expect(library.documents.count == 1)
+
+        library.clear()
+        #expect(library.documents.isEmpty)
+    }
+
+    @Test func attachDocumentsCachesInLibrary() async throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("cached.txt")
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data("cache me".utf8).write(to: url)
+
+        let model = AppModel(conversationStore: ConversationStore(
+            storageURL: FileManager.default.temporaryDirectory
+                .appendingPathComponent("doc-\(UUID().uuidString).json")))
+        model.attachDocuments(from: [url])
+        // Wait for the detached extraction to finish.
+        var waited = 0
+        while model.isExtractingAttachment && waited < 5_000 {
+            try? await Task.sleep(for: .milliseconds(20))
+            waited += 20
+        }
+
+        #expect(model.documentLibrary.document(named: "cached.txt")?.extractedText == "cache me")
+    }
+}

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -875,7 +875,54 @@ private enum RawSocketError: Error {
     case timeout
 }
 
-private func connectedSocket(port: Int) throws -> Int32 {
+    @Test func metricsEndpointReportsServerState() async throws {
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: ContentAndToolBackend(),
+            heartbeatInterval: .seconds(10))
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+
+        let data = try await URLSession.shared.data(
+            for: URLRequest(
+                url: URL(string: "http://127.0.0.1:\(port)/metrics")!)).0
+        let text = String(decoding: data, as: UTF8.self)
+
+        #expect(text.contains("turbofieldfare_requests_total 0"))
+        #expect(text.contains("turbofieldfare_uptime_seconds"))
+        #expect(text.contains("turbofieldfare_model_info{model=\"test-model\"} 1"))
+
+        try await server.shutdown()
+    }
+
+    @Test func metricsCounterGrowsWithCompletions() async throws {
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: ContentAndToolBackend(),
+            heartbeatInterval: .seconds(10))
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+
+        var request = URLRequest(
+            url: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"{"model":"test-model","messages":[{"role":"user","content":"hi"}]}"#.utf8)
+        _ = try await URLSession.shared.data(for: request)
+
+        let data = try await URLSession.shared.data(
+            for: URLRequest(
+                url: URL(string: "http://127.0.0.1:\(port)/metrics")!)).0
+        let text = String(decoding: data, as: UTF8.self)
+
+        #expect(text.contains("turbofieldfare_requests_total 1"))
+
+        try await server.shutdown()
+    }
+
+    private func connectedSocket(port: Int) throws -> Int32 {
     let descriptor = Darwin.socket(AF_INET, SOCK_STREAM, 0)
     guard descriptor >= 0 else {
         throw RawSocketError.systemCall("socket", errno)

--- a/Tests/TurboFieldfareServer/HTTPServerTests.swift
+++ b/Tests/TurboFieldfareServer/HTTPServerTests.swift
@@ -74,6 +74,25 @@ private actor ContentAndToolBackend: ServerInferenceBackend {
     }
 }
 
+/// Captures the rendered message contents so tests can verify prompt
+/// composition (e.g. document injection).
+private actor RecordingBackend: ServerInferenceBackend {
+    private(set) var capturedPrompt = ""
+
+    func generate(
+        _ request: ValidatedChatRequest,
+        onEvent: @escaping @Sendable (ServerInferenceEvent) -> Void
+    ) async throws -> ServerCompletion {
+        capturedPrompt = request.messages.compactMap(\.content).joined(separator: "\n")
+        onEvent(.content("ok"))
+        return ServerCompletion(
+            content: "ok",
+            toolCalls: [],
+            finishReason: "eos",
+            usage: OpenAIUsage(promptTokens: 1, completionTokens: 1, totalTokens: 2))
+    }
+}
+
 private actor PipelinedRequestBackend: ServerInferenceBackend {
     private var continuation: CheckedContinuation<Void, Never>?
     private(set) var generationCount = 0
@@ -918,6 +937,57 @@ private enum RawSocketError: Error {
         let text = String(decoding: data, as: UTF8.self)
 
         #expect(text.contains("turbofieldfare_requests_total 1"))
+
+        try await server.shutdown()
+    }
+
+    @Test func userMessageDocumentIsInjectedIntoPrompt() async throws {
+        let backend = RecordingBackend()
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: backend,
+            heartbeatInterval: .seconds(10))
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+
+        var request = URLRequest(
+            url: URL(string: "http://127.0.0.1:\(port)/v1/chat/completions")!)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "content-type")
+        request.httpBody = Data(#"""
+        {"model":"test-model","messages":[
+          {"role":"user","content":"summarize","document":{"text":"confidential notes","filename":"notes.txt"}}
+        ]}
+        """#.utf8)
+        let response = try await URLSession.shared.data(for: request)
+
+        #expect((response.1 as? HTTPURLResponse)?.statusCode == 200)
+        let prompt = await backend.capturedPrompt
+        #expect(prompt.contains("[Document: notes.txt]"))
+        #expect(prompt.contains("confidential notes"))
+        #expect(prompt.contains("summarize"))
+
+        try await server.shutdown()
+    }
+
+    @Test func conversationsRouteReturnsHistoryOrEmpty() async throws {
+        let server = TurboFieldfareHTTPServer(
+            modelID: "test-model",
+            queueLimit: 1,
+            backend: ContentAndToolBackend(),
+            heartbeatInterval: .seconds(10))
+        let channel = try await server.start(port: 0)
+        let port = try #require(channel.localAddress?.port)
+
+        let data = try await URLSession.shared.data(
+            for: URLRequest(
+                url: URL(string: "http://127.0.0.1:\(port)/v1/conversations")!)).0
+
+        // The endpoint must always return a JSON array (history may be
+        // present on machines where the app has run).
+        let object = try JSONSerialization.jsonObject(with: data) as? [Any]
+        #expect(object != nil)
 
         try await server.shutdown()
     }

--- a/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
@@ -434,9 +434,67 @@ struct ServerArgumentTests {
     @Test func defaults() throws {
         let arguments = try ServerArguments.parse(["--model", "model.gturbo"])
         #expect(arguments.port == 8080)
+        #expect(arguments.host == "127.0.0.1")
+        #expect(arguments.allowRemote == false)
         #expect(arguments.maxContext == 16_384)
         #expect(arguments.queueLimit == 4)
         #expect(arguments.promptCacheMode == .singlePrefix)
+    }
+
+    @Test func acceptsLoopbackHostVariants() throws {
+        for host in ["127.0.0.1", "::1", "localhost", "LOCALHOST"] {
+            let arguments = try ServerArguments.parse([
+                "--model", "model.gturbo",
+                "--host", host,
+            ])
+            #expect(arguments.host == host)
+            #expect(arguments.allowRemote == false)
+        }
+    }
+
+    @Test func rejectsNonLoopbackHostWithoutAllowRemote() throws {
+        #expect(throws: ServerArgumentError.self) {
+            try ServerArguments.parse([
+                "--model", "model.gturbo",
+                "--host", "0.0.0.0",
+            ])
+        }
+        #expect(throws: ServerArgumentError.self) {
+            try ServerArguments.parse([
+                "--model", "model.gturbo",
+                "--host", "192.168.1.10",
+            ])
+        }
+    }
+
+    @Test func permitsNonLoopbackHostWithAllowRemote() throws {
+        let arguments = try ServerArguments.parse([
+            "--model", "model.gturbo",
+            "--host", "0.0.0.0",
+            "--allow-remote",
+        ])
+        #expect(arguments.host == "0.0.0.0")
+        #expect(arguments.allowRemote == true)
+    }
+
+    @Test func allowRemoteIsAFlagNotAValue() throws {
+        // --allow-remote takes no value; the next flag must still parse normally.
+        let arguments = try ServerArguments.parse([
+            "--allow-remote",
+            "--model", "model.gturbo",
+            "--host", "10.0.0.5",
+        ])
+        #expect(arguments.allowRemote == true)
+        #expect(arguments.host == "10.0.0.5")
+    }
+
+    @Test func rejectsEmptyHost() throws {
+        #expect(throws: ServerArgumentError.self) {
+            try ServerArguments.parse([
+                "--model", "model.gturbo",
+                "--host", "   ",
+            ])
+        }
     }
 
     @Test func parsesSinglePrefixModeAndRejectsUnknownMode() throws {

--- a/Tests/TurboFieldfareServer/ServerDocumentExtractorTests.swift
+++ b/Tests/TurboFieldfareServer/ServerDocumentExtractorTests.swift
@@ -1,0 +1,58 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareServerCore
+
+@Suite struct ServerDocumentExtractorTests {
+    @Test func inlineTextIsReturned() throws {
+        let text = try ServerDocumentExtractor.text(
+            for: ServerDocumentReference(text: "  hello world  "))
+        #expect(text == "hello world")
+    }
+
+    @Test func base64TextIsDecoded() throws {
+        let base64 = Data("encoded content".utf8).base64EncodedString()
+        let text = try ServerDocumentExtractor.text(
+            for: ServerDocumentReference(base64: base64))
+        #expect(text == "encoded content")
+    }
+
+    @Test func pathReadsTextFile() throws {
+        let url = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString)
+            .appendingPathComponent("notes.txt")
+        try FileManager.default.createDirectory(at: url.deletingLastPathComponent(),
+                                                withIntermediateDirectories: true)
+        try Data("file content".utf8).write(to: url)
+
+        let text = try ServerDocumentExtractor.text(
+            for: ServerDocumentReference(path: url.path))
+        #expect(text == "file content")
+    }
+
+    @Test func binaryFormatsAreRefused() {
+        #expect(throws: ServerDocumentExtractor.ExtractionError.self) {
+            _ = try ServerDocumentExtractor.text(
+                for: ServerDocumentReference(path: "/tmp/report.pdf"))
+        }
+    }
+
+    @Test func missingSourcesAreRejected() {
+        #expect(throws: ServerDocumentExtractor.ExtractionError.self) {
+            _ = try ServerDocumentExtractor.text(for: ServerDocumentReference())
+        }
+    }
+
+    @Test func multipleSourcesAreRejected() {
+        #expect(throws: ServerDocumentExtractor.ExtractionError.self) {
+            _ = try ServerDocumentExtractor.text(
+                for: ServerDocumentReference(path: "/tmp/x.txt", text: "a"))
+        }
+    }
+
+    @Test func emptyTextIsRejected() {
+        #expect(throws: ServerDocumentExtractor.ExtractionError.self) {
+            _ = try ServerDocumentExtractor.text(
+                for: ServerDocumentReference(text: "   "))
+        }
+    }
+}

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -1,8 +1,9 @@
 # Local OpenAI-compatible server
 
 `TurboFieldfareServer` exposes a local Chat Completions API for one Gemma
-model. It binds to `127.0.0.1` without authentication or TLS. Do not expose it
-through a proxy or tunnel.
+model. It binds to `127.0.0.1` by default, without authentication or TLS. Do
+not expose it through a proxy or tunnel, and keep it on loopback unless you
+explicitly choose otherwise (see [Bind address](#bind-address)).
 
 ## Start the server
 
@@ -26,6 +27,25 @@ swift build -c release --product TurboFieldfareServer
 The server loads the model before opening the port. Wait for
 `TurboFieldfareServer ready`, then keep the process running while clients use
 it.
+
+### Bind address
+
+`--host` selects the bind address (default `127.0.0.1`). Loopback hosts
+(`127.0.0.1`, `::1`, `localhost`) are always allowed. Binding any other host
+is refused unless `--allow-remote` is passed, because the server has no
+authentication or TLS:
+
+```bash
+.build/release/TurboFieldfareServer \
+  --model scratch/gemma4.gturbo \
+  --host 192.168.1.10 \
+  --allow-remote
+```
+
+Only enable `--allow-remote` on a trusted, isolated network. Anyone who can
+reach the bound address can generate with your model, read its outputs, and
+ask it to make tool calls (which the client must still authorize). Prefer a
+loopback connection or an SSH tunnel to a remote host instead.
 
 Check the server from another terminal:
 


### PR DESCRIPTION
## Summary

Adds three independent improvements to the Mac app and the loopback server.

### Mac app: conversation history
- Persistent sidebar (`NavigationSplitView`) listing past conversations, with search, load, delete, and clear-all.
- Conversations are stored as JSON in Application Support and include token counts and stop reason from diagnostics.

### Mac app: document attachments
- Attach PDF, DOCX, TXT, MD, and RTF files (up to 50 MB); extracted text is injected into the prompt with `[Document: …]` context markers.
- Text extraction via PDFKit for PDFs and `NSAttributedString` for DOCX; files over 500k characters are truncated with a visible warning.
- Supported through the file importer **and** drag & drop.

### Fixes
- **Restore `InspectorView`** in the `detail` pane of the `NavigationSplitView`. The sidebar refactor had dropped the runtime controls (context length, expert-cache slots, temperature/Top-K/Top-P, prefill, RDADVISE, unload) from the layout entirely.
- **Remove dead cognitive-mode placeholder** (`runCognitiveCycle`) that skipped generation state initialization (transcript reset, `activeRunRuntimeKey`, live counters).
- **Release security-scoped access** after document extraction: `startAccessingSecurityScopedResource()` was never balanced with `stopAccessingSecurityScopedResource()`, leaking access tokens; drag-and-drop URLs had no scope handling at all.

### Server hardening
- Add `--host` and `--allow-remote`. Binding a non-loopback host is refused unless `--allow-remote` is passed explicitly, since the server has no authentication or TLS.

### CI
- Cache SwiftPM, add a debug build as a fast first signal, and run `swift-format` lint as a non-blocking step.
- Ignore local `TurboFieldfare.app` bundle builds.

## Validation
- `swift build` (debug): clean
- `Scripts/test.sh`: **520 tests in 108 suites, all passing** (includes 5 new tests covering `--host`/`--allow-remote` parsing)