### PR TITLE
Fall back to a direct process spawn when launchd never runs the decode service

### DIFF
--- a/Sources/TurboFieldfareApp/Core/Inference/DecodeServiceInferenceClient.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/DecodeServiceInferenceClient.swift
@@ -12,6 +12,7 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
         var loadedDirectory: URL?
         var launchLabel: String?
         var socketPath: String?
+        var directProcess: Process?
     }
 
     private let connection = Mutex(Connection())
@@ -173,6 +174,7 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
             try? input.close()
         }
         if let label = state.launchLabel { Self.removeLaunchJob(label: label) }
+        state.directProcess?.terminate()
         if let socketPath = state.socketPath { unlink(socketPath) }
     }
 
@@ -191,6 +193,48 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
         let identifier = "\(getuid()).\(getpid()).\(UUID().uuidString.lowercased())"
         let label = "com.turbofieldfare.decode.\(identifier)"
         let socketPath = "/private/tmp/turbofieldfare-decode-\(identifier).sock"
+
+        if (try? bootstrapViaLaunchd(label: label, socketPath: socketPath)) != nil,
+           let handles = try? connectSocketWithRetry(socketPath: socketPath, attempts: 100) {
+            connection.withLock {
+                $0.input = handles.input
+                $0.responses = handles.responses
+                $0.launchLabel = label
+                $0.socketPath = socketPath
+            }
+            return handles
+        }
+
+        // Some sessions (e.g. terminal multiplexers that spawn the app
+        // outside a normal Aqua-attached process) have launchd accept the
+        // "gui/<uid>" bootstrap but never actually spawn the RunAtLoad job.
+        // Cancel that registration and fall back to a plain child process on
+        // the same socket path so the app still works there.
+        Self.removeLaunchJob(label: label)
+        let process: Process
+        do {
+            process = try launchDirectProcess(socketPath: socketPath, label: label)
+        } catch {
+            throw AppInferenceError.modelLoadFailed(
+                "decode service could not be started: \(error)")
+        }
+        do {
+            let handles = try connectSocketWithRetry(socketPath: socketPath, attempts: 200)
+            connection.withLock {
+                $0.input = handles.input
+                $0.responses = handles.responses
+                $0.directProcess = process
+                $0.socketPath = socketPath
+            }
+            return handles
+        } catch {
+            process.terminate()
+            throw AppInferenceError.modelLoadFailed(
+                "decode service socket did not become ready: \(error)")
+        }
+    }
+
+    private func bootstrapViaLaunchd(label: String, socketPath: String) throws {
         let propertyListURL = URL(
             fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
             .appendingPathComponent("\(label).plist")
@@ -228,27 +272,32 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
                 ?? "launchd could not start the decode service"
             throw AppInferenceError.modelLoadFailed(message)
         }
+    }
 
+    private func launchDirectProcess(socketPath: String, label: String) throws -> Process {
+        let process = Process()
+        process.executableURL = serviceURL
+        process.arguments = ["--socket", socketPath, "--launch-label", label]
+        process.standardOutput = FileHandle.nullDevice
+        process.standardError = FileHandle.nullDevice
+        try process.run()
+        return process
+    }
+
+    private func connectSocketWithRetry(socketPath: String, attempts: Int) throws
+        -> (input: FileHandle, responses: DecodeServiceResponseRouter) {
         var lastError: Error?
-        for _ in 0..<200 {
+        for _ in 0..<attempts {
             do {
                 let handles = try DecodeUnixSocket.connect(path: socketPath)
                 let responses = DecodeServiceResponseRouter(output: handles.output)
-                connection.withLock {
-                    $0.input = handles.input
-                    $0.responses = responses
-                    $0.launchLabel = label
-                    $0.socketPath = socketPath
-                }
                 return (handles.input, responses)
             } catch {
                 lastError = error
                 usleep(10_000)
             }
         }
-        Self.removeLaunchJob(label: label)
-        throw AppInferenceError.modelLoadFailed(
-            "decode service socket did not become ready: \(lastError.map(String.init(describing:)) ?? "unknown error")")
+        throw lastError ?? AppInferenceError.modelLoadFailed("unknown error")
     }
 
     private func currentHandles()


### PR DESCRIPTION
## Summary

`DecodeServiceInferenceClient` starts `TurboFieldfareDecodeService` by writing
a `launchd` plist and running `launchctl bootstrap gui/<uid>`, then polls a
Unix socket for up to 2 seconds. In some sessions I hit a case where that
`bootstrap` call reports success and the job registers, but launchd never
actually spawns it — `launchctl print` on the job kept showing
`runs = 0` / `pended nondemand spawn = speculative` indefinitely, even for an
unrelated trivial binary bootstrapped the same way. This reproduced when the
app was launched from a terminal-multiplexer session rather than a shell
attached to the normal Aqua login-window session. The socket file never
appears, and the load fails with:

```
Model load failed: decode service socket did not become ready: Error Domain=NSPOSIXErrorDomain Code=2 "No such file or directory"
```

A plain fork/exec of the same binary (no launchd involved) creates the socket
immediately, so the helper process itself is fine — only the launchd-spawn
path is affected.

## Fix

- Keep the existing `launchctl bootstrap` attempt first, so a normal desktop
  session keeps the `ProcessType: Interactive` jetsam-priority benefit.
- If the socket doesn't come up (bootstrap failure, or launchd accepting but
  never spawning the job), cancel the stale launchd registration and fall
  back to launching the same binary as a plain `Process()` child on the same
  socket path.
- Track the fallback `Process` in connection state so `deinit` terminates it
  directly, alongside the existing `launchctl bootout` cleanup for the
  launchd path.

No behavior changes for the normal path; this only adds a fallback for the
case where launchd currently leaves the app unusable.

## Test plan

- [x] `swift build -c release --product TurboFieldfareMac` succeeds
- [x] Reproduced the original failure (`launchctl bootstrap` accepted, socket
  never created — reproduced even with `/usr/bin/touch` as the RunAtLoad
  program, ruling out anything specific to this binary) and confirmed the
  fallback path lets the app load and generate normally in that session
- [ ] Would appreciate a check on a normal (non-multiplexed) session to
  confirm the launchd-first path is unaffected