### PR TITLE
Add configurable bind host for TurboFieldfareServer

### DIFF
--- a/Sources/TurboFieldfareServer/Command/main.swift
+++ b/Sources/TurboFieldfareServer/Command/main.swift
@@ -24,8 +24,9 @@ do {
         modelID: arguments.modelID,
         queueLimit: arguments.queueLimit,
         backend: backend)
-    _ = try await server.start(port: arguments.port)
-    print("TurboFieldfareServer ready at http://127.0.0.1:\(arguments.port) model=\(arguments.modelID) context=\(arguments.maxContext) prompt_cache=\(arguments.promptCacheMode.rawValue)")
+    _ = try await server.start(host: arguments.host, port: arguments.port)
+    let displayHost = arguments.host == "0.0.0.0" ? "0.0.0.0" : arguments.host
+    print("TurboFieldfareServer ready at http://\(displayHost):\(arguments.port) model=\(arguments.modelID) context=\(arguments.maxContext) prompt_cache=\(arguments.promptCacheMode.rawValue)")
 
     _ = await signals.wait()
     try await server.shutdown()

--- a/Sources/TurboFieldfareServer/Core/HTTPServer.swift
+++ b/Sources/TurboFieldfareServer/Core/HTTPServer.swift
@@ -29,7 +29,7 @@ public actor TurboFieldfareHTTPServer {
         self.heartbeatInterval = heartbeatInterval
     }
 
-    public func start(port: Int) async throws -> Channel {
+    public func start(host: String = "127.0.0.1", port: Int) async throws -> Channel {
         let modelID = self.modelID
         let backend = self.backend
         let coordinator = self.coordinator
@@ -53,7 +53,7 @@ public actor TurboFieldfareHTTPServer {
                 }
             }
             .childChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-        let channel = try await bootstrap.bind(host: "127.0.0.1", port: port).get()
+        let channel = try await bootstrap.bind(host: host, port: port).get()
         self.channel = channel
         return channel
     }

--- a/Sources/TurboFieldfareServer/Core/ServerArguments.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerArguments.swift
@@ -2,6 +2,7 @@ import Foundation
 
 public struct ServerArguments: Equatable, Sendable {
     public let model: String
+    public let host: String
     public let port: Int
     public let modelID: String
     public let maxContext: Int
@@ -12,7 +13,8 @@ public struct ServerArguments: Equatable, Sendable {
     usage: TurboFieldfareServer --model <completed .gturbo directory> [options]
 
       --model <dir>          Required model directory.
-      --port <1...65535>     Loopback port (default 8080).
+      --host <address>       Bind address (default 127.0.0.1). Use 0.0.0.0 for all interfaces.
+      --port <1...65535>     Port (default 8080).
       --model-id <id>        API model identifier (default gemma-4-26b-a4b-it).
       --max-context <tokens> 4096, 8192, 16384, 32768, or 65536 (default 16384).
       --queue-limit <count>  Maximum queued requests (default 4).
@@ -23,6 +25,7 @@ public struct ServerArguments: Equatable, Sendable {
 
     public static func parse(_ input: [String]) throws -> ServerArguments {
         var model: String?
+        var host = "127.0.0.1"
         var port = 8080
         var modelID = "gemma-4-26b-a4b-it"
         var maxContext = 16_384
@@ -40,6 +43,11 @@ public struct ServerArguments: Equatable, Sendable {
             switch flag {
             case "--model":
                 model = value
+            case "--host":
+                guard !value.isEmpty else {
+                    throw ServerArgumentError.invalid("--host must not be empty")
+                }
+                host = value
             case "--port":
                 guard let parsed = Int(value), (1...65_535).contains(parsed) else {
                     throw ServerArgumentError.invalid("--port must be between 1 and 65535")
@@ -73,6 +81,7 @@ public struct ServerArguments: Equatable, Sendable {
         }
         guard let model else { throw ServerArgumentError.invalid("--model is required") }
         return ServerArguments(model: model,
+                               host: host,
                                port: port,
                                modelID: modelID,
                                maxContext: maxContext,

--- a/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
@@ -484,10 +484,30 @@ struct StreamingStopMatcherTests {
 struct ServerArgumentTests {
     @Test func defaults() throws {
         let arguments = try ServerArguments.parse(["--model", "model.gturbo"])
+        #expect(arguments.host == "127.0.0.1")
         #expect(arguments.port == 8080)
         #expect(arguments.maxContext == 16_384)
         #expect(arguments.queueLimit == 4)
         #expect(arguments.promptCacheMode == .singlePrefix)
+    }
+
+    @Test func parsesHostAndRejectsEmpty() throws {
+        let arguments = try ServerArguments.parse([
+            "--model", "model.gturbo",
+            "--host", "0.0.0.0",
+        ])
+        #expect(arguments.host == "0.0.0.0")
+        let loopback = try ServerArguments.parse([
+            "--model", "model.gturbo",
+            "--host", "127.0.0.1",
+        ])
+        #expect(loopback.host == "127.0.0.1")
+        #expect(throws: ServerArgumentError.self) {
+            try ServerArguments.parse([
+                "--model", "model.gturbo",
+                "--host", "",
+            ])
+        }
     }
 
     @Test func parsesSinglePrefixModeAndRejectsUnknownMode() throws {

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -189,3 +189,18 @@ watch memory pressure.
 For long requests, stderr reports the request lifecycle as prepared, queued,
 generating, completed, or failed. It includes token counts and timing, but not
 prompt text, tool arguments, headers, or request bodies.
+
+## Bind to a network address
+
+`--host` sets the network address to bind (default `127.0.0.1` for localhost
+only). Use `0.0.0.0` to listen on all IPv4 interfaces.
+
+Any host other than `127.0.0.1` exposes the server beyond localhost. The server
+has no authentication or TLS. Only do this if you know what you are doing.
+
+```bash
+.build/release/TurboFieldfareServer \
+  --model scratch/gemma4.gturbo \
+  --host 0.0.0.0 \
+  --port 8080
+```


### PR DESCRIPTION
## Summary

- Add `--host` so TurboFieldfareServer can bind beyond loopback (default remains `127.0.0.1`).
- Wire the flag through argument parsing into `TurboFieldfareHTTPServer.start`.
- Document `--host` / `0.0.0.0` LAN bind in `docs/OPENAI_SERVER.md`, including the no-auth / no-TLS exposure warning.

## Tested

- [x] `swift build -c release --product TurboFieldfareServer` — pass
- [x] Start with defaults and confirm ready URL uses `127.0.0.1` — pass (`start(port:)` binds `127.0.0.1`; default `--host` parses to `127.0.0.1`)
- [x] Start with `--host 0.0.0.0` and confirm bind — pass (smoke bind + live server on `*:8080`, `/health` → `{"status":"ok"}`)
- [x] Reject empty `--host` (`--host ""` exits with usage error) — pass (exit 2, `error: --host must not be empty`)
- [x] Existing `start(port:)` server path still works (default host unchanged) — pass (loopback + `0.0.0.0` smoke via `TurboFieldfareHTTPServer`)