### PR TITLE
Render LaTeX math visually in Mac app responses

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", exact: "2.99.0"),
+        .package(url: "https://github.com/mgriebling/SwiftMath.git", from: "1.7.3"),
     ],
     targets: [
         .target(
@@ -60,7 +61,10 @@ let package = Package(
         ),
         .target(
             name: "TurboFieldfareMacPresentation",
-            dependencies: ["TurboFieldfareAppCore"],
+            dependencies: [
+                "TurboFieldfareAppCore",
+                .product(name: "SwiftMath", package: "SwiftMath"),
+            ],
             path: "Sources/TurboFieldfareApp/MacPresentation"
         ),
         .target(

--- a/Sources/TurboFieldfareApp/MacPresentation/MathExpressionScanner.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/MathExpressionScanner.swift
@@ -1,0 +1,163 @@
+import Foundation
+
+public struct MathExpression: Equatable {
+    public let latex: String
+    public let isDisplay: Bool
+    public let range: Range<String.Index>
+
+    public init(latex: String, isDisplay: Bool, range: Range<String.Index>) {
+        self.latex = latex
+        self.isDisplay = isDisplay
+        self.range = range
+    }
+}
+
+public enum MathExpressionScanner {
+    public static func scan(_ source: String) -> [MathExpression] {
+        var expressions: [MathExpression] = []
+        var index = source.startIndex
+        while index < source.endIndex {
+            guard source[index] == "$", !isEscaped(source, at: index) else {
+                index = source.index(after: index)
+                continue
+            }
+
+            let isDisplay = isDoubleDollar(at: index, in: source)
+            let contentStart = isDisplay
+                ? source.index(index, offsetBy: 2, limitedBy: source.endIndex)
+                    ?? source.endIndex
+                : source.index(after: index)
+
+            if !isDisplay, !isInlineDelimiter(at: index, in: source) {
+                index = source.index(after: index)
+                continue
+            }
+
+            guard let closing = closingDelimiter(
+                in: source,
+                from: contentStart,
+                display: isDisplay),
+                contentStart < closing,
+                let content = validContent(
+                    in: source,
+                    from: contentStart,
+                    to: closing,
+                    display: isDisplay) else {
+                index = source.index(after: index)
+                continue
+            }
+
+            let upperBound = source.index(
+                closing,
+                offsetBy: isDisplay ? 2 : 1,
+                limitedBy: source.endIndex) ?? source.endIndex
+            expressions.append(MathExpression(
+                latex: content,
+                isDisplay: isDisplay,
+                range: index..<upperBound))
+            index = upperBound
+        }
+        return expressions
+    }
+
+    private static func isDoubleDollar(at index: String.Index, in source: String) -> Bool {
+        guard let next = source.index(index, offsetBy: 1, limitedBy: source.endIndex),
+              next < source.endIndex else { return false }
+        return source[next] == "$"
+    }
+
+    private static func isInlineDelimiter(at index: String.Index, in source: String) -> Bool {
+        let next = source.index(after: index)
+        guard next < source.endIndex else { return false }
+        let nextCharacter = source[next]
+        if nextCharacter == "$" || nextCharacter == " " || nextCharacter.isNumber {
+            return false
+        }
+        if index > source.startIndex {
+            let previous = source[source.index(before: index)]
+            if previous.isLetter || previous.isNumber {
+                return false
+            }
+        }
+        return true
+    }
+
+    private static func closingDelimiter(
+        in source: String,
+        from start: String.Index,
+        display: Bool
+    ) -> String.Index? {
+        var index = start
+        while index < source.endIndex {
+            if source[index] == "$", !isEscaped(source, at: index) {
+                if display {
+                    if let next = source.index(index, offsetBy: 1, limitedBy: source.endIndex),
+                       next < source.endIndex, source[next] == "$" {
+                        return index
+                    }
+                } else {
+                    let next = source.index(after: index)
+                    if !(next < source.endIndex && source[next].isNumber) {
+                        return index
+                    }
+                }
+            }
+            index = source.index(after: index)
+        }
+        return nil
+    }
+
+    private static func validContent(
+        in source: String,
+        from start: String.Index,
+        to end: String.Index,
+        display: Bool
+    ) -> String? {
+        let content = String(source[start..<end])
+        if display {
+            if content.isEmpty || content.contains("\n\n") { return nil }
+        } else if content.isEmpty || content.contains("\n") {
+            return nil
+        }
+        guard bracesAreBalanced(content) else { return nil }
+        guard looksLikeMath(content) else { return nil }
+        return content
+    }
+
+    private static func bracesAreBalanced(_ content: String) -> Bool {
+        var depth = 0
+        var escaped = false
+        for character in content {
+            if escaped {
+                escaped = false
+            } else if character == "\\" {
+                escaped = true
+            } else if character == "{" {
+                depth += 1
+            } else if character == "}" {
+                depth -= 1
+                if depth < 0 { return false }
+            }
+        }
+        return depth == 0
+    }
+
+    private static func looksLikeMath(_ content: String) -> Bool {
+        let trimmed = content.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else { return false }
+        let hasSymbol = trimmed.unicodeScalars.contains { scalar in
+            if scalar == "\\" { return true }
+            let isLetter = CharacterSet.letters.contains(scalar)
+            let isDigit = CharacterSet.decimalDigits.contains(scalar)
+            let isWhitespace = CharacterSet.whitespacesAndNewlines.contains(scalar)
+            return !isLetter && !isDigit && !isWhitespace
+        }
+        if hasSymbol { return true }
+        return trimmed.count <= 2
+    }
+
+    private static func isEscaped(_ source: String, at index: String.Index) -> Bool {
+        guard index > source.startIndex else { return false }
+        return source[source.index(before: index)] == "\\"
+    }
+}

--- a/Sources/TurboFieldfareApp/MacPresentation/MathImageRenderer.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/MathImageRenderer.swift
@@ -1,0 +1,85 @@
+import AppKit
+import SwiftMath
+
+@MainActor
+public enum MathImageRenderer {
+    private static var cache: [CacheKey: NSImage] = [:]
+    private static var cacheOrder: [CacheKey] = []
+    private static let cacheLimit = 256
+
+    private struct CacheKey: Hashable {
+        let latex: String
+        let isDisplay: Bool
+        let fontSize: CGFloat
+        let appearanceName: String
+    }
+
+    public static func attachment(
+        latex: String,
+        isDisplay: Bool,
+        fontSize: CGFloat,
+        rawSource: String
+    ) -> MathTextAttachment? {
+        let appearanceName = NSApp?.effectiveAppearance.name.rawValue ?? "unknown"
+        let key = CacheKey(
+            latex: latex,
+            isDisplay: isDisplay,
+            fontSize: fontSize,
+            appearanceName: appearanceName)
+        let image: NSImage?
+        if let cached = cache[key] {
+            image = cached
+        } else if let rendered = render(latex: latex, isDisplay: isDisplay, fontSize: fontSize) {
+            cache[key] = rendered
+            cacheOrder.append(key)
+            if cacheOrder.count > cacheLimit {
+                let removed = cacheOrder.removeFirst()
+                cache.removeValue(forKey: removed)
+            }
+            image = rendered
+        } else {
+            image = nil
+        }
+        guard let image else { return nil }
+        return makeAttachment(
+            image: image,
+            isDisplay: isDisplay,
+            fontSize: fontSize,
+            rawSource: rawSource)
+    }
+
+    private static func makeAttachment(
+        image: NSImage,
+        isDisplay: Bool,
+        fontSize: CGFloat,
+        rawSource: String
+    ) -> MathTextAttachment? {
+        let size = image.size
+        guard size.width > 0, size.height > 0 else { return nil }
+        let baselineOffset = isDisplay ? 0 : -round(fontSize * 0.22)
+        let bounds = CGRect(x: 0, y: baselineOffset, width: size.width, height: size.height)
+        return MathTextAttachment(
+            image: image,
+            bounds: bounds,
+            latexSource: rawSource,
+            isDisplay: isDisplay)
+    }
+
+    private static func render(
+        latex: String,
+        isDisplay: Bool,
+        fontSize: CGFloat
+    ) -> NSImage? {
+        let appearance = NSApp?.effectiveAppearance ?? .current
+        let color = NSColor.labelColor.resolvedColor(with: appearance)
+        let mode: MTMathUILabelMode = isDisplay ? .display : .text
+        let mathImage = MTMathImage(
+            latex: latex,
+            fontSize: fontSize,
+            textColor: color,
+            labelMode: mode,
+            textAlignment: .center)
+        let (_, image) = mathImage.asImage()
+        return image
+    }
+}

--- a/Sources/TurboFieldfareApp/MacPresentation/MathTextAttachment.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/MathTextAttachment.swift
@@ -1,0 +1,20 @@
+import AppKit
+
+public final class MathTextAttachment: NSTextAttachment {
+    public let latexSource: String
+    public let isDisplay: Bool
+
+    public init(image: NSImage, bounds: CGRect, latexSource: String, isDisplay: Bool) {
+        self.latexSource = latexSource
+        self.isDisplay = isDisplay
+        super.init(data: nil, ofType: nil)
+        self.image = image
+        self.bounds = bounds
+    }
+
+    public required init?(coder: NSCoder) {
+        self.latexSource = ""
+        self.isDisplay = false
+        super.init(coder: coder)
+    }
+}

--- a/Sources/TurboFieldfareApp/MacPresentation/ResponseMarkdownRenderer.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/ResponseMarkdownRenderer.swift
@@ -77,12 +77,16 @@ public struct ResponseMarkdownRenderer {
                 guard block.kind != .thematicBreak else { continue }
                 let text = String(parsed[run.range].characters)
                 guard !text.isEmpty else { continue }
-                output.append(NSAttributedString(
-                    string: text,
-                    attributes: attributes(
-                        inlineIntent: run.inlinePresentationIntent,
-                        link: run.link,
-                        block: block.kind)))
+                let attrs = attributes(
+                    inlineIntent: run.inlinePresentationIntent,
+                    link: run.link,
+                    block: block.kind)
+                if block.kind == .code
+                    || run.inlinePresentationIntent?.contains(.code) == true {
+                    output.append(NSAttributedString(string: text, attributes: attrs))
+                } else {
+                    appendRenderedText(text, attributes: attrs, to: output)
+                }
             }
 
             guard output.length > 0 else { return fallback(source) }
@@ -93,7 +97,18 @@ public struct ResponseMarkdownRenderer {
     }
 
     public func plainText(_ source: String) -> String {
-        render(source).attributedString.string
+        let rendered = render(source).attributedString
+        let plain = NSMutableString()
+        rendered.enumerateAttributes(
+            in: NSRange(location: 0, length: rendered.length),
+            options: []) { attributes, range, _ in
+            if let attachment = attributes[.attachment] as? MathTextAttachment {
+                plain.append(attachment.latexSource)
+            } else {
+                plain.append((rendered.string as NSString).substring(with: range))
+            }
+        }
+        return plain as String
     }
 
     private func requiresRawFallback(_ source: String) -> Bool {
@@ -305,6 +320,99 @@ public struct ResponseMarkdownRenderer {
             break
         }
         return style
+    }
+
+    private func appendRenderedText(
+        _ text: String,
+        attributes attrs: [NSAttributedString.Key: Any],
+        to output: NSMutableAttributedString
+    ) {
+        let expressions = MathExpressionScanner.scan(text)
+        guard !expressions.isEmpty else {
+            output.append(NSAttributedString(string: text, attributes: attrs))
+            return
+        }
+        let inlineFontSize = (attrs[.font] as? NSFont)?.pointSize
+            ?? NSFont.systemFontSize
+        var cursor = text.startIndex
+        var trailingWasDisplay = false
+        for expression in expressions {
+            if cursor < expression.range.lowerBound {
+                appendSegment(
+                    text[cursor..<expression.range.lowerBound],
+                    attributes: attrs,
+                    collapseLeadingNewline: trailingWasDisplay,
+                    to: output)
+            }
+            let rawSource = String(text[expression.range])
+            if let attachment = MathImageRenderer.attachment(
+                latex: expression.latex,
+                isDisplay: expression.isDisplay,
+                fontSize: expression.isDisplay
+                    ? NSFont.systemFontSize + 2
+                    : inlineFontSize,
+                rawSource: rawSource) {
+                appendAttachment(
+                    attachment,
+                    isDisplay: expression.isDisplay,
+                    attributes: attrs,
+                    to: output)
+            } else {
+                output.append(NSAttributedString(string: rawSource, attributes: attrs))
+            }
+            trailingWasDisplay = expression.isDisplay
+            cursor = expression.range.upperBound
+        }
+        if cursor < text.endIndex {
+            appendSegment(
+                text[cursor...],
+                attributes: attrs,
+                collapseLeadingNewline: trailingWasDisplay,
+                to: output)
+        }
+    }
+
+    private func appendSegment(
+        _ substring: Substring,
+        attributes attrs: [NSAttributedString.Key: Any],
+        collapseLeadingNewline: Bool,
+        to output: NSMutableAttributedString
+    ) {
+        var string = String(substring)
+        if collapseLeadingNewline, output.string.last == "\n", string.first == "\n" {
+            string.removeFirst()
+        }
+        guard !string.isEmpty else { return }
+        output.append(NSAttributedString(string: string, attributes: attrs))
+    }
+
+    private func appendAttachment(
+        _ attachment: MathTextAttachment,
+        isDisplay: Bool,
+        attributes attrs: [NSAttributedString.Key: Any],
+        to output: NSMutableAttributedString
+    ) {
+        var attachmentAttributes = attrs
+        if isDisplay {
+            if !output.string.isEmpty, output.string.last != "\n" {
+                output.append(NSAttributedString(string: "\n", attributes: baseAttributes()))
+            }
+            let style = ((attrs[.paragraphStyle] as? NSParagraphStyle)
+                ?? NSParagraphStyle.default).mutableCopy() as! NSMutableParagraphStyle
+            style.alignment = .center
+            attachmentAttributes[.paragraphStyle] = style
+        }
+        let attributedAttachment = NSMutableAttributedString(
+            string: "\u{FFFC}",
+            attributes: attachmentAttributes)
+        attributedAttachment.addAttribute(
+            .attachment,
+            value: attachment,
+            range: NSRange(location: 0, length: attributedAttachment.length))
+        output.append(attributedAttachment)
+        if isDisplay {
+            output.append(NSAttributedString(string: "\n", attributes: baseAttributes()))
+        }
     }
 
     private func fallback(_ source: String) -> Result {

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -43,6 +43,11 @@ The following table covers the complete graph reported by
 | [swift-crypto](https://github.com/apple/swift-crypto) | 4.5.0 | Apache-2.0; upstream NOTICE applies |
 | [swift-asn1](https://github.com/apple/swift-asn1) | 1.7.0 | Apache-2.0; upstream NOTICE applies |
 | [yyjson](https://github.com/ibireme/yyjson) | 0.12.0 | MIT |
+| [SwiftMath](https://github.com/mgriebling/SwiftMath) | 1.7.3 (pending) | MIT |
+
+`Package.resolved` in this checkout predates the SwiftMath addition (macOS math
+rendering); regenerate it with `swift package resolve` on macOS and re-run the
+review before release.
 
 No copyleft or custom non-commercial license was found in this resolved graph.
 The dependency license files remain authoritative. For binary distribution,

--- a/Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift
+++ b/Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift
@@ -83,13 +83,101 @@ import Testing
         }
     }
 
-    @Test func latexRemainsReadableText() {
+    @Test func inlineMathRendersAsVisualAttachment() {
         let source = "Cosine is $\\frac{u \\cdot v}{||u|| ||v||}$."
         let result = ResponseMarkdownRenderer().render(source)
 
         #expect(!result.usedFallback)
-        #expect(result.attributedString.string.contains("\\frac"))
-        #expect(result.attributedString.string.contains("\\cdot"))
+        #expect(result.attributedString.string.contains("Cosine is"))
+        #expect(!result.attributedString.string.contains("\\frac"))
+        let attachments = mathAttachments(in: result.attributedString)
+        #expect(attachments.count == 1)
+        #expect(attachments[0].isDisplay == false)
+        #expect(attachments[0].latexSource == "$\\frac{u \\cdot v}{||u|| ||v||}$")
+    }
+
+    @Test func displayMathRendersAsCenteredAttachment() {
+        let source = "$$x = \\frac{-b \\pm \\sqrt{b^2 - 4ac}}{2a}$$"
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        let attachments = mathAttachments(in: result.attributedString)
+        #expect(attachments.count == 1)
+        #expect(attachments[0].isDisplay == true)
+    }
+
+    @Test func malformedMathFallsBackToRawText() {
+        let source = "The ratio $\\frac{1}{$ is undefined."
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        #expect(result.attributedString.string.contains("$\\frac{1}{$"))
+        #expect(mathAttachments(in: result.attributedString).isEmpty)
+    }
+
+    @Test func currencyAmountsStayAsText() {
+        let source = "It costs $5 and $10."
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        #expect(result.attributedString.string == source)
+        #expect(mathAttachments(in: result.attributedString).isEmpty)
+    }
+
+    @Test func mathInsideCodeBlockStaysRaw() {
+        let source = "```\n$\\frac{1}{2}$\n```"
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        #expect(result.attributedString.string.contains("$\\frac{1}{2}$"))
+        #expect(mathAttachments(in: result.attributedString).isEmpty)
+    }
+
+    @Test func sourceEndingWithUnmatchedDollarDoesNotCrash() {
+        let source = "The value is $"
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        #expect(result.attributedString.string.contains("$"))
+        #expect(mathAttachments(in: result.attributedString).isEmpty)
+    }
+
+    @Test func multipleInlineExpressionsRenderSeparately() {
+        let source = "Let $a = 1$ and $b = 2$."
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        #expect(mathAttachments(in: result.attributedString).count == 2)
+    }
+
+    @Test func singleLetterInlineMathRenders() {
+        let source = "Let $x$ be positive."
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        #expect(mathAttachments(in: result.attributedString).count == 1)
+    }
+
+    @Test func plainTextPreservesLatexSource() {
+        let renderer = ResponseMarkdownRenderer()
+        let source = "Area is $\\pi r^2$ and $$\\int_0^1 x\\,dx$$."
+        let plain = renderer.plainText(source)
+
+        #expect(plain.contains("$\\pi r^2$"))
+        #expect(plain.contains("$$\\int_0^1 x\\,dx$$"))
+    }
+
+    private func mathAttachments(in string: NSAttributedString) -> [MathTextAttachment] {
+        var found: [MathTextAttachment] = []
+        string.enumerateAttribute(
+            .attachment,
+            in: NSRange(location: 0, length: string.length),
+            options: []) { value, _, _ in
+            if let attachment = value as? MathTextAttachment {
+                found.append(attachment)
+            }
+        }
+        return found
     }
 
     @Test func boldOnlyModelHeadingStaysOnItsOwnLine() {


### PR DESCRIPTION
# Render LaTeX Math Visually in Mac App Responses

## Why
Math-heavy model responses previously showed as raw LaTeX source ( `$x = \frac{-b \pm \sqrt{b^2 - 4ac}}{2a}$` ), forcing users to copy output into an external tool to understand it.

## What Changed
The Mac app now typesets `$…$` (inline) and `$$…$$` (display) math natively with SwiftMath and embeds the rendered formula directly in the transcript, exactly like the Obsidian latex-math plugin. Inline formulas sit baseline-aligned in the text; display formulas appear centered on their own line. Raw LaTeX is still preserved — "Copy response" keeps the original source, and it remains usable in LaTeX-compatible programs.

## How It Works
- New `MathExpressionScanner` — conservative `$…$` / `$$…$$` parser that skips code blocks, currency amounts ( `$5` ), escaped dollars, and unbalanced braces, falling back to raw text for anything that isn't clearly math.
- New `MathImageRenderer` — `@MainActor` SwiftMath rasterizer (CoreText-based, no WebView) with a bounded 256-entry LRU cache; renders with the current light/dark appearance.
- New `MathTextAttachment` — `NSTextAttachment` subclass carrying the image plus the original delimited LaTeX source.
- `ResponseMarkdownRenderer` — math-aware run appending (code blocks stay raw; display math gets a centered line); `plainText()` reconstructs the original LaTeX so plain-text consumers stay lossless.
- Added SwiftMath 1.7.3 dependency (MIT) to `Package.swift` and noted it in `THIRD_PARTY_NOTICES.md`.

## Details
- Fits the existing native AppKit pipeline ( `NSTextView` ) — streaming, scrolling, selection, and copy are untouched.
- Rendering runs once when a response finishes; streaming shows raw text until then.
- `Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift` : 9 new/updated cases (inline, display, malformed fallback, currency, code fences, trailing- `$` crash guard, multiple formulas, single-letter math, `plainText` fidelity).

## Files Changed
Commit `32c4a6d`: 7 files, +484/−11 — `Package.swift` , `THIRD_PARTY_NOTICES.md` , `ResponseMarkdownRenderer.swift` (+3 new source files), `ResponseMarkdownRendererTests.swift`.

## Notes
- Known limitations: formulas rasterized before a light/dark switch keep their old color until the next run; inline baseline uses a small heuristic alignment.