### PR TITLE
Improve Mac app discoverability, contrast, and status copy

### DIFF
--- a/Sources/TurboFieldfareApp/Core/Diagnostics/AppDiagnostics.swift
+++ b/Sources/TurboFieldfareApp/Core/Diagnostics/AppDiagnostics.swift
@@ -17,7 +17,7 @@ public enum AppStopReason: String, Equatable, Sendable {
         case .cancelled: return "cancelled"
         case .failed: return "error"
         case .eos: return "end of sequence"
-        case .endOfTurn: return "finished"
+        case .endOfTurn: return "complete"
         case .stopString: return "stop sequence"
         case .toolCalls: return "tool call"
         }

--- a/Sources/TurboFieldfareApp/Core/Diagnostics/AppDiagnostics.swift
+++ b/Sources/TurboFieldfareApp/Core/Diagnostics/AppDiagnostics.swift
@@ -9,6 +9,19 @@ public enum AppStopReason: String, Equatable, Sendable {
     case endOfTurn
     case stopString
     case toolCalls
+
+    /// Short user-facing label for HUD and Last run (not the wire rawValue).
+    public var displayLabel: String {
+        switch self {
+        case .maxTokens: return "length limit"
+        case .cancelled: return "cancelled"
+        case .failed: return "error"
+        case .eos: return "end of sequence"
+        case .endOfTurn: return "finished"
+        case .stopString: return "stop sequence"
+        case .toolCalls: return "tool call"
+        }
+    }
 }
 
 public struct AppRunnerDiagnostics: Equatable, Sendable {

--- a/Sources/TurboFieldfareApp/Core/State/AppModel.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppModel.swift
@@ -223,9 +223,9 @@ public final class AppModel {
         case (false, true):
             return "You:\n\(outputPromptText)"
         case (true, false):
-            return "Answer:\n\(response)"
+            return "Assistant:\n\(response)"
         case (false, false):
-            return "You:\n\(outputPromptText)\n\nAnswer:\n\(response)"
+            return "You:\n\(outputPromptText)\n\nAssistant:\n\(response)"
         }
     }
 

--- a/Sources/TurboFieldfareApp/Core/State/AppPresentationState.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppPresentationState.swift
@@ -177,8 +177,11 @@ public struct AppPresentationState: Equatable, Sendable {
 
         if case .ready = snapshot.loadState {
             if let reason = snapshot.lastStopReason {
-                return Self(label: "Done · \(reason.displayLabel)", severity: .success,
-                            secondaryAction: .unload)
+                // Normal completion is just "Done"; only unusual stops need a reason.
+                let label = reason == .endOfTurn
+                    ? "Done"
+                    : "Done · \(reason.displayLabel)"
+                return Self(label: label, severity: .success, secondaryAction: .unload)
             }
             return Self(label: "Ready", severity: .success, secondaryAction: .unload)
         }

--- a/Sources/TurboFieldfareApp/Core/State/AppPresentationState.swift
+++ b/Sources/TurboFieldfareApp/Core/State/AppPresentationState.swift
@@ -120,8 +120,11 @@ public struct AppPresentationState: Equatable, Sendable {
                             severity: .error)
             }
             if case .insufficientSpace(let requirement) = snapshot.installReadiness {
+                let shortfall = ByteCountFormatter.string(
+                    fromByteCount: Int64(clamping: requirement.shortfallBytes),
+                    countStyle: .file)
                 return Self(label: "Not enough storage",
-                            detail: "\(requirement.shortfallBytes) bytes more required",
+                            detail: "\(shortfall) more required",
                             severity: .warning)
             }
             if case .checking = snapshot.installReadiness {
@@ -174,7 +177,7 @@ public struct AppPresentationState: Equatable, Sendable {
 
         if case .ready = snapshot.loadState {
             if let reason = snapshot.lastStopReason {
-                return Self(label: "Done · \(reason.rawValue)", severity: .success,
+                return Self(label: "Done · \(reason.displayLabel)", severity: .success,
                             secondaryAction: .unload)
             }
             return Self(label: "Ready", severity: .success, secondaryAction: .unload)

--- a/Sources/TurboFieldfareApp/Mac/App/RootView.swift
+++ b/Sources/TurboFieldfareApp/Mac/App/RootView.swift
@@ -11,12 +11,15 @@ struct RootView: View {
             primaryContent
                 .frame(minWidth: 720, maxWidth: .infinity, maxHeight: .infinity)
 
-            Divider()
+            Rectangle()
+                .fill(TurboFieldfareMacTheme.hairlineDivider)
+                .frame(width: 1)
+                .accessibilityHidden(true)
 
             InspectorView(model: model)
                 .frame(width: 320)
                 .frame(maxHeight: .infinity)
-                .background(Color(nsColor: .windowBackgroundColor))
+                .background(TurboFieldfareMacTheme.elevatedSurface.opacity(0.55))
         }
         .containerBackground(for: .window) {
             LinearGradient(

--- a/Sources/TurboFieldfareApp/Mac/App/TurboFieldfareMacApp.swift
+++ b/Sources/TurboFieldfareApp/Mac/App/TurboFieldfareMacApp.swift
@@ -59,16 +59,16 @@ struct TurboFieldfareMacApp: App {
                     .disabled(!model.canUnloadModel)
             }
             CommandMenu("Settings") {
-                Picker("Send Message With", selection: newlineShortcutBinding) {
+                Picker("Send with", selection: newlineShortcutBinding) {
                     ForEach(AppNewlineShortcut.sendMessageOptions) { shortcut in
                         Text(shortcut.sendMessageLabel).tag(shortcut)
                     }
                 }
-                Picker("Prompt Examples", selection: showPromptExamplesBinding) {
+                Picker("Prompt examples", selection: showPromptExamplesBinding) {
                     Text("Show").tag(true)
                     Text("Hide").tag(false)
                 }
-                Picker("After Sending", selection: sentPromptBehaviorBinding) {
+                Picker("After sending", selection: sentPromptBehaviorBinding) {
                     ForEach(AppSentPromptBehavior.allCases) { behavior in
                         Text(behavior.settingsLabel).tag(behavior)
                     }

--- a/Sources/TurboFieldfareApp/Mac/Components/ErrorBanner.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/ErrorBanner.swift
@@ -18,13 +18,14 @@ struct ErrorBanner: View {
                 Button {
                     model.error = nil
                 } label: {
-                    Label("Dismiss error", systemImage: "xmark")
-                        .labelStyle(.iconOnly)
+                    Image(systemName: "xmark")
                         .font(.caption.weight(.semibold))
                         .frame(width: 28, height: 28)
                         .contentShape(Circle())
                 }
                 .buttonStyle(.plain)
+                .accessibilityLabel("Dismiss error")
+                .help("Dismiss error")
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 8)

--- a/Sources/TurboFieldfareApp/Mac/Components/ErrorBanner.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/ErrorBanner.swift
@@ -31,10 +31,11 @@ struct ErrorBanner: View {
             .padding(.vertical, 8)
             .background {
                 Capsule()
-                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .fill(TurboFieldfareMacTheme.elevatedSurface)
                     .overlay {
-                        Capsule().stroke(.red.opacity(0.55), lineWidth: 1)
+                        Capsule().stroke(.red.opacity(0.7), lineWidth: 1.5)
                     }
+                    .shadow(color: .red.opacity(0.08), radius: 4, y: 1)
             }
             .help(error.technicalDetail)
             .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/Sources/TurboFieldfareApp/Mac/Components/GenerateControl.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/GenerateControl.swift
@@ -18,11 +18,20 @@ struct GenerateControl: View {
         Button {
             model.run()
         } label: {
-            Label("Generate", systemImage: "arrow.up")
-                .font(.callout.weight(.semibold))
-                .padding(.horizontal, 24)
-                .frame(minWidth: 124, minHeight: controlHeight)
-                .contentShape(Capsule())
+            HStack(spacing: 8) {
+                Image(systemName: "arrow.up")
+                    .font(.callout.weight(.semibold))
+                    .accessibilityHidden(true)
+                Text("Generate")
+                    .font(.callout.weight(.semibold))
+                Text(shortcutHint)
+                    .font(.caption.weight(.medium))
+                    .opacity(0.78)
+                    .accessibilityHidden(true)
+            }
+            .padding(.horizontal, 18)
+            .frame(minWidth: 124, minHeight: controlHeight)
+            .contentShape(Capsule())
         }
         .buttonStyle(.plain)
         .foregroundStyle(.white)
@@ -33,6 +42,11 @@ struct GenerateControl: View {
         .keyboardShortcut(.return, modifiers: .command)
         .disabled(!model.canRun)
         .opacity(model.canRun ? 1 : 0.62)
+        .accessibilityElement(children: .ignore)
+        .accessibilityLabel("Generate")
+        .accessibilityValue(shortcutHint)
+        .accessibilityHint(generateAccessibilityHint)
+        .help(generateHelp)
     }
 
     private var runningPill: some View {
@@ -72,7 +86,49 @@ struct GenerateControl: View {
         }
         .keyboardShortcut(.cancelAction)
         .disabled(!model.canCancel)
+        .accessibilityLabel(model.isCancellationPending ? "Stopping generation" : "Stop generation")
         .help("Stop generation")
         .animation(.smooth(duration: 0.2), value: model.presentation.label)
+    }
+
+    private var shortcutHint: String {
+        switch model.newlineShortcut {
+        case .return: return "⌘↩"
+        case .shiftReturn: return "↩"
+        }
+    }
+
+    private var generateHelp: String {
+        if let blocked = generateBlockedReason {
+            return blocked
+        }
+        switch model.newlineShortcut {
+        case .return:
+            return "Generate a response (⌘↩)"
+        case .shiftReturn:
+            return "Generate a response (Return). Use Shift-Return for a new line."
+        }
+    }
+
+    private var generateAccessibilityHint: String {
+        generateHelp
+    }
+
+    private var generateBlockedReason: String? {
+        guard !model.canRun else { return nil }
+        // Prefer load/runtime blockers over empty-prompt so the tip matches the HUD.
+        if model.loadState.isLoading {
+            return "Wait for the model to finish loading"
+        }
+        if !model.isModelAvailable {
+            return "Load the model before generating"
+        }
+        if model.hasStaleLoadedRuntime {
+            return "Reload the model to apply changed settings"
+        }
+        if model.promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Enter a prompt to generate"
+        }
+        return "Generate is unavailable right now"
     }
 }

--- a/Sources/TurboFieldfareApp/Mac/Components/GenerateControl.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/GenerateControl.swift
@@ -54,6 +54,7 @@ struct GenerateControl: View {
         .accessibilityLabel("Generate")
         .accessibilityValue(shortcutHint)
         .accessibilityHint(generateAccessibilityHint)
+        .accessibilityAddTraits(.isButton)
         .help(generateHelp)
     }
 

--- a/Sources/TurboFieldfareApp/Mac/Components/GenerateControl.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/GenerateControl.swift
@@ -34,14 +34,22 @@ struct GenerateControl: View {
             .contentShape(Capsule())
         }
         .buttonStyle(.plain)
-        .foregroundStyle(.white)
-        .background(TurboFieldfareMacTheme.accentColor, in: .capsule)
-        .overlay {
-            Capsule().stroke(.white.opacity(0.16), lineWidth: 0.5)
+        .foregroundStyle(model.canRun ? Color.white : Color.primary.opacity(0.55))
+        .background {
+            Capsule()
+                .fill(model.canRun
+                      ? TurboFieldfareMacTheme.accentColor
+                      : Color.primary.opacity(0.08))
+                .overlay {
+                    Capsule().stroke(
+                        model.canRun
+                            ? Color.white.opacity(0.16)
+                            : TurboFieldfareMacTheme.fieldBorder,
+                        lineWidth: 1)
+                }
         }
         .keyboardShortcut(.return, modifiers: .command)
         .disabled(!model.canRun)
-        .opacity(model.canRun ? 1 : 0.62)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Generate")
         .accessibilityValue(shortcutHint)

--- a/Sources/TurboFieldfareApp/Mac/Components/ModelActionBanner.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/ModelActionBanner.swift
@@ -20,6 +20,7 @@ struct ModelActionBanner: View {
                 }
                 .buttonStyle(.borderedProminent)
                 .controlSize(.small)
+                .accessibilityLabel(buttonTitle(for: action))
             }
             .padding(.horizontal, 14)
             .padding(.vertical, 8)

--- a/Sources/TurboFieldfareApp/Mac/Components/ModelActionBanner.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/ModelActionBanner.swift
@@ -1,4 +1,5 @@
 import TurboFieldfareAppCore
+import TurboFieldfareMacPresentation
 import SwiftUI
 
 struct ModelActionBanner: View {
@@ -12,7 +13,7 @@ struct ModelActionBanner: View {
                     .foregroundStyle(iconColor(for: action))
                     .accessibilityHidden(true)
                 Text(message(for: action))
-                    .font(.callout)
+                    .font(.callout.weight(.medium))
                     .lineLimit(2)
                 Spacer(minLength: 8)
                 Button(buttonTitle(for: action)) {
@@ -23,14 +24,15 @@ struct ModelActionBanner: View {
                 .accessibilityLabel(buttonTitle(for: action))
             }
             .padding(.horizontal, 14)
-            .padding(.vertical, 8)
+            .padding(.vertical, 10)
             .background {
                 RoundedRectangle(cornerRadius: 14)
-                    .fill(Color(nsColor: .controlBackgroundColor))
+                    .fill(TurboFieldfareMacTheme.elevatedSurface)
                     .overlay {
                         RoundedRectangle(cornerRadius: 14)
-                            .stroke(iconColor(for: action).opacity(0.5), lineWidth: 1)
+                            .stroke(iconColor(for: action).opacity(0.75), lineWidth: 1.5)
                     }
+                    .shadow(color: iconColor(for: action).opacity(0.12), radius: 6, y: 1)
             }
             .accessibilityElement(children: .contain)
             .transition(.move(edge: .bottom).combined(with: .opacity))

--- a/Sources/TurboFieldfareApp/Mac/Components/ModelStatusBadge.swift
+++ b/Sources/TurboFieldfareApp/Mac/Components/ModelStatusBadge.swift
@@ -5,7 +5,7 @@ struct ModelStatusBadge: View {
     let model: AppModel
 
     var body: some View {
-        HStack(spacing: 6) {
+        HStack(spacing: 8) {
             statusDot
             Text("Gemma 4 26B")
                 .font(.callout.weight(.semibold))
@@ -27,6 +27,14 @@ struct ModelStatusBadge: View {
     }
 
     private func dot(_ color: Color) -> some View {
-        Circle().fill(color).frame(width: 8, height: 8).accessibilityHidden(true)
+        ZStack {
+            Circle()
+                .fill(color.opacity(0.22))
+                .frame(width: 14, height: 14)
+            Circle()
+                .fill(color)
+                .frame(width: 8, height: 8)
+        }
+        .accessibilityHidden(true)
     }
 }

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
@@ -8,6 +8,7 @@ struct InspectorView: View {
     var body: some View {
         Form {
             modelSection
+            composerSection
             memorySection
             generationSection
             runtimeSection
@@ -20,27 +21,30 @@ struct InspectorView: View {
 
     private var modelSection: some View {
         Section("Model") {
-            LabeledContent("Path") {
-                HStack(spacing: 6) {
-                    Text(model.modelPathText)
-                        .font(.caption)
-                        .truncationMode(.middle)
-                        .lineLimit(1)
-                        .foregroundStyle(.secondary)
-                        .help(model.modelPathText)
-                    Button {
-                        NSPasteboard.general.clearContents()
-                        NSPasteboard.general.setString(model.modelPathText, forType: .string)
-                    } label: {
-                        Label("Copy model path", systemImage: "doc.on.doc")
-                            .labelStyle(.iconOnly)
-                    }
-                    .buttonStyle(.borderless)
-                    .help("Copy model path")
+            HStack(alignment: .firstTextBaseline, spacing: 6) {
+                Text("Path")
+                Spacer(minLength: 8)
+                Text(model.modelPathText)
+                    .font(.caption)
+                    .truncationMode(.middle)
+                    .lineLimit(1)
+                    .foregroundStyle(.secondary)
+                    .help(model.modelPathText)
+                    .textSelection(.enabled)
+                Button {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(model.modelPathText, forType: .string)
+                } label: {
+                    Image(systemName: "doc.on.doc")
                 }
+                .buttonStyle(.borderless)
+                .accessibilityLabel("Copy model path")
+                .accessibilityHint("Copies the model directory path to the clipboard")
+                .help("Copy model path")
             }
             if model.canUnloadModel {
                 Button("Unload Model", action: model.unloadModel)
+                    .accessibilityHint("Frees model memory until you load it again")
             }
             LabeledContent("State") {
                 Text(model.presentation.label)
@@ -70,6 +74,26 @@ struct InspectorView: View {
         .disabled(model.isRunning || model.isInstallingModel)
     }
 
+    private var composerSection: some View {
+        Section("Composer") {
+            Picker("Send with", selection: newlineShortcutBinding) {
+                ForEach(AppNewlineShortcut.sendMessageOptions) { shortcut in
+                    Text(shortcut.sendMessageLabel).tag(shortcut)
+                }
+            }
+            Picker("After sending", selection: sentPromptBehaviorBinding) {
+                ForEach(AppSentPromptBehavior.allCases) { behavior in
+                    Text(behavior.settingsLabel).tag(behavior)
+                }
+            }
+            Toggle("Show prompt examples", isOn: showPromptExamplesBinding)
+            Text("Send with controls Return versus Command-Return. Prompt examples appear when the prompt is empty.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .disabled(model.isRunning)
+    }
+
     private var memorySection: some View {
         Section("Memory") {
             LabeledContent("Context") {
@@ -82,8 +106,8 @@ struct InspectorView: View {
                 .labelsHidden()
                 .fixedSize()
             }
-            LabeledContent("Slots") {
-                Picker("Slots", selection: $model.runtimeOptions.expertCacheSlots) {
+            LabeledContent("Expert cache") {
+                Picker("Expert cache", selection: $model.runtimeOptions.expertCacheSlots) {
                     ForEach(AppRuntimeOptions.allowedSlotCounts, id: \.self) { slots in
                         Text(AppRuntimeOptions.slotsLabel(for: slots)).tag(slots)
                     }
@@ -92,7 +116,7 @@ struct InspectorView: View {
                 .labelsHidden()
                 .fixedSize()
             }
-            Text("More slots can improve decode speed by keeping more experts in memory, but they also use more RAM. Changes are compared with 4K context and 16 slots and apply after reloading the model.")
+            Text("More expert-cache slots can improve decode speed by keeping more experts in memory, but they also use more RAM. Changes are compared with 4K context and 16 slots and apply after reloading the model.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }
@@ -101,6 +125,9 @@ struct InspectorView: View {
 
     private var generationSection: some View {
         Section("Generation") {
+            Text("Response length uses the context space left after your prompt. There is no separate max-length control.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
             LabeledContent("Temperature") {
                 HStack(spacing: 8) {
                     Slider(value: $model.temperature, in: 0...2, step: 0.05)
@@ -125,6 +152,11 @@ struct InspectorView: View {
             Toggle("Top-P", isOn: $model.topPEnabled)
                 .toggleStyle(.switch)
                 .disabled(!model.topKEnabled)
+            if !model.topKEnabled {
+                Text("Top-P applies only while Top-K is on.")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+            }
             if model.topKEnabled && model.topPEnabled {
                 LabeledContent("P value") {
                     HStack(spacing: 8) {
@@ -142,6 +174,9 @@ struct InspectorView: View {
     private var runtimeSection: some View {
         Section("Runtime") {
             Toggle("Prefill", isOn: $model.runtimeOptions.prefillEnabled)
+            Text("Prefill processes the prompt in larger chunks before token-by-token generation. Leave it on for normal use.")
+                .font(.caption)
+                .foregroundStyle(.secondary)
             VStack(alignment: .leading, spacing: 8) {
                 Text("RDADVISE")
                 Picker("RDADVISE", selection: $model.runtimeOptions.rdadvisePolicy) {
@@ -152,7 +187,7 @@ struct InspectorView: View {
                 .pickerStyle(.segmented)
                 .labelsHidden()
             }
-            Text("RDADVISE is experimental. It may speed up short decodes but slow down long decodes.")
+            Text(rdadviseHelp)
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if model.hasStaleLoadedRuntime {
@@ -164,4 +199,40 @@ struct InspectorView: View {
         .disabled(model.isRunning || model.loadState.isLoading)
     }
 
+    private var rdadviseHelp: String {
+        switch model.runtimeOptions.rdadvisePolicy {
+        case .off:
+            return "RDADVISE is off (recommended). Experimental modes may speed short decodes but slow long ones."
+        case .default:
+            return "Default RDADVISE applies the stock read-advice policy. Experimental — reload required."
+        case .bounded:
+            return "Bounded RDADVISE limits advice volume. Experimental — reload required."
+        case .adaptive:
+            return "Adaptive RDADVISE adjusts advice during decode. Experimental — reload required."
+        }
+    }
+
+    private var newlineShortcutBinding: Binding<AppNewlineShortcut> {
+        Binding {
+            model.newlineShortcut
+        } set: { shortcut in
+            model.setNewlineShortcut(shortcut)
+        }
+    }
+
+    private var showPromptExamplesBinding: Binding<Bool> {
+        Binding {
+            model.showPromptExamples
+        } set: { show in
+            model.setShowPromptExamples(show)
+        }
+    }
+
+    private var sentPromptBehaviorBinding: Binding<AppSentPromptBehavior> {
+        Binding {
+            model.sentPromptBehavior
+        } set: { behavior in
+            model.setSentPromptBehavior(behavior)
+        }
+    }
 }

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
@@ -89,7 +89,7 @@ struct InspectorView: View {
                 }
             }
             Toggle("Show prompt examples", isOn: showPromptExamplesBinding)
-            Text("Send with controls Return versus Command-Return. Prompt examples appear when the prompt is empty.")
+            Text("Send with chooses whether Return or Command-Return generates. Prompt examples appear when the prompt is empty.")
                 .font(.caption)
                 .foregroundStyle(.secondary)
         }

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/InspectorView.swift
@@ -1,5 +1,6 @@
 import AppKit
 import TurboFieldfareAppCore
+import TurboFieldfareMacPresentation
 import SwiftUI
 
 struct InspectorView: View {
@@ -15,8 +16,9 @@ struct InspectorView: View {
             RunnerDiagnosticsSection(diagnostics: model.diagnostics)
         }
         .formStyle(.grouped)
-        .scrollContentBackground(.hidden)
-        .background(Color(nsColor: .windowBackgroundColor))
+        // Keep system grouped form backgrounds so rows/fields separate from chrome.
+        .scrollContentBackground(.automatic)
+        .background(TurboFieldfareMacTheme.elevatedSurface.opacity(0.35))
     }
 
     private var modelSection: some View {
@@ -131,9 +133,9 @@ struct InspectorView: View {
             LabeledContent("Temperature") {
                 HStack(spacing: 8) {
                     Slider(value: $model.temperature, in: 0...2, step: 0.05)
-                    Text(model.temperature, format: .number.precision(.fractionLength(2)))
-                        .monospacedDigit()
-                        .frame(width: 36, alignment: .trailing)
+                    numericChip(
+                        model.temperature,
+                        format: .number.precision(.fractionLength(2)))
                 }
             }
             Text("0 uses deterministic greedy decoding. Higher values make sampling more varied.")
@@ -144,7 +146,18 @@ struct InspectorView: View {
             if model.topKEnabled {
                 LabeledContent("K value") {
                     Stepper(value: $model.topK, in: 1...256, step: 1) {
-                        Text("\(model.topK)").monospacedDigit()
+                        Text("\(model.topK)")
+                            .monospacedDigit()
+                            .padding(.horizontal, 8)
+                            .padding(.vertical, 3)
+                            .background {
+                                RoundedRectangle(cornerRadius: 6)
+                                    .fill(TurboFieldfareMacTheme.fieldSurface)
+                                    .overlay {
+                                        RoundedRectangle(cornerRadius: 6)
+                                            .stroke(TurboFieldfareMacTheme.fieldBorder, lineWidth: 1)
+                                    }
+                            }
                     }
                     .fixedSize()
                 }
@@ -161,14 +174,31 @@ struct InspectorView: View {
                 LabeledContent("P value") {
                     HStack(spacing: 8) {
                         Slider(value: $model.topP, in: 0.01...1, step: 0.01)
-                        Text(model.topP, format: .number.precision(.fractionLength(2)))
-                            .monospacedDigit()
-                            .frame(width: 36, alignment: .trailing)
+                        numericChip(
+                            model.topP,
+                            format: .number.precision(.fractionLength(2)))
                     }
                 }
             }
         }
         .disabled(model.isRunning || model.loadState.isLoading)
+    }
+
+    private func numericChip<F: FormatStyle>(_ value: Double, format: F) -> some View
+    where F.FormatInput == Double, F.FormatOutput == String {
+        Text(value, format: format)
+            .monospacedDigit()
+            .frame(minWidth: 40, alignment: .trailing)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background {
+                RoundedRectangle(cornerRadius: 6)
+                    .fill(TurboFieldfareMacTheme.fieldSurface)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 6)
+                            .stroke(TurboFieldfareMacTheme.fieldBorder, lineWidth: 1)
+                    }
+            }
     }
 
     private var runtimeSection: some View {
@@ -191,9 +221,10 @@ struct InspectorView: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             if model.hasStaleLoadedRuntime {
-                Text("Reload required")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
+                Label("Reload required before generating", systemImage: "exclamationmark.triangle.fill")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(TurboFieldfareMacTheme.warningEmphasis)
+                    .accessibilityLabel("Reload required before generating")
             }
         }
         .disabled(model.isRunning || model.loadState.isLoading)

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/RunnerDiagnosticsSection.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/RunnerDiagnosticsSection.swift
@@ -11,7 +11,7 @@ struct RunnerDiagnosticsSection: View {
                 DiagnosticRow("Settings", diagnostics.runtimeOptions.resultSummary, multiline: true)
                 DiagnosticRow("Prompt tokens", diagnostics.promptTokenCount.map(String.init) ?? "unknown")
                 DiagnosticRow("Output tokens", "\(diagnostics.generatedTokens)")
-                DiagnosticRow("Stop", diagnostics.stopReason.rawValue)
+                DiagnosticRow("Stop", diagnostics.stopReason.displayLabel)
 
                 groupLabel("Performance")
                 DiagnosticRow("Prompt prefill", MetricFormat.seconds(diagnostics.prefillSeconds))
@@ -21,8 +21,14 @@ struct RunnerDiagnosticsSection: View {
                         "\(MetricFormat.rate(prefillRate)) tok/s",
                         help: "Prompt tokens divided by prefill time. Compare runs with similar prompt lengths and settings; short prompts include proportionally more fixed overhead.")
                 }
-                DiagnosticRow("First token wait", MetricFormat.seconds(diagnostics.timeToFirstTokenSeconds))
-                DiagnosticRow("Request TTFT", MetricFormat.seconds(diagnostics.requestStartTimeToFirstTokenSeconds))
+                DiagnosticRow(
+                    "First token wait",
+                    MetricFormat.seconds(diagnostics.timeToFirstTokenSeconds),
+                    help: "Time from the end of prompt prefill until the first generated token.")
+                DiagnosticRow(
+                    "Time to first token",
+                    MetricFormat.seconds(diagnostics.requestStartTimeToFirstTokenSeconds),
+                    help: "Time from starting the request through prefill until the first generated token.")
                 DiagnosticRow("Decode duration", MetricFormat.seconds(diagnostics.decodeSeconds))
                 DiagnosticRow("Decode rate", "\(MetricFormat.rate(diagnostics.tokensPerSecond)) tok/s")
                 DiagnosticRow("Peak memory", MetricFormat.memory(diagnostics.peakMemoryBytes))

--- a/Sources/TurboFieldfareApp/Mac/Diagnostics/StatusHUDView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Diagnostics/StatusHUDView.swift
@@ -29,10 +29,11 @@ struct StatusHUDView: View {
         .padding(.vertical, 10)
         .background {
             Capsule()
-                .fill(Color(nsColor: .controlBackgroundColor))
+                .fill(TurboFieldfareMacTheme.elevatedSurface)
                 .overlay {
-                    Capsule().stroke(.separator.opacity(0.5), lineWidth: 0.5)
+                    Capsule().stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
                 }
+                .shadow(color: .black.opacity(0.05), radius: 6, y: 1)
         }
         .gesture(WindowDragGesture())
     }
@@ -76,12 +77,13 @@ private struct PhaseLabel: View {
                 Circle().fill(TurboFieldfareMacTheme.accentColor).frame(width: 7, height: 7)
                 Text(label).contentTransition(.opacity)
             case .quiet(let label):
+                // Status also appears under the model name; keep a compact quiet cue.
                 Text(label)
-                    .foregroundStyle(.secondary)
+                    .foregroundStyle(.primary.opacity(0.72))
                     .contentTransition(.opacity)
             }
         }
-        .font(.caption.weight(.medium))
+        .font(.caption.weight(.semibold))
         .lineLimit(1)
         .accessibilityElement(children: .ignore)
         .accessibilityLabel("Model status")

--- a/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
@@ -100,7 +100,7 @@ struct OutputPaneView: View {
         .accessibilityLabel(responseCopyFeedbackID == nil
                             ? "Copy response"
                             : "Response copied")
-        .accessibilityHint("Copies only the generated answer")
+        .accessibilityHint("Copies only the generated assistant reply")
         .help(responseCopyFeedbackID == nil
               ? "Copy response"
               : "Response copied")
@@ -109,9 +109,9 @@ struct OutputPaneView: View {
     private var emptyPlaceholderContent: some View {
         VStack(spacing: 8) {
             if !needsModelLoad {
-                Text("Choose a predefined example or write your own prompt.")
+                Text("Choose an example below or write your own prompt.")
                     .font(.headline)
-                Text("Describe the goal, relevant context, and any constraints.")
+                Text("Describe the goal, relevant context, and any constraints. Then press Generate.")
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -483,9 +483,9 @@ private struct TranscriptPreview: View {
         Image(systemName: "cube.transparent")
             .font(.title2)
             .foregroundStyle(.quaternary)
-        Text("Choose a predefined example or write your own prompt.")
+        Text("Choose an example below or write your own prompt.")
             .font(.headline)
-        Text("Describe the goal, relevant context, and any constraints.")
+        Text("Describe the goal, relevant context, and any constraints. Then press Generate.")
             .foregroundStyle(.secondary)
     }
     .frame(width: 720, height: 420)

--- a/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
@@ -67,33 +67,53 @@ struct OutputPaneView: View {
             showsPrefillPlaceholder: model.isRunning
                 && model.outputResponsePlainText.isEmpty)
             .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .padding(16)
+            .background {
+                RoundedRectangle(cornerRadius: 16)
+                    .fill(TurboFieldfareMacTheme.elevatedSurface.opacity(0.72))
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 16)
+                            .stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
+                    }
+            }
             .overlay(alignment: .topTrailing) {
                 if !model.isRunning && !model.outputResponsePlainText.isEmpty {
                     copyResponseButton
-                        .padding(8)
+                        .padding(12)
                 }
             }
-            .padding(.horizontal, 24)
-            .padding(.vertical, 20)
+            .padding(.horizontal, 20)
+            .padding(.vertical, 16)
     }
 
     private var copyResponseButton: some View {
         Button {
             copyResponse()
         } label: {
-            Image(systemName: responseCopyFeedbackID == nil
-                  ? "doc.on.doc"
-                  : "checkmark.circle.fill")
-                .font(.callout.weight(.medium))
-                .contentTransition(.symbolEffect(.replace))
+            Label(
+                responseCopyFeedbackID == nil ? "Copy" : "Copied",
+                systemImage: responseCopyFeedbackID == nil
+                    ? "doc.on.doc"
+                    : "checkmark.circle.fill")
+                .labelStyle(.titleAndIcon)
+                .font(.caption.weight(.semibold))
+                .padding(.horizontal, 10)
+                .frame(height: 30)
+                .contentShape(Capsule())
                 .foregroundStyle(responseCopyFeedbackID == nil
-                                 ? Color.secondary
+                                 ? Color.primary
                                  : TurboFieldfareMacTheme.accentColor)
-                .frame(width: 28, height: 28)
-                .contentShape(Circle())
-                .background(.regularMaterial, in: Circle())
-                .overlay {
-                    Circle().stroke(.separator.opacity(0.5), lineWidth: 0.5)
+                .background {
+                    Capsule()
+                        .fill(TurboFieldfareMacTheme.elevatedSurface)
+                        .overlay {
+                            Capsule().stroke(
+                                responseCopyFeedbackID == nil
+                                    ? TurboFieldfareMacTheme.fieldBorder
+                                    : TurboFieldfareMacTheme.accentColor.opacity(0.7),
+                                lineWidth: 1)
+                        }
+                        .shadow(color: .black.opacity(0.08), radius: 4, y: 1)
                 }
         }
         .buttonStyle(.plain)
@@ -188,7 +208,15 @@ private struct EmptyPlaceholderIcon: View {
     var body: some View {
         Image(systemName: systemName)
             .font(.title2)
-            .foregroundStyle(.quaternary)
+            .foregroundStyle(.secondary)
+            .frame(width: 48, height: 48)
+            .background {
+                Circle()
+                    .fill(TurboFieldfareMacTheme.fieldSurface)
+                    .overlay {
+                        Circle().stroke(TurboFieldfareMacTheme.fieldBorder, lineWidth: 1)
+                    }
+            }
             .accessibilityHidden(true)
     }
 }

--- a/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/OutputPaneView.swift
@@ -129,9 +129,10 @@ struct OutputPaneView: View {
     private var emptyPlaceholderContent: some View {
         VStack(spacing: 8) {
             if !needsModelLoad {
-                Text("Choose an example below or write your own prompt.")
+                Text(emptyReadyHeadline)
                     .font(.headline)
-                Text("Describe the goal, relevant context, and any constraints. Then press Generate.")
+                    .multilineTextAlignment(.center)
+                Text(emptyReadyDetail)
                     .font(.callout)
                     .foregroundStyle(.secondary)
                     .multilineTextAlignment(.center)
@@ -168,6 +169,32 @@ struct OutputPaneView: View {
             }
         }
         .frame(maxWidth: .infinity)
+    }
+
+    /// Matches what the chrome actually offers: examples only appear when the
+    /// prompt is empty and the examples toggle is on.
+    private var showsPromptExamplesInChrome: Bool {
+        model.promptText.isEmpty && model.showPromptExamples && !model.isRunning
+    }
+
+    private var emptyReadyHeadline: String {
+        if showsPromptExamplesInChrome {
+            return "Choose an example below or write your own prompt."
+        }
+        if model.promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Write a prompt below to get started."
+        }
+        return "Your prompt is ready."
+    }
+
+    private var emptyReadyDetail: String {
+        if showsPromptExamplesInChrome {
+            return "Describe the goal, relevant context, and any constraints. Then press Generate."
+        }
+        if model.promptText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return "Describe the goal, relevant context, and any constraints. Then press Generate."
+        }
+        return "Edit it if you like, then press Generate."
     }
 
     private var needsModelLoad: Bool {
@@ -511,7 +538,7 @@ private struct TranscriptPreview: View {
         Image(systemName: "cube.transparent")
             .font(.title2)
             .foregroundStyle(.quaternary)
-        Text("Choose an example below or write your own prompt.")
+        Text("Write a prompt below to get started.")
             .font(.headline)
         Text("Describe the goal, relevant context, and any constraints. Then press Generate.")
             .foregroundStyle(.secondary)

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
@@ -9,18 +9,28 @@ struct PromptComposerView: View {
     @State private var showingPromptTips = false
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(spacing: 8) {
+                Text("Prompt")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(.secondary)
+                Spacer(minLength: 8)
+                if promptFocused {
+                    Text(shortcutCaption)
+                        .font(.caption2)
+                        .foregroundStyle(.tertiary)
+                        .accessibilityHidden(true)
+                }
+            }
             editor
             footer
         }
         .padding(14)
-        .background {
-            RoundedRectangle(cornerRadius: 22)
-                .fill(Color(nsColor: .controlBackgroundColor))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 22)
-                        .stroke(.separator.opacity(0.5), lineWidth: 0.5)
-                }
+        .turboElevatedCard(cornerRadius: 22)
+        .onChange(of: model.loadState.isReady) { _, isReady in
+            if isReady && model.promptText.isEmpty {
+                promptFocused = true
+            }
         }
     }
 
@@ -29,6 +39,8 @@ struct PromptComposerView: View {
             .accessibilityLabel("Prompt")
             .font(.body)
             .scrollContentBackground(.hidden)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 6)
             .focused($promptFocused)
             .onKeyPress(.return, phases: [.down, .repeat]) { keyPress in
                 switch PromptSubmissionPolicy.decision(
@@ -46,15 +58,27 @@ struct PromptComposerView: View {
                     return .ignored
                 }
             }
+            .frame(minHeight: editorHeight, maxHeight: 160)
             .frame(height: editorHeight)
+            .background {
+                RoundedRectangle(cornerRadius: 12)
+                    .fill(TurboFieldfareMacTheme.fieldSurface)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(
+                                promptFocused
+                                    ? TurboFieldfareMacTheme.fieldBorderFocused
+                                    : TurboFieldfareMacTheme.fieldBorder,
+                                lineWidth: promptFocused ? 1.5 : 1)
+                    }
+            }
             .overlay(alignment: .topLeading) {
                 if model.promptText.isEmpty {
-                    // Matches the NSTextView text origin: 5pt line fragment
-                    // padding, no vertical inset.
                     Text("Ask anything…")
                         .font(.body)
-                        .foregroundStyle(.tertiary)
-                        .padding(.leading, 5)
+                        .foregroundStyle(TurboFieldfareMacTheme.fieldPlaceholder)
+                        .padding(.leading, 13)
+                        .padding(.top, 8)
                         .allowsHitTesting(false)
                         .accessibilityHidden(true)
                 }
@@ -66,7 +90,15 @@ struct PromptComposerView: View {
     }
 
     private var editorHeight: CGFloat {
-        model.promptText.isEmpty ? 46 : 84
+        // Larger empty hit target so the field is easy to find and click.
+        model.promptText.isEmpty ? 64 : 96
+    }
+
+    private var shortcutCaption: String {
+        switch model.newlineShortcut {
+        case .return: return "⌘↩ to generate"
+        case .shiftReturn: return "↩ to generate · ⇧↩ for newline"
+        }
     }
 
     private var footer: some View {
@@ -82,12 +114,22 @@ struct PromptComposerView: View {
         Button {
             showingPromptTips.toggle()
         } label: {
-            Image(systemName: "questionmark.circle")
-                .frame(width: 28, height: 28)
-                .contentShape(Circle())
+            Label("Tips", systemImage: "questionmark.circle")
+                .labelStyle(.titleAndIcon)
+                .font(.caption.weight(.medium))
+                .padding(.horizontal, 10)
+                .frame(height: 28)
+                .contentShape(Capsule())
         }
         .buttonStyle(.borderless)
-        .foregroundStyle(.secondary)
+        .foregroundStyle(.primary)
+        .background {
+            Capsule()
+                .fill(Color.primary.opacity(0.06))
+                .overlay {
+                    Capsule().stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
+                }
+        }
         .accessibilityLabel("Prompt tips")
         .accessibilityHint("Shows guidance for writing effective prompts")
         .help("Prompt tips")
@@ -135,11 +177,22 @@ struct PromptComposerView: View {
             Button {
                 model.clearOutput()
             } label: {
-                Image(systemName: "trash")
-                    .frame(width: 28, height: 28)
-                    .contentShape(Circle())
+                Label("Clear", systemImage: "trash")
+                    .labelStyle(.titleAndIcon)
+                    .font(.caption.weight(.medium))
+                    .padding(.horizontal, 10)
+                    .frame(height: 28)
+                    .contentShape(Capsule())
             }
             .buttonStyle(.borderless)
+            .foregroundStyle(.primary)
+            .background {
+                Capsule()
+                    .fill(Color.primary.opacity(0.06))
+                    .overlay {
+                        Capsule().stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
+                    }
+            }
             .accessibilityLabel("Clear output")
             .accessibilityHint("Removes the conversation transcript and last-run metrics")
             .help("Clear output")
@@ -148,12 +201,23 @@ struct PromptComposerView: View {
                 model.promptText = ""
                 promptFocused = true
             } label: {
-                Image(systemName: "xmark.circle.fill")
+                Label("Clear", systemImage: "xmark.circle.fill")
+                    .labelStyle(.titleAndIcon)
+                    .font(.caption.weight(.medium))
                     .symbolRenderingMode(.hierarchical)
-                    .frame(width: 28, height: 28)
-                    .contentShape(Circle())
+                    .padding(.horizontal, 10)
+                    .frame(height: 28)
+                    .contentShape(Capsule())
             }
             .buttonStyle(.borderless)
+            .foregroundStyle(.primary)
+            .background {
+                Capsule()
+                    .fill(Color.primary.opacity(0.06))
+                    .overlay {
+                        Capsule().stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
+                    }
+            }
             .accessibilityLabel("Clear prompt")
             .accessibilityHint("Clears the prompt editor")
             .help("Clear prompt")

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
@@ -115,21 +115,9 @@ struct PromptComposerView: View {
             showingPromptTips.toggle()
         } label: {
             Label("Tips", systemImage: "questionmark.circle")
-                .labelStyle(.titleAndIcon)
-                .font(.caption.weight(.medium))
-                .padding(.horizontal, 10)
-                .frame(height: 28)
-                .contentShape(Capsule())
+                .turboQuietControlLabel()
         }
-        .buttonStyle(.borderless)
-        .foregroundStyle(.primary)
-        .background {
-            Capsule()
-                .fill(Color.primary.opacity(0.06))
-                .overlay {
-                    Capsule().stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
-                }
-        }
+        .turboQuietControlChrome()
         .accessibilityLabel("Prompt tips")
         .accessibilityHint("Shows guidance for writing effective prompts")
         .help("Prompt tips")
@@ -178,21 +166,9 @@ struct PromptComposerView: View {
                 model.clearOutput()
             } label: {
                 Label("Clear", systemImage: "trash")
-                    .labelStyle(.titleAndIcon)
-                    .font(.caption.weight(.medium))
-                    .padding(.horizontal, 10)
-                    .frame(height: 28)
-                    .contentShape(Capsule())
+                    .turboQuietControlLabel()
             }
-            .buttonStyle(.borderless)
-            .foregroundStyle(.primary)
-            .background {
-                Capsule()
-                    .fill(Color.primary.opacity(0.06))
-                    .overlay {
-                        Capsule().stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
-                    }
-            }
+            .turboQuietControlChrome()
             .accessibilityLabel("Clear output")
             .accessibilityHint("Removes the conversation transcript and last-run metrics")
             .help("Clear output")
@@ -202,22 +178,10 @@ struct PromptComposerView: View {
                 promptFocused = true
             } label: {
                 Label("Clear", systemImage: "xmark.circle.fill")
-                    .labelStyle(.titleAndIcon)
-                    .font(.caption.weight(.medium))
                     .symbolRenderingMode(.hierarchical)
-                    .padding(.horizontal, 10)
-                    .frame(height: 28)
-                    .contentShape(Capsule())
+                    .turboQuietControlLabel()
             }
-            .buttonStyle(.borderless)
-            .foregroundStyle(.primary)
-            .background {
-                Capsule()
-                    .fill(Color.primary.opacity(0.06))
-                    .overlay {
-                        Capsule().stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
-                    }
-            }
+            .turboQuietControlChrome()
             .accessibilityLabel("Clear prompt")
             .accessibilityHint("Clears the prompt editor")
             .help("Clear prompt")

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptComposerView.swift
@@ -51,11 +51,12 @@ struct PromptComposerView: View {
                 if model.promptText.isEmpty {
                     // Matches the NSTextView text origin: 5pt line fragment
                     // padding, no vertical inset.
-                    Text("Prompt")
+                    Text("Ask anything…")
                         .font(.body)
                         .foregroundStyle(.tertiary)
                         .padding(.leading, 5)
                         .allowsHitTesting(false)
+                        .accessibilityHidden(true)
                 }
             }
     }
@@ -81,13 +82,14 @@ struct PromptComposerView: View {
         Button {
             showingPromptTips.toggle()
         } label: {
-            Label("Prompt tips", systemImage: "questionmark.circle")
-                .labelStyle(.iconOnly)
+            Image(systemName: "questionmark.circle")
                 .frame(width: 28, height: 28)
                 .contentShape(Circle())
         }
         .buttonStyle(.borderless)
         .foregroundStyle(.secondary)
+        .accessibilityLabel("Prompt tips")
+        .accessibilityHint("Shows guidance for writing effective prompts")
         .help("Prompt tips")
         .popover(isPresented: $showingPromptTips,
                  attachmentAnchor: .point(.top),
@@ -133,25 +135,27 @@ struct PromptComposerView: View {
             Button {
                 model.clearOutput()
             } label: {
-                Label("Clear output", systemImage: "trash")
-                    .labelStyle(.iconOnly)
+                Image(systemName: "trash")
                     .frame(width: 28, height: 28)
                     .contentShape(Circle())
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel("Clear output")
+            .accessibilityHint("Removes the conversation transcript and last-run metrics")
             .help("Clear output")
         } else if !model.isRunning && !model.promptText.isEmpty {
             Button {
                 model.promptText = ""
                 promptFocused = true
             } label: {
-                Label("Clear prompt", systemImage: "xmark.circle.fill")
-                    .labelStyle(.iconOnly)
+                Image(systemName: "xmark.circle.fill")
                     .symbolRenderingMode(.hierarchical)
                     .frame(width: 28, height: 28)
                     .contentShape(Circle())
             }
             .buttonStyle(.borderless)
+            .accessibilityLabel("Clear prompt")
+            .accessibilityHint("Clears the prompt editor")
             .help("Clear prompt")
         }
     }

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptExamplesView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptExamplesView.swift
@@ -63,9 +63,11 @@ struct PromptExamplesView: View {
                 RoundedRectangle(cornerRadius: 12)
                     .stroke(.separator.opacity(0.35), lineWidth: 0.5)
             }
+            .accessibilityElement(children: .ignore)
             .accessibilityLabel(preset.title)
             .accessibilityValue(preset.prompt)
-            .accessibilityHint("Copies this prompt into the prompt editor")
+            .accessibilityHint("Inserts this example into the prompt editor")
+            .accessibilityAddTraits(.isButton)
         }
     }
 

--- a/Sources/TurboFieldfareApp/Mac/Generation/PromptExamplesView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Generation/PromptExamplesView.swift
@@ -1,4 +1,5 @@
 import TurboFieldfareAppCore
+import TurboFieldfareMacPresentation
 import SwiftUI
 
 struct PromptExamplesView: View {
@@ -23,14 +24,7 @@ struct PromptExamplesView: View {
             }
         }
         .padding(14)
-        .background {
-            RoundedRectangle(cornerRadius: 18)
-                .fill(Color(nsColor: .controlBackgroundColor))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 18)
-                        .stroke(.separator.opacity(0.5), lineWidth: 0.5)
-                }
-        }
+        .turboElevatedCard(cornerRadius: 18)
         .transition(.opacity.combined(with: .move(edge: .bottom)))
         .accessibilityElement(children: .contain)
     }
@@ -58,10 +52,13 @@ struct PromptExamplesView: View {
                 .contentShape(.rect)
             }
             .buttonStyle(.plain)
-            .background(.quaternary.opacity(0.25), in: .rect(cornerRadius: 12))
-            .overlay {
+            .background {
                 RoundedRectangle(cornerRadius: 12)
-                    .stroke(.separator.opacity(0.35), lineWidth: 0.5)
+                    .fill(TurboFieldfareMacTheme.fieldSurface)
+                    .overlay {
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(TurboFieldfareMacTheme.fieldBorder, lineWidth: 1)
+                    }
             }
             .accessibilityElement(children: .ignore)
             .accessibilityLabel(preset.title)

--- a/Sources/TurboFieldfareApp/Mac/Installation/ModelInstallView.swift
+++ b/Sources/TurboFieldfareApp/Mac/Installation/ModelInstallView.swift
@@ -74,20 +74,22 @@ struct ModelInstallView: View {
             }
             Text(model.modelPathText)
                 .font(.caption.monospaced())
-                .foregroundStyle(.tertiary)
+                .foregroundStyle(.secondary)
                 .lineLimit(2)
                 .truncationMode(.middle)
                 .frame(maxWidth: .infinity, alignment: .leading)
-        }
-        .padding(18)
-        .background {
-            RoundedRectangle(cornerRadius: 20)
-                .fill(Color(nsColor: .controlBackgroundColor))
-                .overlay {
-                    RoundedRectangle(cornerRadius: 20)
-                        .stroke(.separator.opacity(0.5), lineWidth: 0.5)
+                .padding(8)
+                .background {
+                    RoundedRectangle(cornerRadius: 8)
+                        .fill(TurboFieldfareMacTheme.fieldSurface)
+                        .overlay {
+                            RoundedRectangle(cornerRadius: 8)
+                                .stroke(TurboFieldfareMacTheme.fieldBorder, lineWidth: 1)
+                        }
                 }
         }
+        .padding(18)
+        .turboElevatedCard(cornerRadius: 20)
     }
 
     @ViewBuilder

--- a/Sources/TurboFieldfareApp/MacPresentation/InstructionTranscriptDocumentController.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/InstructionTranscriptDocumentController.swift
@@ -150,7 +150,7 @@ public final class InstructionTranscriptDocumentController {
                 attributes: Self.promptAttributes()))
         }
         document.append(NSAttributedString(
-            string: "Answer\n",
+            string: "Assistant\n",
             attributes: Self.assistantLabelAttributes()))
         assistantRange = NSRange(location: document.length, length: 0)
         document.append(NSAttributedString(

--- a/Sources/TurboFieldfareApp/MacPresentation/TurboFieldfareMacTheme.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/TurboFieldfareMacTheme.swift
@@ -62,4 +62,26 @@ public extension View {
                 .shadow(color: .black.opacity(0.06), radius: 8, y: 2)
         }
     }
+
+    /// Label metrics for compact titled secondary controls (Tips, Clear, etc.).
+    func turboQuietControlLabel() -> some View {
+        labelStyle(.titleAndIcon)
+            .font(.caption.weight(.medium))
+            .padding(.horizontal, 10)
+            .frame(height: 28)
+            .contentShape(Capsule())
+    }
+
+    /// Chrome for compact secondary controls next to primary actions.
+    func turboQuietControlChrome() -> some View {
+        buttonStyle(.borderless)
+            .foregroundStyle(.primary)
+            .background {
+                Capsule()
+                    .fill(Color.primary.opacity(0.06))
+                    .overlay {
+                        Capsule().stroke(TurboFieldfareMacTheme.cardBorder, lineWidth: 1)
+                    }
+            }
+    }
 }

--- a/Sources/TurboFieldfareApp/MacPresentation/TurboFieldfareMacTheme.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/TurboFieldfareMacTheme.swift
@@ -9,4 +9,57 @@ public enum TurboFieldfareMacTheme {
         alpha: 1)
 
     public static let accentColor = Color(nsColor: accentNSColor)
+
+    /// Raised card fill (composer shell, examples panel, HUD, banners).
+    /// Uses text-background so surfaces separate from the window chrome —
+    /// `controlBackgroundColor` often matches `windowBackgroundColor`.
+    public static var elevatedSurface: Color {
+        Color(nsColor: .textBackgroundColor)
+    }
+
+    /// Nested input field fill, slightly inset from the card.
+    public static var fieldSurface: Color {
+        Color(nsColor: .controlBackgroundColor).opacity(0.55)
+            .mix(with: Color(nsColor: .textBackgroundColor), by: 0.65)
+    }
+
+    /// Resting border for cards and fields (stronger than `.separator` 0.5).
+    public static var cardBorder: Color {
+        Color.primary.opacity(0.14)
+    }
+
+    public static var fieldBorder: Color {
+        Color.primary.opacity(0.22)
+    }
+
+    public static var fieldBorderFocused: Color {
+        accentColor.opacity(0.9)
+    }
+
+    public static var fieldPlaceholder: Color {
+        Color.secondary
+    }
+
+    public static var hairlineDivider: Color {
+        Color.primary.opacity(0.12)
+    }
+
+    public static var warningEmphasis: Color {
+        Color.orange
+    }
+}
+
+public extension View {
+    /// Shared elevated card chrome used by composer, examples, install, banners.
+    func turboElevatedCard(cornerRadius: CGFloat, border: Color = TurboFieldfareMacTheme.cardBorder) -> some View {
+        background {
+            RoundedRectangle(cornerRadius: cornerRadius)
+                .fill(TurboFieldfareMacTheme.elevatedSurface)
+                .overlay {
+                    RoundedRectangle(cornerRadius: cornerRadius)
+                        .stroke(border, lineWidth: 1)
+                }
+                .shadow(color: .black.opacity(0.06), radius: 8, y: 2)
+        }
+    }
 }

--- a/Tests/TurboFieldfareApp/Core/Diagnostics/AppDiagnosticsTests.swift
+++ b/Tests/TurboFieldfareApp/Core/Diagnostics/AppDiagnosticsTests.swift
@@ -2,6 +2,14 @@ import Testing
 @testable import TurboFieldfareAppCore
 
 @Suite struct AppDiagnosticsTests {
+    @Test func stopReasonDisplayLabelsAreHumanReadable() {
+        #expect(AppStopReason.endOfTurn.displayLabel == "complete")
+        #expect(AppStopReason.maxTokens.displayLabel == "length limit")
+        #expect(AppStopReason.cancelled.displayLabel == "cancelled")
+        #expect(!AppStopReason.endOfTurn.displayLabel.contains("endOfTurn"))
+        #expect(AppStopReason.endOfTurn.displayLabel != "finished")
+    }
+
     @Test func requestStartTTFTAddsPrefillAndPostPrefillWait() {
         let diagnostics = AppDiagnostics(
             generatedTokens: 1,

--- a/Tests/TurboFieldfareApp/Core/State/AppModelServiceReportingTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelServiceReportingTests.swift
@@ -14,7 +14,7 @@ import Testing
 
         #expect(model.currentProcessMemoryBytes == 2_100_000_000)
         #expect(model.outputResponsePlainText == "lossless output")
-        #expect(model.outputConversationPlainText == "Answer:\nlossless output")
+        #expect(model.outputConversationPlainText == "Assistant:\nlossless output")
 
         model.clearOutput()
         #expect(client.generationTranscriptMailbox.completeText.isEmpty)

--- a/Tests/TurboFieldfareApp/Core/State/AppModelTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppModelTests.swift
@@ -186,7 +186,7 @@ import Testing
         #expect(model.outputPromptText == "original prompt")
         #expect(model.outputResponsePlainText == "answer")
         #expect(model.outputConversationPlainText
-            == "You:\noriginal prompt\n\nAnswer:\nanswer")
+            == "You:\noriginal prompt\n\nAssistant:\nanswer")
         #expect(!model.outputConversationPlainText.contains("edited prompt"))
     }
 
@@ -211,7 +211,7 @@ import Testing
 
         #expect(model.promptText == "next draft")
         #expect(model.outputConversationPlainText.hasPrefix(
-            "You:\noriginal prompt\n\nAnswer:\n"))
+            "You:\noriginal prompt\n\nAssistant:\n"))
     }
 
     @MainActor
@@ -270,7 +270,7 @@ import Testing
         #expect(model.hasOutputTranscript)
         #expect(!model.outputResponsePlainText.isEmpty)
         #expect(model.outputConversationPlainText.hasPrefix(
-            "You:\nstop after token\n\nAnswer:\n"))
+            "You:\nstop after token\n\nAssistant:\n"))
 
         model.clearOutput()
         #expect(!model.hasOutputTranscript)

--- a/Tests/TurboFieldfareApp/Core/State/AppPresentationStateTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppPresentationStateTests.swift
@@ -133,8 +133,15 @@ import Testing
         var snapshot = Self.installedSnapshot(loadState: ready)
         snapshot.lastStopReason = .endOfTurn
         let state = AppPresentationState.resolve(snapshot)
-        #expect(state.label == "Done · finished")
+        // Normal end-of-turn is just "Done" — not "Done · finished".
+        #expect(state.label == "Done")
         #expect(!state.label.contains("endOfTurn"))
+        #expect(!state.label.contains("finished"))
+
+        snapshot.lastStopReason = .maxTokens
+        let lengthLimited = AppPresentationState.resolve(snapshot)
+        #expect(lengthLimited.label == "Done · length limit")
+        #expect(!lengthLimited.label.contains("maxTokens"))
     }
 
     @Test func insufficientSpaceUsesFormattedShortfall() {

--- a/Tests/TurboFieldfareApp/Core/State/AppPresentationStateTests.swift
+++ b/Tests/TurboFieldfareApp/Core/State/AppPresentationStateTests.swift
@@ -126,6 +126,33 @@ import Testing
         #expect(state.label == "Prefill (128/514)")
     }
 
+    @Test func lastStopReasonUsesHumanLabelNotRawWireValue() {
+        let ready = AppModelLoadState.ready(
+            modelDirectory: URL(fileURLWithPath: "/tmp/model.gturbo"),
+            loadSeconds: 1)
+        var snapshot = Self.installedSnapshot(loadState: ready)
+        snapshot.lastStopReason = .endOfTurn
+        let state = AppPresentationState.resolve(snapshot)
+        #expect(state.label == "Done · finished")
+        #expect(!state.label.contains("endOfTurn"))
+    }
+
+    @Test func insufficientSpaceUsesFormattedShortfall() {
+        var snapshot = Self.installedSnapshot(loadState: .notLoaded)
+        snapshot.requiresInstallation = true
+        snapshot.installReadiness = .insufficientSpace(
+            AppModelInstallRequirement(
+                requiredBytes: 2_000_000_000,
+                availableBytes: 500_000_000))
+        let state = AppPresentationState.resolve(snapshot)
+        #expect(state.label == "Not enough storage")
+        let detail = state.detail ?? ""
+        #expect(detail.contains("more required"))
+        // Must not dump a raw integer byte count like "1500000000 bytes more required".
+        #expect(!detail.contains("1500000000"))
+        #expect(!detail.hasPrefix(String(1_500_000_000)))
+    }
+
     private static func installedSnapshot(loadState: AppModelLoadState) -> AppPresentationSnapshot {
         AppPresentationSnapshot(requiresInstallation: false,
                                 installState: .idle,

--- a/Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift
+++ b/Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift
@@ -130,9 +130,9 @@ import Testing
 
         #expect(first.mutation == .rebuilt)
         #expect(second.mutation == .appended)
-        #expect(storage.string == "You\nExplain this\n\nAnswer\nHello")
-        #expect(storage.string.components(separatedBy: "Answer").count == 2)
-        let answerRange = (storage.string as NSString).range(of: "Answer")
+        #expect(storage.string == "You\nExplain this\n\nAssistant\nHello")
+        #expect(storage.string.components(separatedBy: "Assistant").count == 2)
+        let answerRange = (storage.string as NSString).range(of: "Assistant")
         let answerColor = storage.attribute(
             .foregroundColor,
             at: answerRange.location,
@@ -154,7 +154,7 @@ import Testing
 
         #expect(prefilling.mutation == .rebuilt)
         #expect(controller.showsPrefillPlaceholder)
-        #expect(storage.string == "You\nExplain this\n\nAnswer\nProcessing your prompt")
+        #expect(storage.string == "You\nExplain this\n\nAssistant\nProcessing your prompt")
         #expect(controller.response.isEmpty)
         #expect(controller.assistantRange.length == 0)
 
@@ -176,7 +176,7 @@ import Testing
 
         #expect(responding.mutation == .rebuilt)
         #expect(!controller.showsPrefillPlaceholder)
-        #expect(storage.string == "You\nExplain this\n\nAnswer\nHello")
+        #expect(storage.string == "You\nExplain this\n\nAssistant\nHello")
         #expect(!storage.string.contains("Processing your prompt"))
         #expect((storage.string as NSString).substring(with: responding.assistantRange)
             == "Hello")
@@ -203,7 +203,7 @@ import Testing
             storage: storage, prompt: "New", response: "Short", isTerminal: false)
 
         #expect(result.mutation == .rebuilt)
-        #expect(storage.string == "You\nNew\n\nAnswer\nShort")
+        #expect(storage.string == "You\nNew\n\nAssistant\nShort")
         #expect(!storage.string.contains("Old"))
         #expect(!storage.string.contains("Long response"))
     }
@@ -226,7 +226,7 @@ import Testing
         #expect(result.mutation == .finalized)
         #expect(controller.isFinalized)
         #expect(controller.response == "**Bold answer**")
-        #expect(storage.string == "You\nQuestion\n\nAnswer\nBold answer")
+        #expect(storage.string == "You\nQuestion\n\nAssistant\nBold answer")
         #expect((storage.string as NSString).substring(with: result.assistantRange)
             == "Bold answer")
 


### PR DESCRIPTION
## Summary

Mac app presentation and copy pass so primary generate and settings paths need less guesswork. No runtime, sampling, install, or model-format changes.

- **Discoverability & status:** human-readable stop reasons and storage shortfalls; Generate shows the send shortcut and explains why it is disabled; Composer prefs (Send with / After sending / Show examples) surface in the inspector; tighter a11y labels on Tips, Clear, Copy, examples, and Generate (exposed as a button).
- **Contrast:** elevated/field theme tokens, focus rings, and stronger borders so the prompt field, example cards, HUD, transcript, inspector, and install surfaces separate from the window chrome (previously `controlBackground` on `windowBackground` nearly hid inputs).
- **Copy polish:** empty conversation text matches whether examples are actually shown; normal completion is **Done** (not `Done · finished` / `endOfTurn`); quiet control chrome shared for Tips/Clear chips.

## Screenshots

### Light mode

<img width="3024" height="1898" alt="image" src="https://github.com/user-attachments/assets/9e3740fd-dc08-4685-84df-52e1a45b0a33" />

### Dark mode

<img width="3024" height="1898" alt="image" src="https://github.com/user-attachments/assets/8003ca12-0cb7-4fc5-aa2e-e8838af6fb02" />

(Installed model, not loaded — shows elevated composer/examples, titled Tips chip, Generate with shortcut, Composer inspector section, Expert cache label, and field contrast.)

## Behavior change details

| Area | Before | After |
| --- | --- | --- |
| HUD after normal reply | `Done · endOfTurn` / `Done · finished` | `Done` |
| Unusual stop | wire-ish labels | `Done · length limit`, etc. |
| Storage shortfall | raw byte integers | formatted shortfall (“more required”) |
| Generate disabled | no reason | help / a11y hint (empty prompt, load, etc.) |
| Prompt / cards | blended into window | elevated cards, field fills, focus ring |
| Empty state + non-empty prompt | promised examples that stay hidden | “Your prompt is ready…” / press Generate |
| Transcript role label | Answer | Assistant |

## Tests run

```bash
swift build -c release          # pass
Scripts/test.sh                 # 646 tests, 121 suites, pass
ruby Scripts/check_markdown_links.rb  # 22 Markdown files, pass
```

Focused coverage added/extended for presentation state and stop-reason display labels (`AppPresentationStateTests`, `AppDiagnosticsTests`).

## Remaining limitations

- Visual contrast is best confirmed by eye after a release rebuild of `TurboFieldfareMac` (theme uses system text/control backgrounds).
- No real-model timing report — inference path and public runtime controls are unchanged.
- Install flow not re-exercised end-to-end in this PR (model already installed on the verification machine).

## Requirements preserved

- macOS 26 / Swift 6.2+ / Metal 4 compatibility
- Bounded-memory model path (no checkpoint/shard/tensor load into Swift heap)
- Public runtime controls limited to those in [Runtime controls](docs/RUNTIME_CONTROLS.md) — labels and help only

By contributing, this work is licensed under Apache License 2.0.
