### PR TITLE
Introduce a model source descriptor for the installer

### DIFF
--- a/Sources/TurboFieldfareRepack/Core/Remote/ModelSourceDescriptor.swift
+++ b/Sources/TurboFieldfareRepack/Core/Remote/ModelSourceDescriptor.swift
@@ -1,0 +1,91 @@
+import Foundation
+
+/// Weight-format family of a supported checkpoint.
+///
+/// The repacker's planning, manifest schema, and install verification all
+/// depend on how a checkpoint stores its weights, not on which checkpoint it
+/// is. Today every supported source is MLX-quantized Gemma, so this enum has
+/// a single case; it exists so that a second family can be added without
+/// reworking the call sites that need to ask "which layout is this?".
+public enum ModelFamily: String, Sendable, Hashable, CaseIterable {
+    case gemma4 = "gemma4"
+}
+
+/// Pinned description of one supported upstream checkpoint.
+///
+/// Adding a model means adding one `ModelSourceDescriptor` instance and its
+/// weight-index SHA-256, validated against a fresh upload of the source.
+public struct ModelSourceDescriptor: Sendable, Hashable {
+    /// Stable identifier for this source.
+    public let key: String
+    public let family: ModelFamily
+    public let displayName: String
+    public let repoID: String
+    public let revision: String
+    public let sourceIndexSHA256: String
+    public let approximateDownloadBytes: UInt64
+    public let installedBytes: UInt64
+    public let reserveBytes: UInt64
+
+    public init(key: String,
+                family: ModelFamily,
+                displayName: String,
+                repoID: String,
+                revision: String,
+                sourceIndexSHA256: String,
+                approximateDownloadBytes: UInt64,
+                installedBytes: UInt64,
+                reserveBytes: UInt64) {
+        self.key = key
+        self.family = family
+        self.displayName = displayName
+        self.repoID = repoID
+        self.revision = revision
+        self.sourceIndexSHA256 = sourceIndexSHA256
+        self.approximateDownloadBytes = approximateDownloadBytes
+        self.installedBytes = installedBytes
+        self.reserveBytes = reserveBytes
+    }
+
+    public func installOptions(outputDirectory: URL,
+                               overwrite: Bool,
+                               token: String?,
+                               resume: Bool = false)
+        -> RemoteStreamingRepackOptions {
+        RemoteStreamingRepackOptions(
+            repoID: repoID,
+            revision: revision,
+            outputDir: outputDirectory.path,
+            token: token,
+            requireKnownSource: true,
+            minFreeReserveBytes: reserveBytes,
+            overwrite: overwrite,
+            resume: resume)
+    }
+}
+
+public extension SupportedModelSource {
+    /// Gemma 4 26B-A4B IT 4-bit (MLX community re-pack).
+    static let gemma4 = ModelSourceDescriptor(
+        key: "gemma4",
+        family: .gemma4,
+        displayName: "Gemma 4 26B-A4B IT 4-bit",
+        repoID: "mlx-community/gemma-4-26b-a4b-it-4bit",
+        revision: "0d77464eeb233a2da68ebf9d7dc4edaac7db956d",
+        sourceIndexSHA256:
+            "bf198c9f5ea6462addca1966e5dd669c407537a876e82cf06db9084c5c850b13",
+        approximateDownloadBytes: 14_620_479_420,
+        installedBytes: 14_291_921_884,
+        reserveBytes: 1_073_741_824)
+
+    /// Every checkpoint this build can install.
+    static let all: [ModelSourceDescriptor] = [gemma4]
+
+    /// The checkpoint installed when no source is specified.
+    static let `default` = gemma4
+
+    /// Look up a descriptor by its `key`, or nil when unknown.
+    static func descriptor(forKey key: String) -> ModelSourceDescriptor? {
+        all.first { $0.key == key }
+    }
+}

--- a/Sources/TurboFieldfareRepack/Core/Remote/SupportedModelSource.swift
+++ b/Sources/TurboFieldfareRepack/Core/Remote/SupportedModelSource.swift
@@ -1,28 +1,29 @@
 import Foundation
 
+/// Convenience accessors for the default source.
+///
+/// These forward to `SupportedModelSource.default`; the descriptors in
+/// `ModelSourceDescriptor.swift` are the source of truth. Prefer
+/// `SupportedModelSource.descriptor(forKey:)` or a concrete descriptor in
+/// new code.
 public enum SupportedModelSource {
-    public static let displayName = "Gemma 4 26B-A4B IT 4-bit"
-    public static let repoID = "mlx-community/gemma-4-26b-a4b-it-4bit"
-    public static let revision = "0d77464eeb233a2da68ebf9d7dc4edaac7db956d"
-    public static let sourceIndexSHA256 =
-        "bf198c9f5ea6462addca1966e5dd669c407537a876e82cf06db9084c5c850b13"
-    public static let approximateDownloadBytes: UInt64 = 14_620_479_420
-    public static let installedBytes: UInt64 = 14_291_921_884
-    public static let reserveBytes: UInt64 = 1_073_741_824
+    public static let displayName = SupportedModelSource.default.displayName
+    public static let repoID = SupportedModelSource.default.repoID
+    public static let revision = SupportedModelSource.default.revision
+    public static let sourceIndexSHA256 = SupportedModelSource.default.sourceIndexSHA256
+    public static let approximateDownloadBytes =
+        SupportedModelSource.default.approximateDownloadBytes
+    public static let installedBytes = SupportedModelSource.default.installedBytes
+    public static let reserveBytes = SupportedModelSource.default.reserveBytes
 
     public static func installOptions(outputDirectory: URL,
                                       overwrite: Bool,
                                       token: String?,
                                       resume: Bool = false)
         -> RemoteStreamingRepackOptions {
-        RemoteStreamingRepackOptions(
-            repoID: repoID,
-            revision: revision,
-            outputDir: outputDirectory.path,
-            token: token,
-            requireKnownSource: true,
-            minFreeReserveBytes: reserveBytes,
-            overwrite: overwrite,
-            resume: resume)
+        SupportedModelSource.default.installOptions(outputDirectory: outputDirectory,
+                                                    overwrite: overwrite,
+                                                    token: token,
+                                                    resume: resume)
     }
 }

--- a/Sources/TurboFieldfareRepack/Core/Verification/SourceFingerprint.swift
+++ b/Sources/TurboFieldfareRepack/Core/Verification/SourceFingerprint.swift
@@ -3,9 +3,12 @@ import Foundation
 /// Snapshot fingerprints pinned by the project. Adding a new entry means the
 /// importer has been validated against a fresh upload of the source.
 public enum SourceFingerprint {
-    public static let knownFingerprints: [String: String] = [
-        SupportedModelSource.repoID: SupportedModelSource.sourceIndexSHA256,
-    ]
+    /// Derived from `SupportedModelSource.all`, so a new descriptor is
+    /// recognised here without a second edit.
+    public static let knownFingerprints: [String: String] = Dictionary(
+        uniqueKeysWithValues: SupportedModelSource.all.map {
+            ($0.repoID, $0.sourceIndexSHA256)
+        })
 
     /// Returns the recognised model ID for a given index.json SHA-256, or nil.
     public static func modelID(forIndexSha256 sha256Hex: String) -> String? {

--- a/Tests/TurboFieldfareRepack/Core/Remote/ModelSourceDescriptorTests.swift
+++ b/Tests/TurboFieldfareRepack/Core/Remote/ModelSourceDescriptorTests.swift
@@ -1,0 +1,107 @@
+import Foundation
+import Testing
+
+@testable import TurboFieldfareRepackCore
+
+@Suite
+struct ModelSourceDescriptorTests {
+    /// The legacy `SupportedModelSource` constants are part of the installer's
+    /// public surface. They must keep resolving to the default descriptor.
+    @Test func legacyAccessorsMatchDefaultDescriptor() {
+        let expected = SupportedModelSource.default
+
+        #expect(SupportedModelSource.displayName == expected.displayName)
+        #expect(SupportedModelSource.repoID == expected.repoID)
+        #expect(SupportedModelSource.revision == expected.revision)
+        #expect(SupportedModelSource.sourceIndexSHA256 == expected.sourceIndexSHA256)
+        #expect(SupportedModelSource.approximateDownloadBytes == expected.approximateDownloadBytes)
+        #expect(SupportedModelSource.installedBytes == expected.installedBytes)
+        #expect(SupportedModelSource.reserveBytes == expected.reserveBytes)
+    }
+
+    /// The pinned Gemma values are a compatibility contract: a changed repo,
+    /// revision, or index digest silently redirects every install.
+    @Test func gemmaDescriptorKeepsPinnedIdentity() {
+        let gemma = SupportedModelSource.gemma4
+
+        #expect(gemma.key == "gemma4")
+        #expect(gemma.family == .gemma4)
+        #expect(gemma.displayName == "Gemma 4 26B-A4B IT 4-bit")
+        #expect(gemma.repoID == "mlx-community/gemma-4-26b-a4b-it-4bit")
+        #expect(gemma.revision == "0d77464eeb233a2da68ebf9d7dc4edaac7db956d")
+        #expect(gemma.sourceIndexSHA256 ==
+                "bf198c9f5ea6462addca1966e5dd669c407537a876e82cf06db9084c5c850b13")
+        #expect(SupportedModelSource.default == gemma)
+    }
+
+    @Test func descriptorLookupResolvesKnownKeysOnly() {
+        #expect(SupportedModelSource.descriptor(forKey: "gemma4") == SupportedModelSource.gemma4)
+        #expect(SupportedModelSource.descriptor(forKey: "nonexistent") == nil)
+        #expect(SupportedModelSource.descriptor(forKey: "") == nil)
+    }
+
+    @Test func descriptorKeysAreUnique() {
+        let keys = SupportedModelSource.all.map(\.key)
+        #expect(Set(keys).count == keys.count)
+    }
+
+    /// `knownFingerprints` is derived with `uniqueKeysWithValues`, which traps
+    /// on a duplicate repo ID. Keep that failure in the suite, not an install.
+    @Test func descriptorRepoIDsAreUnique() {
+        let repoIDs = SupportedModelSource.all.map(\.repoID)
+        #expect(Set(repoIDs).count == repoIDs.count)
+    }
+
+    @Test func everyDescriptorIsRecognisedByFingerprint() {
+        for descriptor in SupportedModelSource.all {
+            #expect(SourceFingerprint.knownFingerprints[descriptor.repoID] ==
+                    descriptor.sourceIndexSHA256)
+            #expect(SourceFingerprint.modelID(forIndexSha256: descriptor.sourceIndexSHA256) ==
+                    descriptor.repoID)
+        }
+        #expect(SourceFingerprint.knownFingerprints.count == SupportedModelSource.all.count)
+    }
+
+    @Test func installOptionsCarryDescriptorPinning() {
+        let descriptor = SupportedModelSource.gemma4
+        let directory = URL(fileURLWithPath: "/tmp/turbo-fieldfare-descriptor-test")
+
+        let options = descriptor.installOptions(outputDirectory: directory,
+                                                overwrite: true,
+                                                token: nil,
+                                                resume: true)
+
+        #expect(options.repoID == descriptor.repoID)
+        #expect(options.revision == descriptor.revision)
+        #expect(options.outputDir == directory.path)
+        #expect(options.minFreeReserveBytes == descriptor.reserveBytes)
+        #expect(options.requireKnownSource)
+        #expect(options.overwrite)
+        #expect(options.resume)
+    }
+
+    /// The legacy entry point must stay behaviourally identical to the
+    /// descriptor call it now forwards to.
+    @Test func legacyInstallOptionsMatchDescriptorInstallOptions() {
+        let directory = URL(fileURLWithPath: "/tmp/turbo-fieldfare-descriptor-parity")
+
+        let legacy = SupportedModelSource.installOptions(outputDirectory: directory,
+                                                         overwrite: false,
+                                                         token: "token",
+                                                         resume: false)
+        let viaDescriptor = SupportedModelSource.default.installOptions(
+            outputDirectory: directory,
+            overwrite: false,
+            token: "token",
+            resume: false)
+
+        #expect(legacy.repoID == viaDescriptor.repoID)
+        #expect(legacy.revision == viaDescriptor.revision)
+        #expect(legacy.outputDir == viaDescriptor.outputDir)
+        #expect(legacy.token == viaDescriptor.token)
+        #expect(legacy.minFreeReserveBytes == viaDescriptor.minFreeReserveBytes)
+        #expect(legacy.requireKnownSource == viaDescriptor.requireKnownSource)
+        #expect(legacy.overwrite == viaDescriptor.overwrite)
+        #expect(legacy.resume == viaDescriptor.resume)
+    }
+}


### PR DESCRIPTION
## What

Collects the installer's pinned model values into a `ModelSourceDescriptor`
value type keyed by a `ModelFamily`, and registers the existing Gemma 4 pin as
the sole entry in `SupportedModelSource.all`.

## Why

The supported source was a set of standalone static constants, so every pinned
value (repo, revision, index digest, size estimates) was addressable only as a
global. That works well for one model, but it means a second model has to
either mutate those globals or thread a parallel set of constants through the
call sites.

Separately, `SourceFingerprint.knownFingerprints` restated the Gemma index
digest as its own literal. Two copies of a value whose whole purpose is to
detect drift is a hazard, so the table now derives from the registry.

## Behaviour

Unchanged. The legacy statics (`SupportedModelSource.repoID`, `.revision`,
`.sourceIndexSHA256`, `.installOptions(...)`, etc.) remain and are thin shims
over `SupportedModelSource.default`, so existing callers and the CLI resolve
exactly the same values. This PR adds no user-visible flag or model choice.

## Tests

New `ModelSourceDescriptorTests` covers:

- shim/descriptor parity, including `installOptions` field-by-field
- the pinned Gemma identity (repo, revision, index digest), so a silent
  re-pin fails in CI rather than at install time
- registry key and repo-ID uniqueness — `knownFingerprints` is built with
  `uniqueKeysWithValues`, which traps on a duplicate repo ID, and this keeps
  that failure in the suite
- fingerprint coverage and round-trip for every registered source

Full suite: 575 tests in 113 suites passing, `swift build -c release` clean.
Branch is one commit on top of `7a99f2a`.

## Context

This is the first of a few narrow PRs factored out of experimental multi-model
work discussed in #44. It is deliberately scoped to the descriptor seam and
stays Gemma-only: the repack planner is still single-family, so registering a
second descriptor here would expose a model choice the planner cannot yet
honour. Happy to adjust naming or drop the legacy shims if you would rather
migrate the call sites outright.
