### PR TITLE
Expose runtime controls in CLI

### DIFF
--- a/Sources/TurboFieldfareCLI/Args.swift
+++ b/Sources/TurboFieldfareCLI/Args.swift
@@ -11,6 +11,11 @@ public struct Args: Equatable, Sendable {
     public var seed: UInt64?
     public var stops: [String]
     public var quiet: Bool
+    public var expertCacheSlots: Int
+    public var expertCachePolicy: String
+    public var prefillEnabled: Bool
+    public var prefillChunkTokens: Int
+    public var rdadvisePolicy: String
 
     public init(model: String,
                 prompt: String? = nil,
@@ -23,7 +28,12 @@ public struct Args: Equatable, Sendable {
                 repetitionPenalty: Float = 1.0,
                 seed: UInt64? = nil,
                 stops: [String] = [],
-                quiet: Bool = false) {
+                quiet: Bool = false,
+                expertCacheSlots: Int = 16,
+                expertCachePolicy: String = "lfu",
+                prefillEnabled: Bool = true,
+                prefillChunkTokens: Int = 128,
+                rdadvisePolicy: String = "off") {
         self.model = model
         self.prompt = prompt
         self.messagesFile = messagesFile
@@ -36,6 +46,11 @@ public struct Args: Equatable, Sendable {
         self.seed = seed
         self.stops = stops
         self.quiet = quiet
+        self.expertCacheSlots = expertCacheSlots
+        self.expertCachePolicy = expertCachePolicy
+        self.prefillEnabled = prefillEnabled
+        self.prefillChunkTokens = prefillChunkTokens
+        self.rdadvisePolicy = rdadvisePolicy
     }
 }
 
@@ -82,6 +97,11 @@ extension Args {
       --seed <uint64>           Deterministic sampling seed (default off).
       --stop <string>           Stop substring (repeatable).
       --quiet                   Suppress the timing footer.
+      --expert-cache-slots <n>  Expert-cache slots: 8, 16, 24, or 32 (default 16).
+      --expert-cache-policy <s> Expert-cache policy: lfu or lru (default lfu).
+      --prefill on|off          Enable or disable chunked prompt prefill (default on).
+      --prefill-chunk-tokens <n> Prefill chunk size: 32, 64, or 128 (default 128).
+      --rdadvise <s>            RDADVISE policy: off, default, bounded, or adaptive (default off).
       --help                    Show this message.
     """
 
@@ -98,6 +118,11 @@ extension Args {
         var seed: UInt64?
         var stops: [String] = []
         var quiet = false
+        var expertCacheSlots = 16
+        var expertCachePolicy = "lfu"
+        var prefillEnabled = true
+        var prefillChunkTokens = 128
+        var rdadvisePolicy = "off"
 
         var index = 0
         while index < argv.count {
@@ -158,6 +183,37 @@ extension Args {
                 seed = parsed
             case "--stop":
                 stops.append(try takeValue(argv, &index, flag: flag))
+            case "--expert-cache-slots":
+                let value = try takeValue(argv, &index, flag: flag)
+                guard let parsed = Int(value), [8, 16, 24, 32].contains(parsed) else {
+                    throw ArgsError.invalidValue(flag: flag, value: value)
+                }
+                expertCacheSlots = parsed
+            case "--expert-cache-policy":
+                let value = try takeValue(argv, &index, flag: flag)
+                guard ["lfu", "lru"].contains(value) else {
+                    throw ArgsError.invalidValue(flag: flag, value: value)
+                }
+                expertCachePolicy = value
+            case "--prefill":
+                let value = try takeValue(argv, &index, flag: flag)
+                switch value {
+                case "on": prefillEnabled = true
+                case "off": prefillEnabled = false
+                default: throw ArgsError.invalidValue(flag: flag, value: value)
+                }
+            case "--prefill-chunk-tokens":
+                let value = try takeValue(argv, &index, flag: flag)
+                guard let parsed = Int(value), [32, 64, 128].contains(parsed) else {
+                    throw ArgsError.invalidValue(flag: flag, value: value)
+                }
+                prefillChunkTokens = parsed
+            case "--rdadvise":
+                let value = try takeValue(argv, &index, flag: flag)
+                guard ["off", "default", "bounded", "adaptive"].contains(value) else {
+                    throw ArgsError.invalidValue(flag: flag, value: value)
+                }
+                rdadvisePolicy = value
             default:
                 throw ArgsError.unknownFlag(flag)
             }
@@ -184,7 +240,12 @@ extension Args {
                     repetitionPenalty: repetitionPenalty,
                     seed: seed,
                     stops: stops,
-                    quiet: quiet)
+                    quiet: quiet,
+                    expertCacheSlots: expertCacheSlots,
+                    expertCachePolicy: expertCachePolicy,
+                    prefillEnabled: prefillEnabled,
+                    prefillChunkTokens: prefillChunkTokens,
+                    rdadvisePolicy: rdadvisePolicy)
     }
 
     private static func takeValue(_ argv: [String],

--- a/Sources/TurboFieldfareCLI/Run.swift
+++ b/Sources/TurboFieldfareCLI/Run.swift
@@ -54,6 +54,11 @@ public func run(args: Args,
             stopStrings: args.stops,
             extraStopTokens: [])
         let runtime = RuntimeConfiguration(
+            expertCacheSlots: args.expertCacheSlots,
+            expertCachePolicy: args.expertCachePolicy == "lru" ? .lru : .lfu,
+            rdadvisePolicy: RDAdvicePolicyMode.parse(args.rdadvisePolicy),
+            prefillEnabled: args.prefillEnabled,
+            prefillChunkTokens: args.prefillChunkTokens,
             forceLogitsHead: !config.isPureGreedy)
 
         guard MTLCreateSystemDefaultDevice() != nil else {

--- a/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
+++ b/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
@@ -16,6 +16,11 @@ import Testing
         #expect(arguments.seed == nil)
         #expect(arguments.stops.isEmpty)
         #expect(!arguments.quiet)
+        #expect(arguments.expertCacheSlots == 16)
+        #expect(arguments.expertCachePolicy == "lfu")
+        #expect(arguments.prefillEnabled)
+        #expect(arguments.prefillChunkTokens == 128)
+        #expect(arguments.rdadvisePolicy == "off")
     }
 
     @Test func generationOptionsParseAndStopsRepeat() throws {
@@ -64,7 +69,10 @@ import Testing
         let expected: Set<String> = [
             "--model", "--prompt", "--messages-file", "--max-new", "--max-context",
             "--temperature", "--top-k", "--top-p", "--repetition-penalty",
-            "--seed", "--stop", "--quiet", "--help",
+            "--seed", "--stop", "--quiet",
+            "--expert-cache-slots", "--expert-cache-policy",
+            "--prefill", "--prefill-chunk-tokens", "--rdadvise",
+            "--help",
         ]
         let words = Args.usage.split { $0.isWhitespace || $0 == "(" || $0 == ")" }
         let options = Set(words.map(String.init).filter { $0.hasPrefix("--") })
@@ -102,6 +110,66 @@ import Testing
                 "--model", "m.gturbo", "--prompt", "hi",
                 "--messages-file", "chat.json",
             ])
+        }
+    }
+
+    @Test func runtimeOptionsParse() throws {
+        let arguments = try Args.parse([
+            "--model", "m.gturbo", "--prompt", "hi",
+            "--expert-cache-slots", "24", "--expert-cache-policy", "lru",
+            "--prefill", "off", "--prefill-chunk-tokens", "64",
+            "--rdadvise", "adaptive",
+        ])
+        #expect(arguments.expertCacheSlots == 24)
+        #expect(arguments.expertCachePolicy == "lru")
+        #expect(!arguments.prefillEnabled)
+        #expect(arguments.prefillChunkTokens == 64)
+        #expect(arguments.rdadvisePolicy == "adaptive")
+    }
+
+    @Test func runtimeOptionsAcceptDocumentedValues() throws {
+        for slots in [8, 16, 24, 32] {
+            let arguments = try Args.parse([
+                "--model", "m.gturbo", "--prompt", "hi",
+                "--expert-cache-slots", "\(slots)",
+            ])
+            #expect(arguments.expertCacheSlots == slots)
+        }
+        for policy in ["lfu", "lru"] {
+            let arguments = try Args.parse([
+                "--model", "m.gturbo", "--prompt", "hi",
+                "--expert-cache-policy", policy,
+            ])
+            #expect(arguments.expertCachePolicy == policy)
+        }
+        for tokens in [32, 64, 128] {
+            let arguments = try Args.parse([
+                "--model", "m.gturbo", "--prompt", "hi",
+                "--prefill-chunk-tokens", "\(tokens)",
+            ])
+            #expect(arguments.prefillChunkTokens == tokens)
+        }
+        for policy in ["off", "default", "bounded", "adaptive"] {
+            let arguments = try Args.parse([
+                "--model", "m.gturbo", "--prompt", "hi", "--rdadvise", policy,
+            ])
+            #expect(arguments.rdadvisePolicy == policy)
+        }
+    }
+
+    @Test func runtimeOptionsRejectUnsupportedValues() {
+        for (flag, value) in [
+            ("--expert-cache-slots", "7"),
+            ("--expert-cache-policy", "fifo"),
+            ("--prefill", "yes"),
+            ("--prefill-chunk-tokens", "256"),
+            ("--rdadvise", "aggressive"),
+        ] {
+            #expect(throws: ArgsError.invalidValue(flag: flag, value: value)) {
+                _ = try Args.parse([
+                    "--model", "m.gturbo", "--prompt", "hi", flag, value,
+                ])
+            }
         }
     }
 }


### PR DESCRIPTION
## Summary

- add CLI options for expert-cache slots and replacement policy
- add CLI options for prompt prefill, prefill chunk size, and RDADVISE policy
- validate each option against the values already supported by `RuntimeConfiguration`
- preserve the existing CLI and runtime defaults when the new options are omitted
- document every option and default in `TurboFieldfareCLI --help`

Closes #92

## Validation

- `Scripts/test.sh` (646 tests passed)
- `swift build -c release`
- `.build/release/TurboFieldfareCLI --help`
- `ruby Scripts/check_markdown_links.rb`
- real-model batch validation using the exact submitted CLI/test files: 56/56 eligible 11K-window chunks completed at the shipped 4K generation/runtime defaults, with no new runtime options supplied
- five of 61 prepared chunks were excluded from both backends before comparison because their tokenized prompts exceed the shipped 4K context; the private run records preserve that limitation
- a blind 12-chunk, two-order, three-judge check completed 72/72 valid verdicts; the aggregate is recorded privately and in the sanitized measurement report

Validation host: Mac17,2, 32 GiB RAM, macOS 26.5.2, Swift 6.2.1.

## Defaults

Defaults are unchanged, so invocations that omit the new options retain the existing bounded-memory and performance behavior. 