### PR TITLE
constrain decoding to a json grammar; fix the tool-call malformed 500 (#84)

### DIFF
--- a/Sources/TurboFieldfare/Runtime/Generation/JSONConstraint.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/JSONConstraint.swift
@@ -14,6 +14,11 @@ import Foundation
 /// cannot be decided without lookahead (more digits may follow); `canStop`
 /// reports it as stoppable while `isComplete` stays false until a terminator
 /// byte lands.
+///
+/// Inside strings the automaton validates UTF-8 sequence structure (lead and
+/// continuation ranges per the WHATWG table, rejecting overlongs, surrogates
+/// and > U+10FFFF), so a document it completes is always decodable text — a
+/// grammar-driven fallback can never splice invalid bytes into a string.
 public struct JSONByteAutomaton: Sendable, Equatable {
     /// Containers deeper than this are rejected; matches llama.cpp's default
     /// guard against runaway nesting.
@@ -40,13 +45,21 @@ public struct JSONByteAutomaton: Sendable, Equatable {
 
     private enum Container: Equatable { case object, array }
 
+    /// Mid-UTF-8-sequence state inside a string: how many continuation bytes
+    /// are still owed, and the constrained range for the first of them (E0,
+    /// ED, F0 and F4 leads restrict it; nil means the generic 0x80...0xBF).
+    private struct UTF8Pending: Equatable {
+        var remaining: Int
+        var first: ClosedRange<UInt8>?
+    }
+
     private enum Mode: Equatable {
         case expectValue
         case expectValueOrClose   // right after '['
         case expectKeyOrClose     // right after '{'
         case expectKey            // after ',' inside an object
         case expectColon
-        case inString(isKey: Bool)
+        case inString(isKey: Bool, utf8: UTF8Pending?)
         case stringEscape(isKey: Bool)
         case stringUnicode(isKey: Bool, remaining: Int)
         case inNumber(NumberPhase)
@@ -84,13 +97,13 @@ public struct JSONByteAutomaton: Sendable, Equatable {
 
         case .expectKeyOrClose:
             if isWhitespace(byte) { return true }
-            if byte == UInt8(ascii: "\"") { mode = .inString(isKey: true); return true }
+            if byte == UInt8(ascii: "\"") { mode = .inString(isKey: true, utf8: nil); return true }
             if byte == UInt8(ascii: "}") { return closeContainer() }
             return false
 
         case .expectKey:
             if isWhitespace(byte) { return true }
-            if byte == UInt8(ascii: "\"") { mode = .inString(isKey: true); return true }
+            if byte == UInt8(ascii: "\"") { mode = .inString(isKey: true, utf8: nil); return true }
             return false
 
         case .expectColon:
@@ -98,7 +111,14 @@ public struct JSONByteAutomaton: Sendable, Equatable {
             if byte == UInt8(ascii: ":") { mode = .expectValue; return true }
             return false
 
-        case .inString(let isKey):
+        case .inString(let isKey, let utf8):
+            if let pending = utf8 {
+                guard (pending.first ?? 0x80...0xBF).contains(byte) else { return false }
+                let rest = pending.remaining - 1
+                mode = .inString(isKey: isKey,
+                                 utf8: rest == 0 ? nil : UTF8Pending(remaining: rest, first: nil))
+                return true
+            }
             switch byte {
             case UInt8(ascii: "\""):
                 mode = isKey ? .expectColon : endedValueMode()
@@ -108,7 +128,11 @@ public struct JSONByteAutomaton: Sendable, Equatable {
                 return true
             case 0x00..<0x20:
                 return false
+            case 0x20...0x7F:
+                return true
             default:
+                guard let pending = Self.utf8Lead(byte) else { return false }
+                mode = .inString(isKey: isKey, utf8: pending)
                 return true
             }
 
@@ -117,7 +141,7 @@ public struct JSONByteAutomaton: Sendable, Equatable {
             case UInt8(ascii: "\""), UInt8(ascii: "\\"), UInt8(ascii: "/"),
                  UInt8(ascii: "b"), UInt8(ascii: "f"), UInt8(ascii: "n"),
                  UInt8(ascii: "r"), UInt8(ascii: "t"):
-                mode = .inString(isKey: isKey)
+                mode = .inString(isKey: isKey, utf8: nil)
                 return true
             case UInt8(ascii: "u"):
                 mode = .stringUnicode(isKey: isKey, remaining: 4)
@@ -129,7 +153,7 @@ public struct JSONByteAutomaton: Sendable, Equatable {
         case .stringUnicode(let isKey, let remaining):
             guard isHexDigit(byte) else { return false }
             mode = remaining == 1
-                ? .inString(isKey: isKey)
+                ? .inString(isKey: isKey, utf8: nil)
                 : .stringUnicode(isKey: isKey, remaining: remaining - 1)
             return true
 
@@ -173,7 +197,7 @@ public struct JSONByteAutomaton: Sendable, Equatable {
     private mutating func startValue(_ byte: UInt8) -> Bool {
         switch byte {
         case UInt8(ascii: "\""):
-            mode = .inString(isKey: false)
+            mode = .inString(isKey: false, utf8: nil)
         case UInt8(ascii: "{"):
             guard stack.count < Self.maxDepth else { return false }
             stack.append(.object)
@@ -242,6 +266,25 @@ public struct JSONByteAutomaton: Sendable, Equatable {
         }
     }
 
+    /// WHATWG UTF-8 lead-byte table: continuation count owed plus the
+    /// restricted range for the first continuation where the lead demands one
+    /// (rejects overlongs, surrogates and codepoints past U+10FFFF). Returns
+    /// nil for bytes that cannot start a sequence (bare continuations, C0/C1,
+    /// F5...FF).
+    private static func utf8Lead(_ byte: UInt8) -> UTF8Pending? {
+        switch byte {
+        case 0xC2...0xDF: return UTF8Pending(remaining: 1, first: nil)
+        case 0xE0:        return UTF8Pending(remaining: 2, first: 0xA0...0xBF)
+        case 0xE1...0xEC: return UTF8Pending(remaining: 2, first: nil)
+        case 0xED:        return UTF8Pending(remaining: 2, first: 0x80...0x9F)
+        case 0xEE...0xEF: return UTF8Pending(remaining: 2, first: nil)
+        case 0xF0:        return UTF8Pending(remaining: 3, first: 0x90...0xBF)
+        case 0xF1...0xF3: return UTF8Pending(remaining: 3, first: nil)
+        case 0xF4:        return UTF8Pending(remaining: 3, first: 0x80...0x8F)
+        default:          return nil
+        }
+    }
+
     private func isWhitespace(_ byte: UInt8) -> Bool {
         byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D
     }
@@ -272,7 +315,7 @@ public final class JSONTokenFilter {
     private var byteCache: [Int32: [UInt8]] = [:]
     private var blockedCache: Set<Int32> = []
 
-    public convenience init(tokenizer: GFTokenizer) {
+    public convenience init(tokenizer: GFTokenizer, extraStopIDs: Set<Int32> = []) {
         let underlying = tokenizer.tokenizer
         self.init(
             pieceLookup: { underlying.convertIdToToken(Int($0)) },
@@ -280,7 +323,7 @@ public final class JSONTokenFilter {
                          tokenizer.toolCallStartID, tokenizer.toolCallEndID,
                          tokenizer.toolResponseID, tokenizer.toolResponseEndID,
                          tokenizer.channelStartID, tokenizer.channelEndID],
-            stopIDs: tokenizer.stopTokenIDs)
+            stopIDs: tokenizer.stopTokenIDs.union(extraStopIDs))
     }
 
     public init(pieceLookup: @escaping PieceLookup,
@@ -293,17 +336,37 @@ public final class JSONTokenFilter {
 
     public var isComplete: Bool { automaton.isComplete }
 
+    /// Times the grammar rejected the sampled token, forcing the
+    /// probability-ordered fallback. Recorded by the generation loop.
+    public private(set) var vetoCount = 0
+
+    public func noteVeto() { vetoCount += 1 }
+
+    /// Raw bytes of the last content token `tryAccept` committed (empty for
+    /// an accepted stop token). The generation loop emits THESE bytes instead
+    /// of detokenizer text under forceJSON: the detokenizer's `cleanUp` pass
+    /// (` ,` → `,` — swift-transformers defaults it on) and its strict flush
+    /// of byte-fallback tails can both drop grammar-validated bytes, breaking
+    /// the valid-JSON guarantee at the output while the automaton believes it
+    /// held.
+    public private(set) var lastAcceptedBytes: [UInt8] = []
+
     /// True when the token may be emitted next: stop tokens pass only where
     /// EOS would leave valid JSON; content tokens pass when every byte
     /// advances the automaton (committed on success).
     public func tryAccept(_ id: Int32) -> Bool {
-        if stopIDs.contains(id) { return automaton.canStop }
+        if stopIDs.contains(id) {
+            guard automaton.canStop else { return false }
+            lastAcceptedBytes = []
+            return true
+        }
         guard let bytes = bytes(for: id), !bytes.isEmpty else { return false }
         var candidate = automaton
         for byte in bytes {
             guard candidate.consume(byte) else { return false }
         }
         automaton = candidate
+        lastAcceptedBytes = bytes
         return true
     }
 
@@ -343,11 +406,60 @@ public final class JSONTokenFilter {
     }
 
     /// Whole-piece `<...>` shapes (e.g. `<unused12>`, `<start_of_image>`) are
-    /// added tokens the detokenizer strips; never let them through.
+    /// added tokens that signal a derailed generation; never let them through.
+    /// This also blocks the vocab's ~97 legitimate single-piece HTML tags
+    /// (`<td>`, `<div>`) — accepted cost: the model can still spell them from
+    /// smaller pieces.
     private static func looksLikeMarker(_ token: String) -> Bool {
         guard token.count > 2, token.hasPrefix("<"), token.hasSuffix(">") else {
             return false
         }
         return !token.dropFirst().dropLast().contains { $0 == "<" || $0 == ">" }
+    }
+}
+
+/// Reassembles the grammar-validated byte stream into printable `String`
+/// deltas, holding back a trailing UTF-8 sequence a token boundary split.
+/// The automaton guarantees the bytes are structurally valid UTF-8, so the
+/// only incomplete point is the tail.
+public struct UTF8StreamAssembler: Sendable {
+    private var pending: [UInt8] = []
+
+    public init() {}
+
+    public mutating func push(_ bytes: [UInt8]) -> String {
+        pending.append(contentsOf: bytes)
+        let cut = Self.completePrefixLength(pending)
+        guard cut > 0 else { return "" }
+        let out = String(decoding: pending[..<cut], as: UTF8.self)
+        pending.removeFirst(cut)
+        return out
+    }
+
+    /// Truncation by max-new can end mid-codepoint; the incomplete tail is
+    /// dropped (mirrors the detokenizer). A COMPLETE document never loses
+    /// bytes here — the automaton refuses to close a string mid-sequence.
+    public mutating func flush() -> String {
+        defer { pending = [] }
+        let cut = Self.completePrefixLength(pending)
+        return cut > 0 ? String(decoding: pending[..<cut], as: UTF8.self) : ""
+    }
+
+    private static func completePrefixLength(_ bytes: [UInt8]) -> Int {
+        var i = bytes.count
+        var trailing = 0
+        while i > 0, trailing < 3, bytes[i - 1] & 0xC0 == 0x80 {
+            i -= 1
+            trailing += 1
+        }
+        guard i > 0 else { return bytes.count }
+        let needed: Int
+        switch bytes[i - 1] {
+        case 0xC2...0xDF: needed = 1
+        case 0xE0...0xEF: needed = 2
+        case 0xF0...0xF4: needed = 3
+        default: return bytes.count   // ASCII tail: nothing pending
+        }
+        return trailing >= needed ? bytes.count : i - 1
     }
 }

--- a/Sources/TurboFieldfare/Runtime/Generation/JSONConstraint.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/JSONConstraint.swift
@@ -1,0 +1,353 @@
+import Foundation
+
+/// Byte-level JSON acceptor for constrained decoding.
+///
+/// Operates on raw UTF-8 bytes so tokenizer pieces that split multi-byte
+/// codepoints (byte-fallback `<0xNN>` tokens, SentencePiece surface splits)
+/// never confuse it: inside a string every byte ≥ 0x20 is legal, including
+/// UTF-8 continuation bytes, so a codepoint split across two tokens is
+/// accepted byte by byte.
+///
+/// The grammar is RFC 8259 JSON with one permissive edge: `\uXXXX` escapes are
+/// validated as four hex digits without pairing surrogates. Root may be any
+/// JSON value. A root-level bare number is the one case where "complete"
+/// cannot be decided without lookahead (more digits may follow); `canStop`
+/// reports it as stoppable while `isComplete` stays false until a terminator
+/// byte lands.
+public struct JSONByteAutomaton: Sendable, Equatable {
+    /// Containers deeper than this are rejected; matches llama.cpp's default
+    /// guard against runaway nesting.
+    public static let maxDepth = 128
+
+    private enum NumberPhase: Equatable {
+        case afterMinus
+        case leadingZero
+        case intDigits
+        case afterDot
+        case fracDigits
+        case afterExpMark
+        case afterExpSign
+        case expDigits
+
+        /// Phases at which the number is a valid JSON number if it ends here.
+        var isTerminal: Bool {
+            switch self {
+            case .leadingZero, .intDigits, .fracDigits, .expDigits: return true
+            case .afterMinus, .afterDot, .afterExpMark, .afterExpSign: return false
+            }
+        }
+    }
+
+    private enum Container: Equatable { case object, array }
+
+    private enum Mode: Equatable {
+        case expectValue
+        case expectValueOrClose   // right after '['
+        case expectKeyOrClose     // right after '{'
+        case expectKey            // after ',' inside an object
+        case expectColon
+        case inString(isKey: Bool)
+        case stringEscape(isKey: Bool)
+        case stringUnicode(isKey: Bool, remaining: Int)
+        case inNumber(NumberPhase)
+        case inLiteral([UInt8])   // remaining bytes of true/false/null
+        case afterValue
+        case complete
+    }
+
+    private var stack: [Container] = []
+    private var mode: Mode = .expectValue
+
+    public init() {}
+
+    /// The root value is closed; only trailing whitespace may follow.
+    public var isComplete: Bool { mode == .complete }
+
+    /// EOS would leave valid JSON here. True at `complete`, and also for a
+    /// root-level bare number sitting on a terminal phase.
+    public var canStop: Bool {
+        if mode == .complete { return true }
+        if case .inNumber(let phase) = mode, stack.isEmpty { return phase.isTerminal }
+        return false
+    }
+
+    /// Feed one byte. Returns false — leaving the automaton unchanged — when
+    /// the byte cannot extend a valid JSON document.
+    public mutating func consume(_ byte: UInt8) -> Bool {
+        switch mode {
+        case .expectValue, .expectValueOrClose:
+            if isWhitespace(byte) { return true }
+            if byte == UInt8(ascii: "]"), mode == .expectValueOrClose {
+                return closeContainer()
+            }
+            return startValue(byte)
+
+        case .expectKeyOrClose:
+            if isWhitespace(byte) { return true }
+            if byte == UInt8(ascii: "\"") { mode = .inString(isKey: true); return true }
+            if byte == UInt8(ascii: "}") { return closeContainer() }
+            return false
+
+        case .expectKey:
+            if isWhitespace(byte) { return true }
+            if byte == UInt8(ascii: "\"") { mode = .inString(isKey: true); return true }
+            return false
+
+        case .expectColon:
+            if isWhitespace(byte) { return true }
+            if byte == UInt8(ascii: ":") { mode = .expectValue; return true }
+            return false
+
+        case .inString(let isKey):
+            switch byte {
+            case UInt8(ascii: "\""):
+                mode = isKey ? .expectColon : endedValueMode()
+                return true
+            case UInt8(ascii: "\\"):
+                mode = .stringEscape(isKey: isKey)
+                return true
+            case 0x00..<0x20:
+                return false
+            default:
+                return true
+            }
+
+        case .stringEscape(let isKey):
+            switch byte {
+            case UInt8(ascii: "\""), UInt8(ascii: "\\"), UInt8(ascii: "/"),
+                 UInt8(ascii: "b"), UInt8(ascii: "f"), UInt8(ascii: "n"),
+                 UInt8(ascii: "r"), UInt8(ascii: "t"):
+                mode = .inString(isKey: isKey)
+                return true
+            case UInt8(ascii: "u"):
+                mode = .stringUnicode(isKey: isKey, remaining: 4)
+                return true
+            default:
+                return false
+            }
+
+        case .stringUnicode(let isKey, let remaining):
+            guard isHexDigit(byte) else { return false }
+            mode = remaining == 1
+                ? .inString(isKey: isKey)
+                : .stringUnicode(isKey: isKey, remaining: remaining - 1)
+            return true
+
+        case .inNumber(let phase):
+            if let next = numberPhase(phase, byte) {
+                mode = .inNumber(next)
+                return true
+            }
+            guard phase.isTerminal else { return false }
+            // The number ends where a non-number byte lands; close the value
+            // and let the terminator byte act on the new mode.
+            let saved = mode
+            mode = endedValueMode()
+            if consume(byte) { return true }
+            mode = saved
+            return false
+
+        case .inLiteral(let remaining):
+            guard byte == remaining.first else { return false }
+            let rest = Array(remaining.dropFirst())
+            mode = rest.isEmpty ? endedValueMode() : .inLiteral(rest)
+            return true
+
+        case .afterValue:
+            if isWhitespace(byte) { return true }
+            switch (stack.last, byte) {
+            case (.object, UInt8(ascii: ",")): mode = .expectKey; return true
+            case (.object, UInt8(ascii: "}")): return closeContainer()
+            case (.array, UInt8(ascii: ",")): mode = .expectValue; return true
+            case (.array, UInt8(ascii: "]")): return closeContainer()
+            default: return false
+            }
+
+        case .complete:
+            return isWhitespace(byte)
+        }
+    }
+
+    // MARK: - Transitions
+
+    private mutating func startValue(_ byte: UInt8) -> Bool {
+        switch byte {
+        case UInt8(ascii: "\""):
+            mode = .inString(isKey: false)
+        case UInt8(ascii: "{"):
+            guard stack.count < Self.maxDepth else { return false }
+            stack.append(.object)
+            mode = .expectKeyOrClose
+        case UInt8(ascii: "["):
+            guard stack.count < Self.maxDepth else { return false }
+            stack.append(.array)
+            mode = .expectValueOrClose
+        case UInt8(ascii: "t"):
+            mode = .inLiteral(Array("rue".utf8))
+        case UInt8(ascii: "f"):
+            mode = .inLiteral(Array("alse".utf8))
+        case UInt8(ascii: "n"):
+            mode = .inLiteral(Array("ull".utf8))
+        case UInt8(ascii: "-"):
+            mode = .inNumber(.afterMinus)
+        case UInt8(ascii: "0"):
+            mode = .inNumber(.leadingZero)
+        case UInt8(ascii: "1")...UInt8(ascii: "9"):
+            mode = .inNumber(.intDigits)
+        default:
+            return false
+        }
+        return true
+    }
+
+    private mutating func closeContainer() -> Bool {
+        stack.removeLast()
+        mode = stack.isEmpty ? .complete : .afterValue
+        return true
+    }
+
+    private func endedValueMode() -> Mode {
+        stack.isEmpty ? .complete : .afterValue
+    }
+
+    private func numberPhase(_ phase: NumberPhase, _ byte: UInt8) -> NumberPhase? {
+        let isDigit = (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte)
+        switch phase {
+        case .afterMinus:
+            guard isDigit else { return nil }
+            return byte == UInt8(ascii: "0") ? .leadingZero : .intDigits
+        case .leadingZero:
+            if byte == UInt8(ascii: ".") { return .afterDot }
+            if byte == UInt8(ascii: "e") || byte == UInt8(ascii: "E") { return .afterExpMark }
+            return nil
+        case .intDigits:
+            if isDigit { return .intDigits }
+            if byte == UInt8(ascii: ".") { return .afterDot }
+            if byte == UInt8(ascii: "e") || byte == UInt8(ascii: "E") { return .afterExpMark }
+            return nil
+        case .afterDot:
+            return isDigit ? .fracDigits : nil
+        case .fracDigits:
+            if isDigit { return .fracDigits }
+            if byte == UInt8(ascii: "e") || byte == UInt8(ascii: "E") { return .afterExpMark }
+            return nil
+        case .afterExpMark:
+            if isDigit { return .expDigits }
+            if byte == UInt8(ascii: "+") || byte == UInt8(ascii: "-") { return .afterExpSign }
+            return nil
+        case .afterExpSign:
+            return isDigit ? .expDigits : nil
+        case .expDigits:
+            return isDigit ? .expDigits : nil
+        }
+    }
+
+    private func isWhitespace(_ byte: UInt8) -> Bool {
+        byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D
+    }
+
+    private func isHexDigit(_ byte: UInt8) -> Bool {
+        (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte)
+            || (UInt8(ascii: "a")...UInt8(ascii: "f")).contains(byte)
+            || (UInt8(ascii: "A")...UInt8(ascii: "F")).contains(byte)
+    }
+}
+
+/// Filters sampled token ids through `JSONByteAutomaton` for one generation.
+///
+/// Token → bytes goes through the tokenizer's piece table, not `decode()`:
+/// SentencePiece pieces carry the space marker `▁` (mapped to a space) and
+/// byte-fallback pieces `<0xNN>` carry one raw byte. Special/control tokens
+/// (turn, channel, tool markers) are never valid JSON output and are blocked
+/// by id; unknown `<...>` marker-shaped pieces are blocked by pattern because
+/// the detokenizer strips them from the output, which would desync the
+/// automaton from the emitted text.
+public final class JSONTokenFilter {
+    public typealias PieceLookup = (Int32) -> String?
+
+    private let piece: PieceLookup
+    private let blockedIDs: Set<Int32>
+    private let stopIDs: Set<Int32>
+    private var automaton = JSONByteAutomaton()
+    private var byteCache: [Int32: [UInt8]] = [:]
+    private var blockedCache: Set<Int32> = []
+
+    public convenience init(tokenizer: GFTokenizer) {
+        let underlying = tokenizer.tokenizer
+        self.init(
+            pieceLookup: { underlying.convertIdToToken(Int($0)) },
+            blockedIDs: [tokenizer.bosID, tokenizer.padID,
+                         tokenizer.toolCallStartID, tokenizer.toolCallEndID,
+                         tokenizer.toolResponseID, tokenizer.toolResponseEndID,
+                         tokenizer.channelStartID, tokenizer.channelEndID],
+            stopIDs: tokenizer.stopTokenIDs)
+    }
+
+    public init(pieceLookup: @escaping PieceLookup,
+                blockedIDs: Set<Int32>,
+                stopIDs: Set<Int32>) {
+        self.piece = pieceLookup
+        self.blockedIDs = blockedIDs.union(stopIDs)
+        self.stopIDs = stopIDs
+    }
+
+    public var isComplete: Bool { automaton.isComplete }
+
+    /// True when the token may be emitted next: stop tokens pass only where
+    /// EOS would leave valid JSON; content tokens pass when every byte
+    /// advances the automaton (committed on success).
+    public func tryAccept(_ id: Int32) -> Bool {
+        if stopIDs.contains(id) { return automaton.canStop }
+        guard let bytes = bytes(for: id), !bytes.isEmpty else { return false }
+        var candidate = automaton
+        for byte in bytes {
+            guard candidate.consume(byte) else { return false }
+        }
+        automaton = candidate
+        return true
+    }
+
+    // MARK: - Token bytes
+
+    private static let spaceMarker = "\u{2581}"
+
+    private func bytes(for id: Int32) -> [UInt8]? {
+        if blockedCache.contains(id) { return nil }
+        if let cached = byteCache[id] { return cached }
+        guard !blockedIDs.contains(id), let raw = piece(id), !raw.isEmpty else {
+            blockedCache.insert(id)
+            return nil
+        }
+        let resolved: [UInt8]?
+        if let byte = Self.byteFallback(raw) {
+            resolved = [byte]
+        } else if Self.looksLikeMarker(raw) {
+            resolved = nil
+        } else {
+            resolved = Array(raw.replacingOccurrences(of: Self.spaceMarker,
+                                                      with: " ").utf8)
+        }
+        guard let resolved else {
+            blockedCache.insert(id)
+            return nil
+        }
+        byteCache[id] = resolved
+        return resolved
+    }
+
+    private static func byteFallback(_ token: String) -> UInt8? {
+        guard token.count == 6, token.hasPrefix("<0x"), token.hasSuffix(">") else {
+            return nil
+        }
+        return UInt8(token.dropFirst(3).dropLast(), radix: 16)
+    }
+
+    /// Whole-piece `<...>` shapes (e.g. `<unused12>`, `<start_of_image>`) are
+    /// added tokens the detokenizer strips; never let them through.
+    private static func looksLikeMarker(_ token: String) -> Bool {
+        guard token.count > 2, token.hasPrefix("<"), token.hasSuffix(">") else {
+            return false
+        }
+        return !token.dropFirst().dropLast().contains { $0 == "<" || $0 == ">" }
+    }
+}

--- a/Sources/TurboFieldfare/Runtime/Generation/JSONConstraint.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/JSONConstraint.swift
@@ -8,9 +8,11 @@ import Foundation
 /// UTF-8 continuation bytes, so a codepoint split across two tokens is
 /// accepted byte by byte.
 ///
-/// The grammar is RFC 8259 JSON with one permissive edge: `\uXXXX` escapes are
-/// validated as four hex digits without pairing surrogates. Root may be any
-/// JSON value. A root-level bare number is the one case where "complete"
+/// The grammar is RFC 8259 JSON with surrogate pairing enforced in `\uXXXX`
+/// escapes: a high surrogate must be followed immediately by `\u` + a low
+/// surrogate, and a lone low surrogate is rejected — Foundation's JSON
+/// parsers refuse lone surrogates, so allowing them would break the
+/// decodable-output guarantee. Root may be any JSON value. A root-level bare number is the one case where "complete"
 /// cannot be decided without lookahead (more digits may follow); `canStop`
 /// reports it as stoppable while `isComplete` stays false until a terminator
 /// byte lands.
@@ -61,7 +63,9 @@ public struct JSONByteAutomaton: Sendable, Equatable {
         case expectColon
         case inString(isKey: Bool, utf8: UTF8Pending?)
         case stringEscape(isKey: Bool)
-        case stringUnicode(isKey: Bool, remaining: Int)
+        case stringUnicode(isKey: Bool, remaining: Int, value: UInt16, expectLow: Bool)
+        // A completed high surrogate owes exactly `\` + `u` + a low escape.
+        case stringHighSurrogate(isKey: Bool, sawBackslash: Bool)
         case inNumber(NumberPhase)
         case inLiteral([UInt8])   // remaining bytes of true/false/null
         case afterValue
@@ -144,17 +148,41 @@ public struct JSONByteAutomaton: Sendable, Equatable {
                 mode = .inString(isKey: isKey, utf8: nil)
                 return true
             case UInt8(ascii: "u"):
-                mode = .stringUnicode(isKey: isKey, remaining: 4)
+                mode = .stringUnicode(isKey: isKey, remaining: 4, value: 0, expectLow: false)
                 return true
             default:
                 return false
             }
 
-        case .stringUnicode(let isKey, let remaining):
-            guard isHexDigit(byte) else { return false }
-            mode = remaining == 1
-                ? .inString(isKey: isKey, utf8: nil)
-                : .stringUnicode(isKey: isKey, remaining: remaining - 1)
+        case .stringUnicode(let isKey, let remaining, let value, let expectLow):
+            guard let digit = hexValue(byte) else { return false }
+            let accumulated = value << 4 | UInt16(digit)
+            if remaining > 1 {
+                mode = .stringUnicode(isKey: isKey, remaining: remaining - 1,
+                                      value: accumulated, expectLow: expectLow)
+                return true
+            }
+            let isHigh = (0xD800...0xDBFF).contains(accumulated)
+            let isLow = (0xDC00...0xDFFF).contains(accumulated)
+            if expectLow {
+                guard isLow else { return false }
+                mode = .inString(isKey: isKey, utf8: nil)
+                return true
+            }
+            if isLow { return false }               // lone low surrogate
+            mode = isHigh
+                ? .stringHighSurrogate(isKey: isKey, sawBackslash: false)
+                : .inString(isKey: isKey, utf8: nil)
+            return true
+
+        case .stringHighSurrogate(let isKey, let sawBackslash):
+            if !sawBackslash {
+                guard byte == UInt8(ascii: "\\") else { return false }
+                mode = .stringHighSurrogate(isKey: isKey, sawBackslash: true)
+                return true
+            }
+            guard byte == UInt8(ascii: "u") else { return false }
+            mode = .stringUnicode(isKey: isKey, remaining: 4, value: 0, expectLow: true)
             return true
 
         case .inNumber(let phase):
@@ -289,10 +317,13 @@ public struct JSONByteAutomaton: Sendable, Equatable {
         byte == 0x20 || byte == 0x09 || byte == 0x0A || byte == 0x0D
     }
 
-    private func isHexDigit(_ byte: UInt8) -> Bool {
-        (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte)
-            || (UInt8(ascii: "a")...UInt8(ascii: "f")).contains(byte)
-            || (UInt8(ascii: "A")...UInt8(ascii: "F")).contains(byte)
+    private func hexValue(_ byte: UInt8) -> UInt8? {
+        switch byte {
+        case UInt8(ascii: "0")...UInt8(ascii: "9"): return byte - UInt8(ascii: "0")
+        case UInt8(ascii: "a")...UInt8(ascii: "f"): return byte - UInt8(ascii: "a") + 10
+        case UInt8(ascii: "A")...UInt8(ascii: "F"): return byte - UInt8(ascii: "A") + 10
+        default: return nil
+        }
     }
 }
 

--- a/Sources/TurboFieldfare/Runtime/Generation/JSONConstraint.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/JSONConstraint.swift
@@ -23,15 +23,40 @@ import Foundation
 /// grammar-driven fallback can never splice invalid bytes into a string.
 public struct JSONByteAutomaton: Sendable, Equatable {
     /// Containers deeper than this are rejected; matches llama.cpp's default
-    /// guard against runaway nesting.
+    /// guard against runaway nesting. It also bounds the unbounded recursion in
+    /// `GemmaToolCallParser`'s `object()`/`value()`.
     public static let maxDepth = 128
+
+    /// Which language the automaton accepts. `.strict` is RFC 8259 — the
+    /// `--force-json` path, unchanged. `.gemmaToolArguments` is the tool-call
+    /// argument dialect the Gemma 4 chat template renders and
+    /// `GemmaToolCallParser` reads: an object root with BARE keys at every
+    /// depth, strings delimited by the `<|"|>` escape token instead of quotes,
+    /// and bounded numbers with no exponent.
+    public enum Dialect: Sendable, Equatable {
+        case strict
+        case gemmaToolArguments
+    }
+
+    /// The tokenizer's escape token, used verbatim as the dialect's string
+    /// delimiter. It has no proper border, so its KMP failure function is
+    /// identically zero: on a mismatch the matcher resets to zero and
+    /// re-dispatches the current byte, which is byte for byte the leftmost scan
+    /// `GemmaToolCallParser.gemmaString()` performs.
+    private static let gemmaDelimiter = Array(#"<|"|>"#.utf8)
+
+    /// Digits accepted on each side of the decimal point in the Gemma dialect.
+    /// `Decimal(string:)` returns nil past an implementation-defined magnitude
+    /// and the parser turns that nil into `.malformed`, so bounding the literal
+    /// removes Foundation's boundary from the subset argument.
+    private static let maximumNumberDigits = 15
 
     private enum NumberPhase: Equatable {
         case afterMinus
         case leadingZero
-        case intDigits
+        case intDigits(Int)
         case afterDot
-        case fracDigits
+        case fracDigits(Int)
         case afterExpMark
         case afterExpSign
         case expDigits
@@ -48,11 +73,33 @@ public struct JSONByteAutomaton: Sendable, Equatable {
     private enum Container: Equatable { case object, array }
 
     /// Mid-UTF-8-sequence state inside a string: how many continuation bytes
-    /// are still owed, and the constrained range for the first of them (E0,
-    /// ED, F0 and F4 leads restrict it; nil means the generic 0x80...0xBF).
+    /// are still owed, the constrained range for the first of them (E0, ED, F0
+    /// and F4 leads restrict it; nil means the generic 0x80...0xBF), and the
+    /// scalar accumulated so far — the Gemma dialect needs the finished scalar
+    /// to decide whether it grapheme-merges with a following delimiter byte.
     private struct UTF8Pending: Equatable {
         var remaining: Int
         var first: ClosedRange<UInt8>?
+        var value: UInt32
+    }
+
+    /// Which production a string belongs to. One implementation of the escape
+    /// and surrogate rules serves all three, so the hardened `\uXXXX` handling
+    /// cannot drift between dialects.
+    private enum StringKind: Equatable { case objectKey, value, gemmaValue }
+
+    /// `GemmaToolCallParser` lexes an `[Character]`, so a raw scalar that
+    /// grapheme-joins with an adjacent ASCII character hides that character from
+    /// it. Both directions have to be blocked inside a `<|"|>` string.
+    private enum GraphemeGuard: Equatable {
+        case none
+        /// The previous scalar is Grapheme_Cluster_Break=Prepend: it would
+        /// swallow a following `<` (the closing delimiter) or `\` (an escape).
+        case forward
+        /// The previous character is structurally significant to the parser —
+        /// the opening delimiter's `>`, or the last character of an escape — so
+        /// a combining scalar here would fuse with it and hide it.
+        case backward
     }
 
     private enum Mode: Equatable {
@@ -61,11 +108,15 @@ public struct JSONByteAutomaton: Sendable, Equatable {
         case expectKeyOrClose     // right after '{'
         case expectKey            // after ',' inside an object
         case expectColon
-        case inString(isKey: Bool, utf8: UTF8Pending?)
-        case stringEscape(isKey: Bool)
-        case stringUnicode(isKey: Bool, remaining: Int, value: UInt16, expectLow: Bool)
+        case inString(kind: StringKind, utf8: UTF8Pending?)
+        case stringEscape(kind: StringKind)
+        case stringUnicode(kind: StringKind, remaining: Int, value: UInt16, expectLow: Bool)
         // A completed high surrogate owes exactly `\` + `u` + a low escape.
-        case stringHighSurrogate(isKey: Bool, sawBackslash: Bool)
+        case stringHighSurrogate(kind: StringKind, sawBackslash: Bool)
+        case inBareKey                                  // Gemma dialect only
+        case gemmaOpen(matched: Int)                    // 1...4 delimiter bytes
+        // `delimiter > 0` implies `utf8 == nil`: a partial delimiter is ASCII.
+        case inGemmaString(delimiter: Int, utf8: UTF8Pending?, guard: GraphemeGuard)
         case inNumber(NumberPhase)
         case inLiteral([UInt8])   // remaining bytes of true/false/null
         case afterValue
@@ -75,7 +126,11 @@ public struct JSONByteAutomaton: Sendable, Equatable {
     private var stack: [Container] = []
     private var mode: Mode = .expectValue
 
-    public init() {}
+    public let dialect: Dialect
+
+    public init(dialect: Dialect = .strict) {
+        self.dialect = dialect
+    }
 
     /// The root value is closed; only trailing whitespace may follow.
     public var isComplete: Bool { mode == .complete }
@@ -101,34 +156,40 @@ public struct JSONByteAutomaton: Sendable, Equatable {
 
         case .expectKeyOrClose:
             if isWhitespace(byte) { return true }
-            if byte == UInt8(ascii: "\"") { mode = .inString(isKey: true, utf8: nil); return true }
             if byte == UInt8(ascii: "}") { return closeContainer() }
-            return false
+            return startKey(byte)
 
         case .expectKey:
             if isWhitespace(byte) { return true }
-            if byte == UInt8(ascii: "\"") { mode = .inString(isKey: true, utf8: nil); return true }
-            return false
+            return startKey(byte)
 
         case .expectColon:
             if isWhitespace(byte) { return true }
             if byte == UInt8(ascii: ":") { mode = .expectValue; return true }
             return false
 
-        case .inString(let isKey, let utf8):
+        case .inBareKey:
+            if isWhitespace(byte) { mode = .expectColon; return true }
+            if byte == UInt8(ascii: ":") { mode = .expectValue; return true }
+            return Self.isBareKeyByte(byte)
+
+        case .inString(let kind, let utf8):
             if let pending = utf8 {
                 guard (pending.first ?? 0x80...0xBF).contains(byte) else { return false }
                 let rest = pending.remaining - 1
-                mode = .inString(isKey: isKey,
-                                 utf8: rest == 0 ? nil : UTF8Pending(remaining: rest, first: nil))
+                mode = .inString(kind: kind,
+                                 utf8: rest == 0
+                                     ? nil
+                                     : UTF8Pending(remaining: rest, first: nil,
+                                                   value: pending.value << 6 | UInt32(byte & 0x3F)))
                 return true
             }
             switch byte {
             case UInt8(ascii: "\""):
-                mode = isKey ? .expectColon : endedValueMode()
+                mode = closedStringMode(kind)
                 return true
             case UInt8(ascii: "\\"):
-                mode = .stringEscape(isKey: isKey)
+                mode = .stringEscape(kind: kind)
                 return true
             case 0x00..<0x20:
                 return false
@@ -136,29 +197,116 @@ public struct JSONByteAutomaton: Sendable, Equatable {
                 return true
             default:
                 guard let pending = Self.utf8Lead(byte) else { return false }
-                mode = .inString(isKey: isKey, utf8: pending)
+                mode = .inString(kind: kind, utf8: pending)
                 return true
             }
 
-        case .stringEscape(let isKey):
+        case .gemmaOpen(let matched):
+            guard byte == Self.gemmaDelimiter[matched] else { return false }
+            mode = matched == Self.gemmaDelimiter.count - 1
+                ? .inGemmaString(delimiter: 0, utf8: nil, guard: .backward)
+                : .gemmaOpen(matched: matched + 1)
+            return true
+
+        case .inGemmaString(let delimiter, let utf8, let graphemeGuard):
+            if let pending = utf8 {
+                guard (pending.first ?? 0x80...0xBF).contains(byte) else { return false }
+                let accumulated = pending.value << 6 | UInt32(byte & 0x3F)
+                let rest = pending.remaining - 1
+                if rest == 0 {
+                    guard let scalar = Unicode.Scalar(accumulated) else { return false }
+                    if graphemeGuard == .backward, Self.mergesBackward(scalar) { return false }
+                    mode = .inGemmaString(delimiter: 0, utf8: nil,
+                                          guard: Self.mergesForward(scalar) ? .forward : .none)
+                    return true
+                }
+                let next = UTF8Pending(remaining: rest, first: nil, value: accumulated)
+                // Prune sequence prefixes every continuation byte would have to
+                // reject, which would strand the fallback scan mid-codepoint:
+                // after `CC` under a backward guard all 64 completions are
+                // combining marks.
+                guard graphemeGuard != .backward
+                        || Self.rangeHasGraphemeBase(Self.pendingScalarRange(next)) else {
+                    return false
+                }
+                mode = .inGemmaString(delimiter: 0, utf8: next, guard: graphemeGuard)
+                return true
+            }
+            if delimiter > 0 {
+                if byte == Self.gemmaDelimiter[delimiter] {
+                    mode = delimiter == Self.gemmaDelimiter.count - 1
+                        ? endedValueMode()
+                        : .inGemmaString(delimiter: delimiter + 1, utf8: nil, guard: .none)
+                    return true
+                }
+                mode = .inGemmaString(delimiter: 0, utf8: nil, guard: .none)
+                return consume(byte)
+            }
+            switch byte {
+            case UInt8(ascii: "<"):
+                // A Prepend scalar would swallow this byte in the parser's
+                // grapheme-cluster lexer, hiding the closing delimiter.
+                guard graphemeGuard != .forward else { return false }
+                mode = .inGemmaString(delimiter: 1, utf8: nil, guard: .none)
+                return true
+            case UInt8(ascii: "\\"):
+                guard graphemeGuard != .forward else { return false }
+                mode = .stringEscape(kind: .gemmaValue)
+                return true
+            case 0x09, 0x0A, 0x0D:
+                mode = .inGemmaString(delimiter: 0, utf8: nil, guard: .none)
+                return true
+            case 0x00..<0x20:
+                return false
+            case 0x20...0x7F:
+                // ASCII never joins backwards onto an ASCII character, so it
+                // always clears the guard and is always available — which is
+                // what keeps the fallback scan from running out of options.
+                mode = .inGemmaString(delimiter: 0, utf8: nil, guard: .none)
+                return true
+            default:
+                guard let pending = Self.utf8Lead(byte) else { return false }
+                guard graphemeGuard != .backward
+                        || Self.rangeHasGraphemeBase(Self.pendingScalarRange(pending)) else {
+                    return false
+                }
+                mode = .inGemmaString(delimiter: 0, utf8: pending, guard: graphemeGuard)
+                return true
+            }
+
+        case .stringEscape(let kind):
             switch byte {
             case UInt8(ascii: "\""), UInt8(ascii: "\\"), UInt8(ascii: "/"),
                  UInt8(ascii: "b"), UInt8(ascii: "f"), UInt8(ascii: "n"),
                  UInt8(ascii: "r"), UInt8(ascii: "t"):
-                mode = .inString(isKey: isKey, utf8: nil)
+                mode = openStringMode(kind)
                 return true
             case UInt8(ascii: "u"):
-                mode = .stringUnicode(isKey: isKey, remaining: 4, value: 0, expectLow: false)
+                mode = .stringUnicode(kind: kind, remaining: 4, value: 0, expectLow: false)
                 return true
             default:
                 return false
             }
 
-        case .stringUnicode(let isKey, let remaining, let value, let expectLow):
+        case .stringUnicode(let kind, let remaining, let value, let expectLow):
             guard let digit = hexValue(byte) else { return false }
             let accumulated = value << 4 | UInt16(digit)
             if remaining > 1 {
-                mode = .stringUnicode(isKey: isKey, remaining: remaining - 1,
+                // Prune escape prefixes no digit can complete, or the fallback
+                // scan strands the automaton mid-escape with the whole
+                // vocabulary vetoed: after `\udc2` every hex digit spells a
+                // lone low surrogate, and under `\u` + expectLow every prefix
+                // outside D8...DF can never reach one.
+                let shift = UInt16(4 * (remaining - 1))
+                let lowest = accumulated << shift
+                let highest = lowest | ((1 << shift) - 1)
+                let lowSurrogates: ClosedRange<UInt16> = 0xDC00...0xDFFF
+                let reachable = expectLow
+                    ? (lowest...highest).overlaps(lowSurrogates)
+                    : !(lowest >= lowSurrogates.lowerBound
+                        && highest <= lowSurrogates.upperBound)
+                guard reachable else { return false }
+                mode = .stringUnicode(kind: kind, remaining: remaining - 1,
                                       value: accumulated, expectLow: expectLow)
                 return true
             }
@@ -166,23 +314,23 @@ public struct JSONByteAutomaton: Sendable, Equatable {
             let isLow = (0xDC00...0xDFFF).contains(accumulated)
             if expectLow {
                 guard isLow else { return false }
-                mode = .inString(isKey: isKey, utf8: nil)
+                mode = openStringMode(kind)
                 return true
             }
             if isLow { return false }               // lone low surrogate
             mode = isHigh
-                ? .stringHighSurrogate(isKey: isKey, sawBackslash: false)
-                : .inString(isKey: isKey, utf8: nil)
+                ? .stringHighSurrogate(kind: kind, sawBackslash: false)
+                : openStringMode(kind)
             return true
 
-        case .stringHighSurrogate(let isKey, let sawBackslash):
+        case .stringHighSurrogate(let kind, let sawBackslash):
             if !sawBackslash {
                 guard byte == UInt8(ascii: "\\") else { return false }
-                mode = .stringHighSurrogate(isKey: isKey, sawBackslash: true)
+                mode = .stringHighSurrogate(kind: kind, sawBackslash: true)
                 return true
             }
             guard byte == UInt8(ascii: "u") else { return false }
-            mode = .stringUnicode(isKey: isKey, remaining: 4, value: 0, expectLow: true)
+            mode = .stringUnicode(kind: kind, remaining: 4, value: 0, expectLow: true)
             return true
 
         case .inNumber(let phase):
@@ -222,10 +370,40 @@ public struct JSONByteAutomaton: Sendable, Equatable {
 
     // MARK: - Transitions
 
+    /// An object key. `.strict` wants `"`; the Gemma dialect wants a bare
+    /// identifier — the chat template renders keys unquoted at every depth
+    /// (`format_argument` propagates `escape_keys=False` into nested mappings)
+    /// and the parser rejects quoted ones, which is failure cause #1 in the
+    /// upstream report.
+    private mutating func startKey(_ byte: UInt8) -> Bool {
+        switch dialect {
+        case .strict:
+            guard byte == UInt8(ascii: "\"") else { return false }
+            mode = .inString(kind: .objectKey, utf8: nil)
+            return true
+        case .gemmaToolArguments:
+            guard Self.isBareKeyByte(byte) else { return false }
+            mode = .inBareKey
+            return true
+        }
+    }
+
     private mutating func startValue(_ byte: UInt8) -> Bool {
+        if dialect == .gemmaToolArguments {
+            // The tool-call body is always an argument object.
+            guard !stack.isEmpty || byte == UInt8(ascii: "{") else { return false }
+            if byte == UInt8(ascii: "<") {
+                mode = .gemmaOpen(matched: 1)
+                return true
+            }
+            // The parser's `"`-delimited path silently eats interior
+            // whitespace, so a quoted string would decode to something other
+            // than what was generated. Only the escape-token delimiter passes.
+            guard byte != UInt8(ascii: "\"") else { return false }
+        }
         switch byte {
         case UInt8(ascii: "\""):
-            mode = .inString(isKey: false, utf8: nil)
+            mode = .inString(kind: .value, utf8: nil)
         case UInt8(ascii: "{"):
             guard stack.count < Self.maxDepth else { return false }
             stack.append(.object)
@@ -245,7 +423,7 @@ public struct JSONByteAutomaton: Sendable, Equatable {
         case UInt8(ascii: "0"):
             mode = .inNumber(.leadingZero)
         case UInt8(ascii: "1")...UInt8(ascii: "9"):
-            mode = .inNumber(.intDigits)
+            mode = .inNumber(.intDigits(1))
         default:
             return false
         }
@@ -262,26 +440,108 @@ public struct JSONByteAutomaton: Sendable, Equatable {
         stack.isEmpty ? .complete : .afterValue
     }
 
+    /// Back into the string body after an escape. The escape's raw text is
+    /// ASCII, so nothing can be swallowed forwards — but its last character is
+    /// one the parser's `escapedFragment` compares literally, so a combining
+    /// scalar must not fuse onto it.
+    private func openStringMode(_ kind: StringKind) -> Mode {
+        kind == .gemmaValue
+            ? .inGemmaString(delimiter: 0, utf8: nil, guard: .backward)
+            : .inString(kind: kind, utf8: nil)
+    }
+
+    private func closedStringMode(_ kind: StringKind) -> Mode {
+        kind == .objectKey ? .expectColon : endedValueMode()
+    }
+
+    /// The bare-key alphabet `GemmaToolCallParser.objectKey()` accepts,
+    /// narrowed to ASCII so the trie and the fallback scan stay byte-local.
+    private static func isBareKeyByte(_ byte: UInt8) -> Bool {
+        switch byte {
+        case UInt8(ascii: "A")...UInt8(ascii: "Z"),
+             UInt8(ascii: "a")...UInt8(ascii: "z"),
+             UInt8(ascii: "0")...UInt8(ascii: "9"),
+             UInt8(ascii: "_"), UInt8(ascii: "-"),
+             UInt8(ascii: "."), UInt8(ascii: "$"):
+            return true
+        default:
+            return false
+        }
+    }
+
+    /// True when this scalar grapheme-merges with a following `<`, which would
+    /// hide the closing `<|"|>` from `GemmaToolCallParser`: its lexer scans an
+    /// `[Character]`, so a Grapheme_Cluster_Break=Prepend scalar (U+0600,
+    /// U+0D4E, …) swallows the delimiter's first byte and the string never
+    /// terminates. Asking the stdlib instead of hardcoding the class keeps the
+    /// check exact for whatever Unicode version is linked. The same probe
+    /// covers `\`, because Prepend joins with anything that follows it.
+    private static func mergesForward(_ scalar: Unicode.Scalar) -> Bool {
+        guard !scalar.isASCII else { return false }
+        var probe = String(scalar)
+        probe.append("<")
+        return probe.count == 1
+    }
+
+    /// True when this scalar joins onto the preceding character — a combining
+    /// mark, ZWJ, and everything else Unicode lets attach backwards. Any ASCII
+    /// base answers the same question here (the base-sensitive rules are Hangul,
+    /// emoji-ZWJ and regional indicators, none of which an ASCII character
+    /// triggers), so one representative probe covers every position the dialect
+    /// guards.
+    private static func mergesBackward(_ scalar: Unicode.Scalar) -> Bool {
+        guard !scalar.isASCII else { return false }
+        var probe = ">"
+        probe.unicodeScalars.append(scalar)
+        return probe.count == 1
+    }
+
+    /// The exact set of scalars an unfinished UTF-8 sequence can still reach,
+    /// honouring the lead byte's restricted first-continuation range.
+    private static func pendingScalarRange(_ pending: UTF8Pending) -> ClosedRange<UInt32> {
+        let range = pending.first ?? 0x80...0xBF
+        let tailBits = UInt32(6 * (pending.remaining - 1))
+        let head = pending.value << 6
+        let lowest = (head | UInt32(range.lowerBound & 0x3F)) << tailBits
+        let highest = ((head | UInt32(range.upperBound & 0x3F)) << tailBits)
+            | ((1 << tailBits) - 1)
+        return lowest...highest
+    }
+
+    /// True when some scalar in the range does not join backwards. Scanning
+    /// stops at the first one, which is the answer for all but the runs of pure
+    /// combining marks the check exists to catch.
+    private static func rangeHasGraphemeBase(_ range: ClosedRange<UInt32>) -> Bool {
+        for value in range {
+            guard let scalar = Unicode.Scalar(value) else { continue }
+            if !mergesBackward(scalar) { return true }
+        }
+        return false
+    }
+
     private func numberPhase(_ phase: NumberPhase, _ byte: UInt8) -> NumberPhase? {
         let isDigit = (UInt8(ascii: "0")...UInt8(ascii: "9")).contains(byte)
+        let isExponentMark = byte == UInt8(ascii: "e") || byte == UInt8(ascii: "E")
+        let allowsExponent = dialect == .strict
+        let digitCap = dialect == .strict ? Int.max : Self.maximumNumberDigits
         switch phase {
         case .afterMinus:
             guard isDigit else { return nil }
-            return byte == UInt8(ascii: "0") ? .leadingZero : .intDigits
+            return byte == UInt8(ascii: "0") ? .leadingZero : .intDigits(1)
         case .leadingZero:
             if byte == UInt8(ascii: ".") { return .afterDot }
-            if byte == UInt8(ascii: "e") || byte == UInt8(ascii: "E") { return .afterExpMark }
+            if isExponentMark, allowsExponent { return .afterExpMark }
             return nil
-        case .intDigits:
-            if isDigit { return .intDigits }
+        case .intDigits(let digits):
+            if isDigit { return digits < digitCap ? .intDigits(digits + 1) : nil }
             if byte == UInt8(ascii: ".") { return .afterDot }
-            if byte == UInt8(ascii: "e") || byte == UInt8(ascii: "E") { return .afterExpMark }
+            if isExponentMark, allowsExponent { return .afterExpMark }
             return nil
         case .afterDot:
-            return isDigit ? .fracDigits : nil
-        case .fracDigits:
-            if isDigit { return .fracDigits }
-            if byte == UInt8(ascii: "e") || byte == UInt8(ascii: "E") { return .afterExpMark }
+            return isDigit ? .fracDigits(1) : nil
+        case .fracDigits(let digits):
+            if isDigit { return digits < digitCap ? .fracDigits(digits + 1) : nil }
+            if isExponentMark, allowsExponent { return .afterExpMark }
             return nil
         case .afterExpMark:
             if isDigit { return .expDigits }
@@ -296,19 +556,20 @@ public struct JSONByteAutomaton: Sendable, Equatable {
 
     /// WHATWG UTF-8 lead-byte table: continuation count owed plus the
     /// restricted range for the first continuation where the lead demands one
-    /// (rejects overlongs, surrogates and codepoints past U+10FFFF). Returns
-    /// nil for bytes that cannot start a sequence (bare continuations, C0/C1,
+    /// (rejects overlongs, surrogates and codepoints past U+10FFFF). `value`
+    /// seeds the scalar accumulator with the lead's payload bits. Returns nil
+    /// for bytes that cannot start a sequence (bare continuations, C0/C1,
     /// F5...FF).
     private static func utf8Lead(_ byte: UInt8) -> UTF8Pending? {
         switch byte {
-        case 0xC2...0xDF: return UTF8Pending(remaining: 1, first: nil)
-        case 0xE0:        return UTF8Pending(remaining: 2, first: 0xA0...0xBF)
-        case 0xE1...0xEC: return UTF8Pending(remaining: 2, first: nil)
-        case 0xED:        return UTF8Pending(remaining: 2, first: 0x80...0x9F)
-        case 0xEE...0xEF: return UTF8Pending(remaining: 2, first: nil)
-        case 0xF0:        return UTF8Pending(remaining: 3, first: 0x90...0xBF)
-        case 0xF1...0xF3: return UTF8Pending(remaining: 3, first: nil)
-        case 0xF4:        return UTF8Pending(remaining: 3, first: 0x80...0x8F)
+        case 0xC2...0xDF: return UTF8Pending(remaining: 1, first: nil, value: UInt32(byte & 0x1F))
+        case 0xE0:        return UTF8Pending(remaining: 2, first: 0xA0...0xBF, value: UInt32(byte & 0x0F))
+        case 0xE1...0xEC: return UTF8Pending(remaining: 2, first: nil, value: UInt32(byte & 0x0F))
+        case 0xED:        return UTF8Pending(remaining: 2, first: 0x80...0x9F, value: UInt32(byte & 0x0F))
+        case 0xEE...0xEF: return UTF8Pending(remaining: 2, first: nil, value: UInt32(byte & 0x0F))
+        case 0xF0:        return UTF8Pending(remaining: 3, first: 0x90...0xBF, value: UInt32(byte & 0x07))
+        case 0xF1...0xF3: return UTF8Pending(remaining: 3, first: nil, value: UInt32(byte & 0x07))
+        case 0xF4:        return UTF8Pending(remaining: 3, first: 0x80...0x8F, value: UInt32(byte & 0x07))
         default:          return nil
         }
     }
@@ -336,15 +597,12 @@ public struct JSONByteAutomaton: Sendable, Equatable {
 /// by id; unknown `<...>` marker-shaped pieces are blocked by pattern because
 /// the detokenizer strips them from the output, which would desync the
 /// automaton from the emitted text.
-public final class JSONTokenFilter {
-    public typealias PieceLookup = (Int32) -> String?
+public final class JSONTokenFilter: TokenGrammarFilter {
+    public typealias PieceLookup = TokenByteTable.PieceLookup
 
-    private let piece: PieceLookup
-    private let blockedIDs: Set<Int32>
+    private let table: TokenByteTable
     private let stopIDs: Set<Int32>
     private var automaton = JSONByteAutomaton()
-    private var byteCache: [Int32: [UInt8]] = [:]
-    private var blockedCache: Set<Int32> = []
 
     public convenience init(tokenizer: GFTokenizer, extraStopIDs: Set<Int32> = []) {
         let underlying = tokenizer.tokenizer
@@ -360,8 +618,8 @@ public final class JSONTokenFilter {
     public init(pieceLookup: @escaping PieceLookup,
                 blockedIDs: Set<Int32>,
                 stopIDs: Set<Int32>) {
-        self.piece = pieceLookup
-        self.blockedIDs = blockedIDs.union(stopIDs)
+        self.table = TokenByteTable(pieceLookup: pieceLookup,
+                                    blockedIDs: blockedIDs.union(stopIDs))
         self.stopIDs = stopIDs
     }
 
@@ -391,7 +649,7 @@ public final class JSONTokenFilter {
             lastAcceptedBytes = []
             return true
         }
-        guard let bytes = bytes(for: id), !bytes.isEmpty else { return false }
+        guard let bytes = table.bytes(for: id), !bytes.isEmpty else { return false }
         var candidate = automaton
         for byte in bytes {
             guard candidate.consume(byte) else { return false }
@@ -399,53 +657,6 @@ public final class JSONTokenFilter {
         automaton = candidate
         lastAcceptedBytes = bytes
         return true
-    }
-
-    // MARK: - Token bytes
-
-    private static let spaceMarker = "\u{2581}"
-
-    private func bytes(for id: Int32) -> [UInt8]? {
-        if blockedCache.contains(id) { return nil }
-        if let cached = byteCache[id] { return cached }
-        guard !blockedIDs.contains(id), let raw = piece(id), !raw.isEmpty else {
-            blockedCache.insert(id)
-            return nil
-        }
-        let resolved: [UInt8]?
-        if let byte = Self.byteFallback(raw) {
-            resolved = [byte]
-        } else if Self.looksLikeMarker(raw) {
-            resolved = nil
-        } else {
-            resolved = Array(raw.replacingOccurrences(of: Self.spaceMarker,
-                                                      with: " ").utf8)
-        }
-        guard let resolved else {
-            blockedCache.insert(id)
-            return nil
-        }
-        byteCache[id] = resolved
-        return resolved
-    }
-
-    private static func byteFallback(_ token: String) -> UInt8? {
-        guard token.count == 6, token.hasPrefix("<0x"), token.hasSuffix(">") else {
-            return nil
-        }
-        return UInt8(token.dropFirst(3).dropLast(), radix: 16)
-    }
-
-    /// Whole-piece `<...>` shapes (e.g. `<unused12>`, `<start_of_image>`) are
-    /// added tokens that signal a derailed generation; never let them through.
-    /// This also blocks the vocab's ~97 legitimate single-piece HTML tags
-    /// (`<td>`, `<div>`) — accepted cost: the model can still spell them from
-    /// smaller pieces.
-    private static func looksLikeMarker(_ token: String) -> Bool {
-        guard token.count > 2, token.hasPrefix("<"), token.hasSuffix(">") else {
-            return false
-        }
-        return !token.dropFirst().dropLast().contains { $0 == "<" || $0 == ">" }
     }
 }
 

--- a/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
@@ -62,9 +62,10 @@ public struct RawCompletionScratch: @unchecked Sendable {
 extension GenerationConfig {
     /// A pure-greedy config can use the fused head's GPU argmax
     /// (`RealForwardRunner.lastGreedyToken`) instead of sampling from the
-    /// logits buffer. Anything else needs real logits.
+    /// logits buffer. Anything else — including JSON-constrained decoding,
+    /// which must inspect and veto candidates — needs real logits.
     public var isPureGreedy: Bool {
-        temperature == 0 && repetitionPenalty == 1
+        temperature == 0 && repetitionPenalty == 1 && !forceJSON
     }
 
 }
@@ -174,6 +175,7 @@ public func runRawCompletion(producer: any LogitProducer,
 
     let decodeStart = Date()
     let prefillSeconds = decodeStart.timeIntervalSince(prefillStart)
+    let jsonFilter = config.forceJSON ? JSONTokenFilter(tokenizer: tokenizer) : nil
     var stopMatcher = StreamingStopMatcher(stops: config.stopStrings)
     var generated = 0
     var reason: StopReason = .maxTokens
@@ -189,13 +191,15 @@ public func runRawCompletion(producer: any LogitProducer,
                 tokenID = Int32(bitPattern: token)
             case .logitsWritten:
                 tokenID = try sampleOnce(scratch: scratch, context: context,
-                                         history: history, config: config, position: generated)
+                                         history: history, config: config, position: generated,
+                                         jsonFilter: jsonFilter)
             }
         } else if fusedGreedy {
             tokenID = Int32(bitPattern: fusedRunner!.lastGreedyToken)
         } else {
             tokenID = try sampleOnce(scratch: scratch, context: context,
-                                     history: history, config: config, position: generated)
+                                     history: history, config: config, position: generated,
+                                     jsonFilter: jsonFilter)
         }
         generated += 1
         uncommittedBoundaryTokenIDs = [tokenID]
@@ -216,6 +220,13 @@ public func runRawCompletion(producer: any LogitProducer,
         let delta = detok.push(tokenID)
         let visible = stopMatcher.push(delta)
         onProgress(.token(index: generated - 1, id: tokenID, delta: visible))
+
+        if let jsonFilter, jsonFilter.isComplete {
+            let tail = stopMatcher.push(detok.flush()) + stopMatcher.finish()
+            if !tail.isEmpty { onProgress(.tail(tail)) }
+            reason = .eos
+            break
+        }
 
         let hitStopString = stopMatcher.isStopped || shouldStop()
         let hitMax = generated >= config.maxNewTokens
@@ -245,12 +256,53 @@ public func runRawCompletion(producer: any LogitProducer,
 }
 
 private func sampleOnce(scratch: RawCompletionScratch, context: MetalContext,
-                        history: [Int32], config: GenerationConfig, position: Int) throws -> Int32 {
+                        history: [Int32], config: GenerationConfig, position: Int,
+                        jsonFilter: JSONTokenFilter? = nil) throws -> Int32 {
     let cb = context.queue.makeCommandBuffer()!
     scratch.sampler.sample(commandBuffer: cb, logits: scratch.logits, probs: scratch.probs,
                            history: history, config: config, position: position,
                            outToken: scratch.outToken)
     cb.commit(); cb.waitUntilCompleted()
     try checkCommandBufferError(cb.error)
-    return Int32(bitPattern: scratch.outToken.contents().load(as: UInt32.self))
+    let sampled = Int32(bitPattern: scratch.outToken.contents().load(as: UInt32.self))
+    guard let jsonFilter, !jsonFilter.tryAccept(sampled) else { return sampled }
+    return try grammarFallbackToken(scratch: scratch, filter: jsonFilter)
+}
+
+/// The GPU-sampled token broke the JSON grammar. `scratch.probs` (shared
+/// storage, written by the completed softcap+softmax pass) is walked in
+/// probability order — first automaton-accepted token wins. A capped
+/// candidate set covers the common case; the full vocabulary is scanned only
+/// if every high-probability candidate is grammar-invalid.
+private func grammarFallbackToken(scratch: RawCompletionScratch,
+                                  filter: JSONTokenFilter) throws -> Int32 {
+    let vocab = scratch.sampler.vocab
+    let probs = scratch.probs.contents().bindMemory(to: Float16.self, capacity: vocab)
+
+    var top: [(id: Int32, p: Float16)] = []
+    top.reserveCapacity(257)
+    var floor: Float16 = 0
+    for id in 0..<vocab {
+        let p = probs[id]
+        guard p > floor else { continue }
+        top.append((Int32(id), p))
+        if top.count > 256 {
+            let minIndex = top.indices.min { top[$0].p < top[$1].p }!
+            top.remove(at: minIndex)
+            floor = top.min { $0.p < $1.p }!.p
+        }
+    }
+    top.sort { $0.p > $1.p }
+    for candidate in top where filter.tryAccept(candidate.id) {
+        return candidate.id
+    }
+
+    let remaining = (0..<vocab)
+        .map { (id: Int32($0), p: probs[$0]) }
+        .sorted { $0.p > $1.p }
+    for candidate in remaining where filter.tryAccept(candidate.id) {
+        return candidate.id
+    }
+    throw GeneratorError.invalidGenerationConfig(
+        "force-json: no token in the vocabulary can extend the JSON document")
 }

--- a/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
@@ -28,6 +28,9 @@ public struct RawDecodeResult: Sendable {
     public let kvPosition: Int
     public let kvBackedTokenIDs: [Int32]
     public let uncommittedBoundaryTokenIDs: [Int32]
+    /// Times the JSON grammar vetoed the GPU-sampled token and the
+    /// probability-ordered fallback chose instead. 0 unless `forceJSON`.
+    public var grammarVetoes: Int = 0
 }
 
 /// Preallocated per-generation buffers (two 512 KiB vocab buffers plus a token
@@ -175,11 +178,22 @@ public func runRawCompletion(producer: any LogitProducer,
 
     let decodeStart = Date()
     let prefillSeconds = decodeStart.timeIntervalSince(prefillStart)
-    let jsonFilter = config.forceJSON ? JSONTokenFilter(tokenizer: tokenizer) : nil
+    let jsonFilter = config.forceJSON
+        ? JSONTokenFilter(tokenizer: tokenizer, extraStopIDs: config.extraStopTokens)
+        : nil
+    var jsonAssembler = UTF8StreamAssembler()
     var stopMatcher = StreamingStopMatcher(stops: config.stopStrings)
     var generated = 0
     var reason: StopReason = .maxTokens
     var uncommittedBoundaryTokenIDs: [Int32] = []
+
+    // Under forceJSON the emitted text is the automaton-validated byte stream,
+    // NOT detokenizer output: the library decode applies `cleanUp` (` ,`→`,`)
+    // and drops undecodable byte-fallback tails, either of which would desync
+    // what the grammar guaranteed from what the caller receives.
+    func flushTail() -> String {
+        jsonFilter != nil ? jsonAssembler.flush() : detok.flush()
+    }
 
     while true {
         try Task.checkCancellation()
@@ -212,17 +226,22 @@ public func runRawCompletion(producer: any LogitProducer,
             } else {
                 reason = .eos
             }
-            let tail = stopMatcher.push(detok.flush()) + stopMatcher.finish()
+            let tail = stopMatcher.push(flushTail()) + stopMatcher.finish()
             if !tail.isEmpty { onProgress(.tail(tail)) }
             break
         }
 
-        let delta = detok.push(tokenID)
+        let delta: String
+        if let jsonFilter {
+            delta = jsonAssembler.push(jsonFilter.lastAcceptedBytes)
+        } else {
+            delta = detok.push(tokenID)
+        }
         let visible = stopMatcher.push(delta)
         onProgress(.token(index: generated - 1, id: tokenID, delta: visible))
 
         if let jsonFilter, jsonFilter.isComplete {
-            let tail = stopMatcher.push(detok.flush()) + stopMatcher.finish()
+            let tail = stopMatcher.push(flushTail()) + stopMatcher.finish()
             if !tail.isEmpty { onProgress(.tail(tail)) }
             reason = .eos
             break
@@ -231,7 +250,7 @@ public func runRawCompletion(producer: any LogitProducer,
         let hitStopString = stopMatcher.isStopped || shouldStop()
         let hitMax = generated >= config.maxNewTokens
         if hitStopString || hitMax {
-            let tail = stopMatcher.push(detok.flush()) + stopMatcher.finish()
+            let tail = stopMatcher.push(flushTail()) + stopMatcher.finish()
             if !tail.isEmpty { onProgress(.tail(tail)) }
             reason = hitStopString ? .stopString : .maxTokens
             break
@@ -252,7 +271,8 @@ public func runRawCompletion(producer: any LogitProducer,
                            reason: reason,
                            kvPosition: position,
                            kvBackedTokenIDs: history,
-                           uncommittedBoundaryTokenIDs: uncommittedBoundaryTokenIDs)
+                           uncommittedBoundaryTokenIDs: uncommittedBoundaryTokenIDs,
+                           grammarVetoes: jsonFilter?.vetoCount ?? 0)
 }
 
 private func sampleOnce(scratch: RawCompletionScratch, context: MetalContext,
@@ -266,6 +286,7 @@ private func sampleOnce(scratch: RawCompletionScratch, context: MetalContext,
     try checkCommandBufferError(cb.error)
     let sampled = Int32(bitPattern: scratch.outToken.contents().load(as: UInt32.self))
     guard let jsonFilter, !jsonFilter.tryAccept(sampled) else { return sampled }
+    jsonFilter.noteVeto()
     return try grammarFallbackToken(scratch: scratch, filter: jsonFilter)
 }
 

--- a/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
@@ -219,7 +219,11 @@ public func runRawCompletion(producer: any LogitProducer,
         uncommittedBoundaryTokenIDs = [tokenID]
 
         if tokenizer.stopTokenIDs.contains(tokenID) || config.extraStopTokens.contains(tokenID) {
-            if tokenID == tokenizer.endOfTurnID {
+            if jsonFilter != nil {
+                // Grammar-gated stops always mean "the JSON may end here";
+                // .toolCalls/.endOfTurn semantics don't apply to forced JSON.
+                reason = .eos
+            } else if tokenID == tokenizer.endOfTurnID {
                 reason = .endOfTurn
             } else if tokenID == tokenizer.toolResponseID {
                 reason = .toolCalls

--- a/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
@@ -197,9 +197,6 @@ public func runRawCompletion(producer: any LogitProducer,
         ? JSONTokenFilter(tokenizer: tokenizer, extraStopIDs: config.extraStopTokens)
         : nil
     let grammar: (any TokenGrammarFilter)? = jsonFilter ?? toolFilter
-    let grammarExhausted = jsonFilter != nil
-        ? "force-json: no token in the vocabulary can extend the JSON document"
-        : "tool-call grammar: no token in the vocabulary can extend the tool call"
     var jsonAssembler = UTF8StreamAssembler()
     var stopMatcher = StreamingStopMatcher(stops: config.stopStrings)
     var generated = 0
@@ -211,28 +208,53 @@ public func runRawCompletion(producer: any LogitProducer,
     // and drops undecodable byte-fallback tails, either of which would desync
     // what the grammar guaranteed from what the caller receives.
     func flushTail() -> String {
-        jsonFilter != nil ? jsonAssembler.flush() : detok.flush()
+        if jsonFilter != nil { return jsonAssembler.flush() }
+        // Inside an open `<|tool_call>` region the byte-fallback pieces the
+        // detokenizer is holding back are raw bytes of an argument — the `é`
+        // tail of a path — not assistant prose. The region dies with the
+        // generation and is never decoded, so those bytes are not text anyone
+        // may show: dropping them is the whole point of holding them back.
+        if toolFilter?.isInsideCall == true { return "" }
+        return detok.flush()
     }
 
     while true {
         try Task.checkCancellation()
 
-        let tokenID: Int32
+        let sampled: Int32?
         if generated == 0, let seed = prefillSeed {
             switch seed {
             case .greedyToken(let token):
-                tokenID = Int32(bitPattern: token)
+                sampled = Int32(bitPattern: token)
             case .logitsWritten:
-                tokenID = try sampleOnce(scratch: scratch, context: context,
+                sampled = try sampleOnce(scratch: scratch, context: context,
                                          history: history, config: config, position: generated,
-                                         grammar: grammar, exhaustedMessage: grammarExhausted)
+                                         grammar: grammar)
             }
         } else if fusedGreedy {
-            tokenID = Int32(bitPattern: fusedRunner!.lastGreedyToken)
+            sampled = Int32(bitPattern: fusedRunner!.lastGreedyToken)
         } else {
-            tokenID = try sampleOnce(scratch: scratch, context: context,
+            sampled = try sampleOnce(scratch: scratch, context: context,
                                      history: history, config: config, position: generated,
-                                     grammar: grammar, exhaustedMessage: grammarExhausted)
+                                     grammar: grammar)
+        }
+        // The grammar admits no token at all. Under the tool-call grammar that
+        // is the region byte cap: at `GemmaToolCallParser.maximumBytes` every
+        // token overflows it and `<tool_call|>` cannot close an argument object
+        // that is still open, so the region can only be abandoned. That is the
+        // budget running out inside a call, which the caller already handles —
+        // report it as such instead of failing the whole request. Force-json
+        // has no bounded region to abandon: there, an empty vocabulary is a
+        // real configuration failure.
+        guard let tokenID = sampled else {
+            guard toolFilter != nil else {
+                throw GeneratorError.invalidGenerationConfig(
+                    "force-json: no token in the vocabulary can extend the JSON document")
+            }
+            let tail = stopMatcher.push(flushTail()) + stopMatcher.finish()
+            if !tail.isEmpty { onProgress(.tail(tail)) }
+            reason = .maxTokens
+            break
         }
         generated += 1
         uncommittedBoundaryTokenIDs = [tokenID]
@@ -300,10 +322,11 @@ public func runRawCompletion(producer: any LogitProducer,
                            toolNameVetoes: toolFilter?.nameVetoCount ?? 0)
 }
 
+/// nil when the active grammar accepts nothing: the caller decides whether that
+/// ends the generation or fails it.
 private func sampleOnce(scratch: RawCompletionScratch, context: MetalContext,
                         history: [Int32], config: GenerationConfig, position: Int,
-                        grammar: (any TokenGrammarFilter)?,
-                        exhaustedMessage: String) throws -> Int32 {
+                        grammar: (any TokenGrammarFilter)?) throws -> Int32? {
     let cb = context.queue.makeCommandBuffer()!
     scratch.sampler.sample(commandBuffer: cb, logits: scratch.logits, probs: scratch.probs,
                            history: history, config: config, position: position,
@@ -313,18 +336,17 @@ private func sampleOnce(scratch: RawCompletionScratch, context: MetalContext,
     let sampled = Int32(bitPattern: scratch.outToken.contents().load(as: UInt32.self))
     guard let grammar, !grammar.tryAccept(sampled) else { return sampled }
     grammar.noteVeto()
-    return try grammarFallbackToken(scratch: scratch, filter: grammar,
-                                    exhaustedMessage: exhaustedMessage)
+    return grammarFallbackToken(scratch: scratch, filter: grammar)
 }
 
 /// The GPU-sampled token broke the active grammar. `scratch.probs` (shared
 /// storage, written by the completed softcap+softmax pass) is walked in
 /// probability order — first grammar-accepted token wins. A capped candidate
 /// set covers the common case; the full vocabulary is scanned only if every
-/// high-probability candidate is grammar-invalid.
+/// high-probability candidate is grammar-invalid. nil when the sweep comes back
+/// empty: the grammar has painted itself into a corner.
 private func grammarFallbackToken(scratch: RawCompletionScratch,
-                                  filter: any TokenGrammarFilter,
-                                  exhaustedMessage: String) throws -> Int32 {
+                                  filter: any TokenGrammarFilter) -> Int32? {
     let vocab = scratch.sampler.vocab
     let probs = scratch.probs.contents().bindMemory(to: Float16.self, capacity: vocab)
 
@@ -352,5 +374,5 @@ private func grammarFallbackToken(scratch: RawCompletionScratch,
     for candidate in remaining where filter.tryAccept(candidate.id) {
         return candidate.id
     }
-    throw GeneratorError.invalidGenerationConfig(exhaustedMessage)
+    return nil
 }

--- a/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/RawCompletion.swift
@@ -31,6 +31,12 @@ public struct RawDecodeResult: Sendable {
     /// Times the JSON grammar vetoed the GPU-sampled token and the
     /// probability-ordered fallback chose instead. 0 unless `forceJSON`.
     public var grammarVetoes: Int = 0
+    /// Times the tool-call grammar vetoed the GPU-sampled token. 0 unless the
+    /// tool-call constraint ran.
+    public var toolGrammarVetoes: Int = 0
+    /// Of those, the ones where the rejected token died while the function name
+    /// was still being spelled — the model wanted a tool that was not declared.
+    public var toolNameVetoes: Int = 0
 }
 
 /// Preallocated per-generation buffers (two 512 KiB vocab buffers plus a token
@@ -90,15 +96,24 @@ public func runRawCompletion(producer: any LogitProducer,
                              scratch: RawCompletionScratch,
                              prefillConfig: PrefillRuntimeConfig = .defaultChunked,
                              start: RawCompletionStart = .reset,
+                             toolFilter: ToolCallTokenFilter? = nil,
                              shouldStop: () -> Bool = { false },
                              onProgress: (RawDecodeProgress) -> Void) async throws -> RawDecodeResult {
     try config.validate()
+    // The two grammars speak different languages about the same token stream;
+    // there is no meaningful intersection to enforce.
+    guard !(config.forceJSON && toolFilter != nil) else {
+        throw GeneratorError.invalidGenerationConfig(
+            "forceJSON and the tool-call grammar cannot constrain the same generation")
+    }
     guard !promptIds.isEmpty else {
         throw GeneratorError.emptyPrompt
     }
     let fusedRunner = producer as? RealForwardRunner
     let fusedGreedy = fusedRunner?.usesFusedGreedyHead == true
-    guard !fusedGreedy || config.isPureGreedy else {
+    // A constrained decode has to see and veto candidates, which the fused
+    // head's GPU argmax never surfaces.
+    guard !fusedGreedy || (config.isPureGreedy && toolFilter == nil) else {
         throw PrefillError.unsupportedPrefillSeed(
             "the fused-head producer cannot serve this sampling configuration; use a logits head")
     }
@@ -181,6 +196,10 @@ public func runRawCompletion(producer: any LogitProducer,
     let jsonFilter = config.forceJSON
         ? JSONTokenFilter(tokenizer: tokenizer, extraStopIDs: config.extraStopTokens)
         : nil
+    let grammar: (any TokenGrammarFilter)? = jsonFilter ?? toolFilter
+    let grammarExhausted = jsonFilter != nil
+        ? "force-json: no token in the vocabulary can extend the JSON document"
+        : "tool-call grammar: no token in the vocabulary can extend the tool call"
     var jsonAssembler = UTF8StreamAssembler()
     var stopMatcher = StreamingStopMatcher(stops: config.stopStrings)
     var generated = 0
@@ -206,14 +225,14 @@ public func runRawCompletion(producer: any LogitProducer,
             case .logitsWritten:
                 tokenID = try sampleOnce(scratch: scratch, context: context,
                                          history: history, config: config, position: generated,
-                                         jsonFilter: jsonFilter)
+                                         grammar: grammar, exhaustedMessage: grammarExhausted)
             }
         } else if fusedGreedy {
             tokenID = Int32(bitPattern: fusedRunner!.lastGreedyToken)
         } else {
             tokenID = try sampleOnce(scratch: scratch, context: context,
                                      history: history, config: config, position: generated,
-                                     jsonFilter: jsonFilter)
+                                     grammar: grammar, exhaustedMessage: grammarExhausted)
         }
         generated += 1
         uncommittedBoundaryTokenIDs = [tokenID]
@@ -276,12 +295,15 @@ public func runRawCompletion(producer: any LogitProducer,
                            kvPosition: position,
                            kvBackedTokenIDs: history,
                            uncommittedBoundaryTokenIDs: uncommittedBoundaryTokenIDs,
-                           grammarVetoes: jsonFilter?.vetoCount ?? 0)
+                           grammarVetoes: jsonFilter?.vetoCount ?? 0,
+                           toolGrammarVetoes: toolFilter?.vetoCount ?? 0,
+                           toolNameVetoes: toolFilter?.nameVetoCount ?? 0)
 }
 
 private func sampleOnce(scratch: RawCompletionScratch, context: MetalContext,
                         history: [Int32], config: GenerationConfig, position: Int,
-                        jsonFilter: JSONTokenFilter? = nil) throws -> Int32 {
+                        grammar: (any TokenGrammarFilter)?,
+                        exhaustedMessage: String) throws -> Int32 {
     let cb = context.queue.makeCommandBuffer()!
     scratch.sampler.sample(commandBuffer: cb, logits: scratch.logits, probs: scratch.probs,
                            history: history, config: config, position: position,
@@ -289,18 +311,20 @@ private func sampleOnce(scratch: RawCompletionScratch, context: MetalContext,
     cb.commit(); cb.waitUntilCompleted()
     try checkCommandBufferError(cb.error)
     let sampled = Int32(bitPattern: scratch.outToken.contents().load(as: UInt32.self))
-    guard let jsonFilter, !jsonFilter.tryAccept(sampled) else { return sampled }
-    jsonFilter.noteVeto()
-    return try grammarFallbackToken(scratch: scratch, filter: jsonFilter)
+    guard let grammar, !grammar.tryAccept(sampled) else { return sampled }
+    grammar.noteVeto()
+    return try grammarFallbackToken(scratch: scratch, filter: grammar,
+                                    exhaustedMessage: exhaustedMessage)
 }
 
-/// The GPU-sampled token broke the JSON grammar. `scratch.probs` (shared
+/// The GPU-sampled token broke the active grammar. `scratch.probs` (shared
 /// storage, written by the completed softcap+softmax pass) is walked in
-/// probability order — first automaton-accepted token wins. A capped
-/// candidate set covers the common case; the full vocabulary is scanned only
-/// if every high-probability candidate is grammar-invalid.
+/// probability order — first grammar-accepted token wins. A capped candidate
+/// set covers the common case; the full vocabulary is scanned only if every
+/// high-probability candidate is grammar-invalid.
 private func grammarFallbackToken(scratch: RawCompletionScratch,
-                                  filter: JSONTokenFilter) throws -> Int32 {
+                                  filter: any TokenGrammarFilter,
+                                  exhaustedMessage: String) throws -> Int32 {
     let vocab = scratch.sampler.vocab
     let probs = scratch.probs.contents().bindMemory(to: Float16.self, capacity: vocab)
 
@@ -328,6 +352,5 @@ private func grammarFallbackToken(scratch: RawCompletionScratch,
     for candidate in remaining where filter.tryAccept(candidate.id) {
         return candidate.id
     }
-    throw GeneratorError.invalidGenerationConfig(
-        "force-json: no token in the vocabulary can extend the JSON document")
+    throw GeneratorError.invalidGenerationConfig(exhaustedMessage)
 }

--- a/Sources/TurboFieldfare/Runtime/Generation/Sampler.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/Sampler.swift
@@ -61,6 +61,10 @@ public struct GenerationConfig: Sendable {
             throw GeneratorError.invalidGenerationConfig(
                 "topP below one requires topK; full-vocabulary nucleus sampling is not implemented")
         }
+        if forceJSON, !stopStrings.isEmpty {
+            throw GeneratorError.invalidGenerationConfig(
+                "stopStrings are incompatible with forceJSON; the grammar owns termination")
+        }
     }
 
 }

--- a/Sources/TurboFieldfare/Runtime/Generation/Sampler.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/Sampler.swift
@@ -15,6 +15,10 @@ public struct GenerationConfig: Sendable {
     public var seed: UInt64? = nil         // nil = nondeterministic
     public var stopStrings: [String] = []
     public var extraStopTokens: Set<Int32> = []
+    /// Constrain decoding to grammar-valid JSON (byte-level automaton over
+    /// sampled candidates; EOS forced once the root value closes). Requires a
+    /// logits head — incompatible with the fused greedy path.
+    public var forceJSON: Bool = false
 
     public init(maxNewTokens: Int = 256,
                 temperature: Float = 1.0,
@@ -23,7 +27,8 @@ public struct GenerationConfig: Sendable {
                 repetitionPenalty: Float = 1.0,
                 seed: UInt64? = nil,
                 stopStrings: [String] = [],
-                extraStopTokens: Set<Int32> = []) {
+                extraStopTokens: Set<Int32> = [],
+                forceJSON: Bool = false) {
         self.maxNewTokens = maxNewTokens
         self.temperature = temperature
         self.topK = topK
@@ -32,6 +37,7 @@ public struct GenerationConfig: Sendable {
         self.seed = seed
         self.stopStrings = stopStrings
         self.extraStopTokens = extraStopTokens
+        self.forceJSON = forceJSON
     }
 
     public func validate() throws {

--- a/Sources/TurboFieldfare/Runtime/Generation/TokenByteTable.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/TokenByteTable.swift
@@ -1,0 +1,82 @@
+import Foundation
+
+/// Token id → raw UTF-8 bytes with the piece-table quirks both grammar filters
+/// need: the SentencePiece space marker `▁` maps to a space, `<0xNN>`
+/// byte-fallback pieces carry one raw byte, and whole-piece `<...>` markers are
+/// blocked because the detokenizer strips them, which would desync the
+/// automaton from the emitted text. `allowedMarkerIDs` opts specific markers
+/// back in: the tool-call grammar needs `<|"|>` (the tokenizer's escape token)
+/// as a literal five-byte string delimiter.
+public final class TokenByteTable {
+    public typealias PieceLookup = (Int32) -> String?
+
+    private static let spaceMarker = "\u{2581}"
+
+    private let piece: PieceLookup
+    private let blockedIDs: Set<Int32>
+    private let allowedMarkerIDs: Set<Int32>
+    private var byteCache: [Int32: [UInt8]] = [:]
+    private var blockedCache: Set<Int32> = []
+
+    public init(pieceLookup: @escaping PieceLookup,
+                blockedIDs: Set<Int32>,
+                allowedMarkerIDs: Set<Int32> = []) {
+        self.piece = pieceLookup
+        self.blockedIDs = blockedIDs
+        self.allowedMarkerIDs = allowedMarkerIDs
+    }
+
+    /// nil when the id is blocked, unknown, empty, or marker-shaped.
+    public func bytes(for id: Int32) -> [UInt8]? {
+        if blockedCache.contains(id) { return nil }
+        if let cached = byteCache[id] { return cached }
+        guard !blockedIDs.contains(id), let raw = piece(id), !raw.isEmpty else {
+            blockedCache.insert(id)
+            return nil
+        }
+        let resolved: [UInt8]?
+        if let byte = Self.byteFallback(raw) {
+            resolved = [byte]
+        } else if Self.looksLikeMarker(raw), !allowedMarkerIDs.contains(id) {
+            resolved = nil
+        } else {
+            resolved = Array(raw.replacingOccurrences(of: Self.spaceMarker,
+                                                      with: " ").utf8)
+        }
+        guard let resolved else {
+            blockedCache.insert(id)
+            return nil
+        }
+        byteCache[id] = resolved
+        return resolved
+    }
+
+    private static func byteFallback(_ token: String) -> UInt8? {
+        guard token.count == 6, token.hasPrefix("<0x"), token.hasSuffix(">") else {
+            return nil
+        }
+        return UInt8(token.dropFirst(3).dropLast(), radix: 16)
+    }
+
+    /// Whole-piece `<...>` shapes (e.g. `<unused12>`, `<start_of_image>`) are
+    /// added tokens that signal a derailed generation; never let them through
+    /// unless the caller opted the id in. This also blocks the vocab's ~97
+    /// legitimate single-piece HTML tags (`<td>`, `<div>`) — accepted cost: the
+    /// model can still spell them from smaller pieces.
+    private static func looksLikeMarker(_ token: String) -> Bool {
+        guard token.count > 2, token.hasPrefix("<"), token.hasSuffix(">") else {
+            return false
+        }
+        return !token.dropFirst().dropLast().contains { $0 == "<" || $0 == ">" }
+    }
+}
+
+/// A grammar that can veto sampled tokens inside the raw-completion loop.
+public protocol TokenGrammarFilter: AnyObject {
+    /// True when the token may be emitted next; state is committed only on
+    /// success, so speculative calls during the fallback scan are free.
+    func tryAccept(_ id: Int32) -> Bool
+    /// Recorded by the loop when the GPU-sampled token was rejected.
+    func noteVeto()
+    var vetoCount: Int { get }
+}

--- a/Sources/TurboFieldfare/Runtime/Generation/ToolCallConstraint.swift
+++ b/Sources/TurboFieldfare/Runtime/Generation/ToolCallConstraint.swift
@@ -1,0 +1,296 @@
+import Foundation
+
+/// The Gemma marker ids the tool-call grammar treats as terminal symbols.
+public struct ToolCallMarkerIDs: Sendable, Equatable {
+    public var toolCallStart: Int32      // <|tool_call>
+    public var toolCallEnd: Int32        // <tool_call|>
+    public var toolResponse: Int32       // <|tool_response>
+    public var toolResponseEnd: Int32    // <tool_response|>
+    public var channelStart: Int32       // <|channel>
+    public var channelEnd: Int32         // <channel|>
+    public var escape: Int32             // <|"|>
+    public var endOfTurn: Int32          // <turn|>
+    public var eos: Int32
+    public var bos: Int32
+    public var pad: Int32
+
+    public init(toolCallStart: Int32, toolCallEnd: Int32, toolResponse: Int32,
+                toolResponseEnd: Int32, channelStart: Int32, channelEnd: Int32,
+                escape: Int32, endOfTurn: Int32, eos: Int32, bos: Int32, pad: Int32) {
+        self.toolCallStart = toolCallStart
+        self.toolCallEnd = toolCallEnd
+        self.toolResponse = toolResponse
+        self.toolResponseEnd = toolResponseEnd
+        self.channelStart = channelStart
+        self.channelEnd = channelEnd
+        self.escape = escape
+        self.endOfTurn = endOfTurn
+        self.eos = eos
+        self.bos = bos
+        self.pad = pad
+    }
+
+    public init(tokenizer: GFTokenizer) {
+        self.init(toolCallStart: tokenizer.toolCallStartID,
+                  toolCallEnd: tokenizer.toolCallEndID,
+                  toolResponse: tokenizer.toolResponseID,
+                  toolResponseEnd: tokenizer.toolResponseEndID,
+                  channelStart: tokenizer.channelStartID,
+                  channelEnd: tokenizer.channelEndID,
+                  escape: tokenizer.escapeTokenID,
+                  endOfTurn: tokenizer.endOfTurnID,
+                  eos: tokenizer.eosID,
+                  bos: tokenizer.bosID,
+                  pad: tokenizer.padID)
+    }
+}
+
+/// Byte trie over the declared tool names; `{` only leaves a terminal node, so
+/// a generated name is always one of the declared ones. Shared prefixes cost
+/// nothing: a node can be terminal AND have children, which is what makes
+/// `get` and `get_all` both reachable.
+///
+/// Names outside the alphabet `OpenAIToolName.isValid` guarantees (1...64 bytes
+/// of ASCII `[-0-9A-Za-z_]`) are dropped rather than forced: that alphabet is
+/// exactly what `GemmaToolCallParser.identifier()` reads back, so forcing
+/// anything else would spell a name the parser cannot return. Dropping every
+/// name leaves the trie empty, which blocks `<|tool_call>` outright.
+struct ToolCallNameTrie {
+    static let maximumNameBytes = 64
+
+    private struct Node {
+        var children: [UInt8: Int] = [:]
+        var isTerminal = false
+    }
+
+    private var nodes: [Node] = [Node()]
+
+    let root = 0
+
+    init(_ names: Set<String>) {
+        for name in names.sorted() {
+            let bytes = Array(name.utf8)
+            guard (1...Self.maximumNameBytes).contains(bytes.count),
+                  bytes.allSatisfy(Self.isNameByte) else { continue }
+            var node = root
+            for byte in bytes {
+                if let next = nodes[node].children[byte] {
+                    node = next
+                } else {
+                    nodes.append(Node())
+                    let next = nodes.count - 1
+                    nodes[node].children[byte] = next
+                    node = next
+                }
+            }
+            nodes[node].isTerminal = true
+        }
+    }
+
+    var isEmpty: Bool { nodes.count == 1 }
+
+    func child(_ node: Int, _ byte: UInt8) -> Int? { nodes[node].children[byte] }
+
+    func isTerminal(_ node: Int) -> Bool { nodes[node].isTerminal }
+
+    private static func isNameByte(_ byte: UInt8) -> Bool {
+        switch byte {
+        case 45, 48...57, 65...90, 95, 97...122: true
+        default: false
+        }
+    }
+}
+
+/// Constrains the assistant turn so that every `<|tool_call>` block it opens is
+/// a `GemmaToolCallParser`-decodable call for a declared tool.
+///
+/// The accepted language is a strict SUBSET of what `GemmaToolCallParser`
+/// accepts, so a region this filter closes always parses: bare object keys at
+/// every depth (the parser rejects quoted ones), `<|"|>`-delimited strings (the
+/// `"`-delimited path silently eats whitespace), bounded numbers (the parser
+/// turns out-of-range literals into `malformed`), a name forced from the
+/// declared set, and no raw scalar that would grapheme-merge with the closing
+/// delimiter.
+///
+/// The filter owns only the tool markers and the bytes between them: free prose
+/// before the first call is unconstrained and reaches the caller through the
+/// detokenizer exactly as it does without the filter.
+public final class ToolCallTokenFilter: TokenGrammarFilter {
+    private enum Phase {
+        case free                            // prose; the filter is transparent
+        case prefix(matched: Int)            // matching "call:" byte by byte
+        case name(node: Int)                 // walking the trie
+        case arguments(JSONByteAutomaton)    // dialect .gemmaToolArguments
+        case afterCall                       // a call closed; the turn continues
+    }
+
+    private static let callPrefix = Array("call:".utf8)
+
+    private let table: TokenByteTable
+    private let markers: ToolCallMarkerIDs
+    private let trie: ToolCallNameTrie
+    /// Markers that can never appear between `<|tool_call>` and `<tool_call|>`.
+    private let blockedInsideCall: Set<Int32>
+    private var phase: Phase = .free
+    /// How far the last rejected token got before the grammar refused it. A
+    /// token that reaches the argument object and dies there is not a signal
+    /// about the tool name, even though the committed phase is still `.name`.
+    private var lastRejectionPhase: Phase?
+    /// Region bytes accepted so far. Deliberately outside the copy-on-try
+    /// snapshot: the fallback scan can try hundreds of candidates per token and
+    /// a region runs to 256 KiB.
+    private var body: [UInt8] = []
+
+    public convenience init(tokenizer: GFTokenizer, allowedNames: Set<String>) {
+        let underlying = tokenizer.tokenizer
+        self.init(pieceLookup: { underlying.convertIdToToken(Int($0)) },
+                  markers: ToolCallMarkerIDs(tokenizer: tokenizer),
+                  allowedNames: allowedNames)
+    }
+
+    public init(pieceLookup: @escaping TokenByteTable.PieceLookup,
+                markers: ToolCallMarkerIDs,
+                allowedNames: Set<String>) {
+        self.markers = markers
+        self.trie = ToolCallNameTrie(allowedNames)
+        let blocked: Set<Int32> = [markers.toolCallStart, markers.toolCallEnd,
+                                   markers.toolResponse, markers.toolResponseEnd,
+                                   markers.channelStart, markers.channelEnd,
+                                   markers.endOfTurn, markers.eos,
+                                   markers.bos, markers.pad]
+        self.blockedInsideCall = blocked
+        self.table = TokenByteTable(pieceLookup: pieceLookup,
+                                    blockedIDs: blocked.subtracting([markers.escape]),
+                                    allowedMarkerIDs: [markers.escape])
+    }
+
+    /// Times the grammar vetoed the sampled token, forcing the
+    /// probability-ordered fallback. Recorded by the generation loop.
+    public private(set) var vetoCount = 0
+
+    /// Of those, the ones where the rejected token died while the function name
+    /// was still being spelled — the signal that the model wanted a tool that
+    /// was not declared, as opposed to one that mis-wrote its arguments.
+    public private(set) var nameVetoCount = 0
+
+    /// Grammar-validated bytes (`call:` … `}`) of the region the last accepted
+    /// token closed; nil for every other token. The decoder parses THESE bytes
+    /// instead of `tokenizer.decode(_:skipSpecialTokens:)`, whose `cleanUp`
+    /// pass rewrites ` ,` → `,` and ` 's` → `'s` inside string arguments.
+    public private(set) var closedCallBody: [UInt8]?
+
+    /// Calls closed so far this generation.
+    public private(set) var emittedCalls = 0
+
+    /// A region is open: the generation was cut before the call closed.
+    public var isInsideCall: Bool {
+        switch phase {
+        case .prefix, .name, .arguments: true
+        case .free, .afterCall: false
+        }
+    }
+
+    public func noteVeto() {
+        vetoCount += 1
+        switch lastRejectionPhase ?? phase {
+        case .prefix, .name: nameVetoCount += 1
+        case .free, .arguments, .afterCall: break
+        }
+    }
+
+    /// True when the token may be emitted next. State is committed only on
+    /// success, so the loop's speculative fallback scan is free.
+    public func tryAccept(_ id: Int32) -> Bool {
+        closedCallBody = nil
+        lastRejectionPhase = phase
+        switch phase {
+        case .free:
+            if id == markers.toolCallStart {
+                // With nothing declared there is no name the parser could
+                // resolve, so the block never opens and the turn stays prose.
+                guard !trie.isEmpty else { return false }
+                phase = .prefix(matched: 0)
+                body.removeAll(keepingCapacity: true)
+                return true
+            }
+            // Closing markers with nothing open are `malformed` in the decoder.
+            if id == markers.toolCallEnd || id == markers.toolResponseEnd { return false }
+            // `<|tool_response>` before any call is the orphan stop the server
+            // currently turns into a 500.
+            if id == markers.toolResponse { return emittedCalls > 0 }
+            return true
+
+        case .afterCall:
+            // The template emits `<|tool_response>` after an unanswered call and
+            // never `<turn|>`; keeping the set to these two also pins
+            // `rawStopReason` to `.toolCalls` for the prompt cache.
+            if id == markers.toolCallStart {
+                phase = .prefix(matched: 0)
+                body.removeAll(keepingCapacity: true)
+                return true
+            }
+            return id == markers.toolResponse
+
+        case .prefix, .name, .arguments:
+            if id == markers.toolCallEnd {
+                guard case .arguments(let automaton) = phase, automaton.isComplete else {
+                    return false
+                }
+                emittedCalls += 1
+                closedCallBody = body
+                body.removeAll(keepingCapacity: true)
+                phase = .afterCall
+                return true
+            }
+            guard !blockedInsideCall.contains(id),
+                  let bytes = table.bytes(for: id), !bytes.isEmpty,
+                  body.count + bytes.count <= GemmaToolCallParser.maximumBytes else {
+                return false
+            }
+            var candidate = phase
+            for byte in bytes {
+                guard Self.consume(byte, into: &candidate, trie: trie) else {
+                    lastRejectionPhase = candidate
+                    return false
+                }
+            }
+            phase = candidate
+            body.append(contentsOf: bytes)
+            return true
+        }
+    }
+
+    private static func consume(_ byte: UInt8,
+                                into phase: inout Phase,
+                                trie: ToolCallNameTrie) -> Bool {
+        switch phase {
+        case .prefix(let matched):
+            guard byte == callPrefix[matched] else { return false }
+            phase = matched == callPrefix.count - 1
+                ? .name(node: trie.root)
+                : .prefix(matched: matched + 1)
+            return true
+
+        case .name(let node):
+            if let next = trie.child(node, byte) {
+                phase = .name(node: next)
+                return true
+            }
+            // The template renders no whitespace around the name, so `{` on a
+            // terminal node is the only way out of the trie.
+            guard byte == UInt8(ascii: "{"), trie.isTerminal(node) else { return false }
+            var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+            guard automaton.consume(byte) else { return false }
+            phase = .arguments(automaton)
+            return true
+
+        case .arguments(var automaton):
+            guard automaton.consume(byte) else { return false }
+            phase = .arguments(automaton)
+            return true
+
+        case .free, .afterCall:
+            return false
+        }
+    }
+}

--- a/Sources/TurboFieldfare/Tokenization/GemmaToolCallParser.swift
+++ b/Sources/TurboFieldfare/Tokenization/GemmaToolCallParser.swift
@@ -85,7 +85,12 @@ private struct Parser {
         let start = index
         while index < characters.count {
             let character = characters[index]
-            guard character.isLetter || character.isNumber || character == "_" else { break }
+            // Matches OpenAIToolName.isValid, which the server already accepts:
+            // hyphens are legal in OpenAI tool names, and the chat template
+            // renders the name verbatim into the call, so a narrower identifier
+            // alphabet makes every hyphenated tool undecodable.
+            guard character.isLetter || character.isNumber
+                    || character == "_" || character == "-" else { break }
             index += 1
         }
         guard index > start else { throw GemmaToolCallParserError.malformed }
@@ -171,12 +176,20 @@ private struct Parser {
         try consume("\"")
         var result = ""
         while !isAtEnd {
-            if take("\"") { return result }
-            if take("\\") {
+            // `take` skips whitespace before matching, which silently swallowed
+            // every space, tab and newline inside the string: `"/tmp/a b c"`
+            // decoded as `/tmp/abc`. Inside a string no character is a
+            // delimiter to skip past.
+            let character = characters[index]
+            if character == "\"" {
+                index += 1
+                return result
+            }
+            index += 1
+            if character == "\\" {
                 result += try escapedFragment()
             } else {
-                result.append(characters[index])
-                index += 1
+                result.append(character)
             }
         }
         throw GemmaToolCallParserError.malformed

--- a/Sources/TurboFieldfare/Tokenization/StructuredAssistantDecoder.swift
+++ b/Sources/TurboFieldfare/Tokenization/StructuredAssistantDecoder.swift
@@ -31,8 +31,21 @@ public final class StructuredAssistantDecoder: @unchecked Sendable {
         self.idGenerator = idGenerator
     }
 
-    public func consume(tokenID: Int32, delta: String) throws -> [StructuredAssistantEvent] {
+    /// `validatedBody` carries the grammar-approved bytes of the region this
+    /// token closed. When present the parse runs on THOSE bytes instead of
+    /// `decode(_:skipSpecialTokens:)`: the library decode applies `cleanUp`
+    /// (` ,` → `,`, ` 's` → `'s`; swift-transformers defaults it on and this
+    /// tokenizer's config does not disable it), which silently rewrites string
+    /// arguments.
+    public func consume(tokenID: Int32,
+                        delta: String,
+                        validatedBody: [UInt8]? = nil) throws -> [StructuredAssistantEvent] {
         guard !failed else { throw GemmaToolCallParserError.malformed }
+        // NOTE: the channel markers are checked before the tool-region
+        // accumulation below, so a marker inside a region is swallowed instead
+        // of reaching the parser. That is a real gap (upstream issue #84), but
+        // reordering would change behaviour with the constraint off; with the
+        // constraint on the filter vetoes those markers before they get here.
         if tokenID == tokenizer.channelStartID {
             label = ""
             channel = .label
@@ -56,7 +69,8 @@ public final class StructuredAssistantDecoder: @unchecked Sendable {
                 throw GemmaToolCallParserError.malformed
             }
             toolTokens = nil
-            let text = tokenizer.decode(tokens, skipSpecialTokens: false)
+            let text = validatedBody.map { String(decoding: $0, as: UTF8.self) }
+                ?? tokenizer.decode(tokens, skipSpecialTokens: false)
             do {
                 let call = try GemmaToolCallParser().parse(
                     text, allowedTools: allowedTools, id: idGenerator())
@@ -76,6 +90,9 @@ public final class StructuredAssistantDecoder: @unchecked Sendable {
         }
         if var tokens = toolTokens {
             tokens.append(tokenID)
+            // NOTE: a token-count cap, not a byte cap — deliberately left alone
+            // because tightening it would change behaviour with the constraint
+            // off. The tool-call filter caps the real byte count.
             guard tokens.count * MemoryLayout<Int32>.size <= GemmaToolCallParser.maximumBytes else {
                 failed = true
                 throw GemmaToolCallParserError.oversized
@@ -110,4 +127,7 @@ public final class StructuredAssistantDecoder: @unchecked Sendable {
     }
 
     public var hasToolCalls: Bool { emittedCalls > 0 }
+
+    /// A `<|tool_call>` region is open: the generation was cut before it closed.
+    public var hasOpenToolRegion: Bool { toolTokens != nil }
 }

--- a/Sources/TurboFieldfare/Tokenization/Tokenizer.swift
+++ b/Sources/TurboFieldfare/Tokenization/Tokenizer.swift
@@ -42,6 +42,10 @@ public struct GFTokenizer: @unchecked Sendable {
     public let toolResponseEndID: Int32
     public let channelStartID: Int32
     public let channelEndID: Int32
+    /// `<|"|>`, the template's `escape_token`: the string delimiter inside a
+    /// tool-call argument body, and the one marker-shaped piece the tool-call
+    /// grammar must let through verbatim.
+    public let escapeTokenID: Int32
     public let stopTokenIDs: Set<Int32>
     public let vocabSize: Int
 
@@ -117,7 +121,8 @@ public struct GFTokenizer: @unchecked Sendable {
               let toolCallEnd = tokenizer.convertTokenToId("<tool_call|>"),
               let toolResponseEnd = tokenizer.convertTokenToId("<tool_response|>"),
               let channelStart = tokenizer.convertTokenToId("<|channel>"),
-              let channelEnd = tokenizer.convertTokenToId("<channel|>") else {
+              let channelEnd = tokenizer.convertTokenToId("<channel|>"),
+              let escape = tokenizer.convertTokenToId("<|\"|>") else {
             throw GFTokenizerError.missingSpecialToken("Gemma tool/channel markers")
         }
 
@@ -131,6 +136,7 @@ public struct GFTokenizer: @unchecked Sendable {
         self.toolResponseEndID = Int32(toolResponseEnd)
         self.channelStartID = Int32(channelStart)
         self.channelEndID = Int32(channelEnd)
+        self.escapeTokenID = Int32(escape)
         self.stopTokenIDs = [self.eosID, self.endOfTurnID, self.toolResponseID]
         self.vocabSize = 262_144
     }

--- a/Sources/TurboFieldfareCLI/Args.swift
+++ b/Sources/TurboFieldfareCLI/Args.swift
@@ -12,6 +12,7 @@ public struct Args: Equatable, Sendable {
     public var repetitionPenalty: Float
     public var seed: UInt64?
     public var stops: [String]
+    public var forceJSON: Bool
     public var quiet: Bool
     public var expertCacheSlots: Int
     public var expertCachePolicy: RuntimeExpertCachePolicy
@@ -30,6 +31,7 @@ public struct Args: Equatable, Sendable {
                 repetitionPenalty: Float = 1.0,
                 seed: UInt64? = nil,
                 stops: [String] = [],
+                forceJSON: Bool = false,
                 quiet: Bool = false,
                 expertCacheSlots: Int = RuntimeConfiguration.production.expertCacheSlots,
                 expertCachePolicy: RuntimeExpertCachePolicy = RuntimeConfiguration.production.expertCachePolicy,
@@ -47,6 +49,7 @@ public struct Args: Equatable, Sendable {
         self.repetitionPenalty = repetitionPenalty
         self.seed = seed
         self.stops = stops
+        self.forceJSON = forceJSON
         self.quiet = quiet
         self.expertCacheSlots = expertCacheSlots
         self.expertCachePolicy = expertCachePolicy
@@ -98,6 +101,8 @@ extension Args {
       --repetition-penalty <f>   Repetition penalty (default 1.0).
       --seed <uint64>            Deterministic sampling seed (default off).
       --stop <string>            Stop substring (repeatable).
+      --force-json               Constrain decoding to grammar-valid JSON;
+                                 EOS is forced when the root value closes.
       --quiet                    Suppress the timing footer.
       --expert-cache-slots <n>   Expert-cache slots: 8, 16, 24, or 32 (default 16).
       --expert-cache-policy <s>  Expert-cache policy: lfu or lru (default lfu).
@@ -146,6 +151,7 @@ extension Args {
         var repetitionPenalty: Float = 1.0
         var seed: UInt64?
         var stops: [String] = []
+        var forceJSON = false
         var quiet = false
         let runtimeDefaults = RuntimeConfiguration.production
         var expertCacheSlots = runtimeDefaults.expertCacheSlots
@@ -213,6 +219,9 @@ extension Args {
                 seed = parsed
             case "--stop":
                 stops.append(try takeValue(argv, &index, flag: flag))
+            case "--force-json":
+                forceJSON = true
+                index += 1
             case "--expert-cache-slots":
                 let value = try takeValue(argv, &index, flag: flag)
                 guard let parsed = Int(value),
@@ -272,6 +281,7 @@ extension Args {
                              repetitionPenalty: repetitionPenalty,
                              seed: seed,
                              stops: stops,
+                             forceJSON: forceJSON,
                              quiet: quiet,
                              expertCacheSlots: expertCacheSlots,
                              expertCachePolicy: expertCachePolicy,

--- a/Sources/TurboFieldfareCLI/Args.swift
+++ b/Sources/TurboFieldfareCLI/Args.swift
@@ -103,6 +103,7 @@ extension Args {
       --stop <string>            Stop substring (repeatable).
       --force-json               Constrain decoding to grammar-valid JSON;
                                  EOS is forced when the root value closes.
+                                 Incompatible with --stop
       --quiet                    Suppress the timing footer.
       --expert-cache-slots <n>   Expert-cache slots: 8, 16, 24, or 32 (default 16).
       --expert-cache-policy <s>  Expert-cache policy: lfu or lru (default lfu).
@@ -265,6 +266,9 @@ extension Args {
             throw ArgsError.mutuallyExclusive("--prompt", "--messages-file")
         }
         if prompt == nil && messagesFile == nil { throw ArgsError.modeMissing }
+        if forceJSON && !stops.isEmpty {
+            throw ArgsError.mutuallyExclusive("--force-json", "--stop")
+        }
         if temperature > 0, topK == nil, let topP, topP < 1 {
             throw ArgsError.invalidValue(
                 flag: "--top-p",

--- a/Sources/TurboFieldfareCLI/Run.swift
+++ b/Sources/TurboFieldfareCLI/Run.swift
@@ -52,7 +52,8 @@ public func run(args: Args,
             repetitionPenalty: args.repetitionPenalty,
             seed: args.seed,
             stopStrings: args.stops,
-            extraStopTokens: [])
+            extraStopTokens: [],
+            forceJSON: args.forceJSON)
         let runtime = try args.resolvedRuntimeConfiguration(
             forceLogitsHead: !config.isPureGreedy)
 

--- a/Sources/TurboFieldfareCLI/Run.swift
+++ b/Sources/TurboFieldfareCLI/Run.swift
@@ -96,7 +96,8 @@ public func run(args: Args,
             let tokensPerSecond = stats.decodeSeconds > 0
                 ? Double(stats.newTokens) / stats.decodeSeconds
                 : 0
-            let footer = "\n[stop=\(String(describing: stats.reason)) prefill=\(stats.prefillTokens)tok new=\(stats.newTokens)tok decode=\(String(format: "%.2f", stats.decodeSeconds))s tok/s=\(String(format: "%.3f", tokensPerSecond))]\n"
+            let vetoes = args.forceJSON ? " vetoes=\(stats.grammarVetoes)" : ""
+            let footer = "\n[stop=\(String(describing: stats.reason)) prefill=\(stats.prefillTokens)tok new=\(stats.newTokens)tok decode=\(String(format: "%.2f", stats.decodeSeconds))s tok/s=\(String(format: "%.3f", tokensPerSecond))\(vetoes)]\n"
             stderr.write(Data(footer.utf8))
         }
         return RunResult(exitCode: 0)

--- a/Sources/TurboFieldfareServer/Command/main.swift
+++ b/Sources/TurboFieldfareServer/Command/main.swift
@@ -19,13 +19,14 @@ do {
     let backend = try await ServerModelSession.load(
         modelDirectory: modelURL,
         maxContext: arguments.maxContext,
-        promptCacheMode: arguments.promptCacheMode)
+        promptCacheMode: arguments.promptCacheMode,
+        toolCallGrammar: arguments.toolCallGrammar)
     let server = TurboFieldfareHTTPServer(
         modelID: arguments.modelID,
         queueLimit: arguments.queueLimit,
         backend: backend)
     _ = try await server.start(port: arguments.port)
-    print("TurboFieldfareServer ready at http://127.0.0.1:\(arguments.port) model=\(arguments.modelID) context=\(arguments.maxContext) prompt_cache=\(arguments.promptCacheMode.rawValue)")
+    print("TurboFieldfareServer ready at http://127.0.0.1:\(arguments.port) model=\(arguments.modelID) context=\(arguments.maxContext) prompt_cache=\(arguments.promptCacheMode.rawValue) tool_call_grammar=\(arguments.toolCallGrammar.rawValue)")
 
     _ = await signals.wait()
     try await server.shutdown()

--- a/Sources/TurboFieldfareServer/Core/ServerArguments.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerArguments.swift
@@ -7,6 +7,7 @@ public struct ServerArguments: Equatable, Sendable {
     public let maxContext: Int
     public let queueLimit: Int
     public let promptCacheMode: ServerPromptCacheMode
+    public let toolCallGrammar: ServerToolCallGrammarMode
 
     public static let usage = """
     usage: TurboFieldfareServer --model <completed .gturbo directory> [options]
@@ -18,6 +19,9 @@ public struct ServerArguments: Equatable, Sendable {
       --queue-limit <count>  Maximum queued requests (default 4).
       --prompt-cache-mode <off|single-prefix>
                              Prompt KV reuse mode (default single-prefix).
+      --tool-call-grammar <on|off>
+                             Constrain <|tool_call> blocks to the Gemma
+                             tool-call grammar (default on).
       --help                 Show this help.
     """
 
@@ -28,6 +32,7 @@ public struct ServerArguments: Equatable, Sendable {
         var maxContext = 16_384
         var queueLimit = 4
         var promptCacheMode: ServerPromptCacheMode = .singlePrefix
+        var toolCallGrammar: ServerToolCallGrammarMode = .on
         var index = 0
         while index < input.count {
             let flag = input[index]
@@ -67,6 +72,12 @@ public struct ServerArguments: Equatable, Sendable {
                         "--prompt-cache-mode must be off or single-prefix")
                 }
                 promptCacheMode = parsed
+            case "--tool-call-grammar":
+                guard let parsed = ServerToolCallGrammarMode(rawValue: value) else {
+                    throw ServerArgumentError.invalid(
+                        "--tool-call-grammar must be on or off")
+                }
+                toolCallGrammar = parsed
             default:
                 throw ServerArgumentError.invalid("unknown flag: \(flag)")
             }
@@ -77,7 +88,8 @@ public struct ServerArguments: Equatable, Sendable {
                                modelID: modelID,
                                maxContext: maxContext,
                                queueLimit: queueLimit,
-                               promptCacheMode: promptCacheMode)
+                               promptCacheMode: promptCacheMode,
+                               toolCallGrammar: toolCallGrammar)
     }
 }
 

--- a/Sources/TurboFieldfareServer/Core/ServerInference.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerInference.swift
@@ -77,6 +77,8 @@ struct StructuredOutputFailureDiagnostics: Equatable, Sendable {
     let kvPositionMatchesHistory: Bool
     let completionCountMatchesHistory: Bool
     let prefillAccountingMatches: Bool
+    let toolGrammarVetoes: Int
+    let toolNameVetoes: Int
     let renderedPromptHash: String
     let effectivePromptHash: String
     let generatedHash: String
@@ -165,6 +167,8 @@ struct StructuredOutputFailureDiagnostics: Equatable, Sendable {
         self.completionCountMatchesHistory = offset == result.newTokens
         self.prefillAccountingMatches = !prefillOverflow
             && prefillAccounted == result.prefillTokens
+        self.toolGrammarVetoes = result.toolGrammarVetoes
+        self.toolNameVetoes = result.toolNameVetoes
         self.renderedPromptHash = Self.i32leSHA256([renderedPromptIDs[...]])
         self.effectivePromptHash = Self.i32leSHA256([effectivePromptIDs[...]])
         self.generatedHash = Self.i32leSHA256(generatedSegments)
@@ -219,6 +223,8 @@ struct StructuredOutputFailureDiagnostics: Equatable, Sendable {
             "kv_position_matches_history=\(kvPositionMatchesHistory)",
             "completion_count_matches_history=\(completionCountMatchesHistory)",
             "prefill_accounting_matches=\(prefillAccountingMatches)",
+            "tool_grammar_vetoes=\(toolGrammarVetoes)",
+            "tool_name_vetoes=\(toolNameVetoes)",
             "rendered_prompt_i32le_sha256=\(renderedPromptHash)",
             "effective_prompt_i32le_sha256=\(effectivePromptHash)",
             "generated_i32le_sha256=\(generatedHash)",
@@ -374,6 +380,14 @@ public actor ServerCoordinator {
     public var isActive: Bool { active }
 }
 
+/// Whether `<|tool_call>` blocks are constrained to the Gemma tool-call
+/// grammar. `off` restores the pre-constraint token stream exactly, which is
+/// what makes the flag a usable escape hatch and a regression control.
+public enum ServerToolCallGrammarMode: String, Sendable, Equatable {
+    case on
+    case off
+}
+
 public actor ServerModelSession: ServerInferenceBackend {
     private let context: MetalContext
     private let model: Model
@@ -384,11 +398,13 @@ public actor ServerModelSession: ServerInferenceBackend {
     private let maxContext: Int
     private let promptCacheMode: ServerPromptCacheMode
     private let promptCacheDomain: ServerPromptCacheDomain
+    private let toolCallGrammar: ServerToolCallGrammarMode
     private var promptCache = ServerPromptCache()
 
     public static func load(modelDirectory: URL,
                             maxContext: Int,
-                            promptCacheMode: ServerPromptCacheMode = .singlePrefix) async throws -> ServerModelSession {
+                            promptCacheMode: ServerPromptCacheMode = .singlePrefix,
+                            toolCallGrammar: ServerToolCallGrammarMode = .on) async throws -> ServerModelSession {
         let tokenizerFolder = GFTokenizer.tokenizerFolder(forModelDirectory: modelDirectory)
         guard let tokenizerFolder else {
             throw GFTokenizerError.missingToolTemplate
@@ -441,7 +457,8 @@ public actor ServerModelSession: ServerInferenceBackend {
                                   prefillConfig: runtime.prefillConfig,
                                   maxContext: maxContext,
                                   promptCacheMode: promptCacheMode,
-                                  promptCacheDomain: promptCacheDomain)
+                                  promptCacheDomain: promptCacheDomain,
+                                  toolCallGrammar: toolCallGrammar)
     }
 
     private init(context: MetalContext,
@@ -452,7 +469,8 @@ public actor ServerModelSession: ServerInferenceBackend {
                  prefillConfig: PrefillRuntimeConfig,
                  maxContext: Int,
                  promptCacheMode: ServerPromptCacheMode,
-                 promptCacheDomain: ServerPromptCacheDomain) {
+                 promptCacheDomain: ServerPromptCacheDomain,
+                 toolCallGrammar: ServerToolCallGrammarMode) {
         self.context = context
         self.model = model
         self.tokenizer = tokenizer
@@ -462,6 +480,7 @@ public actor ServerModelSession: ServerInferenceBackend {
         self.maxContext = maxContext
         self.promptCacheMode = promptCacheMode
         self.promptCacheDomain = promptCacheDomain
+        self.toolCallGrammar = toolCallGrammar
     }
 
     public func generate(
@@ -530,6 +549,14 @@ public actor ServerModelSession: ServerInferenceBackend {
                 tokenizer: tokenizer,
                 allowedTools: Set(request.tools.map(\.name)))
             : nil
+        // Same predicate and same name set as the decoder. With no tools
+        // declared the trie is empty and `<|tool_call>` is blocked outright:
+        // that shape decodes as `unknownTool` today, which the server turns
+        // into a 500; now it comes back as text.
+        let toolFilter = toolCallGrammar == .on && needsToolTemplate
+            ? ToolCallTokenFilter(tokenizer: tokenizer,
+                                  allowedNames: Set(request.tools.map(\.name)))
+            : nil
         var stopMatcher = StreamingStopMatcher(stops: request.generationConfig.stopStrings)
         var content = ""
         var calls: [ParsedToolCall] = []
@@ -545,6 +572,7 @@ public actor ServerModelSession: ServerInferenceBackend {
             scratch: scratch,
             prefillConfig: prefillConfig,
             start: completionStart,
+            toolFilter: toolFilter,
             shouldStop: { shouldStop }) { progress in
                 guard decodingError == nil else { return }
                 do {
@@ -553,7 +581,9 @@ public actor ServerModelSession: ServerInferenceBackend {
                         break
                     case .token(_, let tokenID, let delta):
                         let events = if let decoder {
-                            try decoder.consume(tokenID: tokenID, delta: delta)
+                            try decoder.consume(tokenID: tokenID,
+                                                delta: delta,
+                                                validatedBody: toolFilter?.closedCallBody)
                         } else {
                             delta.isEmpty ? [] : [StructuredAssistantEvent.content(delta)]
                         }
@@ -608,12 +638,22 @@ public actor ServerModelSession: ServerInferenceBackend {
                 kind: .decoderConsume,
                 cause: .classify(decodingError))
         }
-        do {
-            try decoder?.finish()
-        } catch {
-            throw structuredFailure(
-                kind: .decoderFinish,
-                cause: .classify(error))
+        // A tool call cut off by the completion budget is a length stop, not a
+        // server error: report what was decoded instead of turning the whole
+        // request into a 500. Only reachable with the grammar on — without it an
+        // open region can also mean the model derailed, which the diagnostics
+        // must keep surfacing.
+        let truncatedByBudget = toolFilter != nil
+            && decoder?.hasOpenToolRegion == true
+            && result.reason == .maxTokens
+        if !truncatedByBudget {
+            do {
+                try decoder?.finish()
+            } catch {
+                throw structuredFailure(
+                    kind: .decoderFinish,
+                    cause: .classify(error))
+            }
         }
         if needsToolTemplate, result.reason == .toolCalls, calls.isEmpty {
             throw structuredFailure(kind: .orphanToolResponse, cause: .none)
@@ -624,7 +664,9 @@ public actor ServerModelSession: ServerInferenceBackend {
             onEvent(.content(tail))
         }
         let reason: String
-        if !calls.isEmpty {
+        if truncatedByBudget {
+            reason = "length"
+        } else if !calls.isEmpty {
             reason = "tool_calls"
         } else if result.reason == .maxTokens {
             reason = "length"

--- a/Sources/TurboFieldfareServer/Core/ServerInference.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerInference.swift
@@ -680,7 +680,15 @@ public actor ServerModelSession: ServerInferenceBackend {
                 content: content,
                 calls: calls,
                 result: result,
-                stopStringFiltered: stopMatcher.isStopped)
+                stopStringFiltered: stopMatcher.isStopped,
+                toolRegionOpen: truncatedByBudget)
+        }
+        if truncatedByBudget {
+            // The cache refused the entry above; the KV it would have described
+            // must go too. It ends inside a call this response did not reveal,
+            // so nothing may resume from it — same disposal the pre-constraint
+            // 500 got from the `completed` guard, without the 500.
+            runner.reset()
         }
         completed = true
         return ServerCompletion(

--- a/Sources/TurboFieldfareServer/Core/ServerPromptCache.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerPromptCache.swift
@@ -43,15 +43,23 @@ struct ServerPromptCache: Sendable {
         entry = nil
     }
 
+    /// Records the turn as the prefix the next request may resume from. Only a
+    /// turn the client can reproduce from what it received qualifies, so the
+    /// entry is refused for an unsafe stop, for a filtered stop string, and —
+    /// `toolRegionOpen` — for a KV that ends inside a `<|tool_call>` region the
+    /// generation never closed: the client's history cannot contain a call the
+    /// response never revealed, so resuming there would silently continue one.
     mutating func publish(
         domain: ServerPromptCacheDomain,
         request: ValidatedChatRequest,
         content: String,
         calls: [ParsedToolCall],
         result: RawDecodeResult,
-        stopStringFiltered: Bool = false
+        stopStringFiltered: Bool = false,
+        toolRegionOpen: Bool = false
     ) {
-        guard result.kvPosition == result.kvBackedTokenIDs.count,
+        guard !toolRegionOpen,
+              result.kvPosition == result.kvBackedTokenIDs.count,
               !result.kvBackedTokenIDs.isEmpty,
               result.uncommittedBoundaryTokenIDs.count == 1,
               !stopStringFiltered,

--- a/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
+++ b/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
@@ -68,7 +68,7 @@ import TurboFieldfare
         let expected: Set<String> = [
             "--model", "--prompt", "--messages-file", "--max-new", "--max-context",
             "--temperature", "--top-k", "--top-p", "--repetition-penalty",
-            "--seed", "--stop", "--quiet", "--expert-cache-slots",
+            "--seed", "--stop", "--force-json", "--quiet", "--expert-cache-slots",
             "--expert-cache-policy", "--prefill", "--prefill-chunk-tokens",
             "--rdadvise", "--help",
         ]

--- a/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
+++ b/Tests/TurboFieldfare/Core/CLI/CLIArgumentsTests.swift
@@ -56,6 +56,15 @@ import TurboFieldfare
         }
     }
 
+    @Test func forceJSONRejectsStopStrings() {
+        #expect(throws: ArgsError.mutuallyExclusive("--force-json", "--stop")) {
+            _ = try Args.parse([
+                "--model", "m.gturbo", "--prompt", "hi",
+                "--force-json", "--stop", "}",
+            ])
+        }
+    }
+
     @Test func topKAboveKernelLimitRejected() {
         #expect(throws: ArgsError.invalidValue(flag: "--top-k", value: "257")) {
             _ = try Args.parse([

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/GemmaArgumentDialectTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/GemmaArgumentDialectTests.swift
@@ -1,0 +1,337 @@
+import Testing
+import Foundation
+@testable import TurboFieldfare
+
+/// `JSONByteAutomaton(dialect: .gemmaToolArguments)`: the argument language the
+/// Gemma 4 chat template renders and `GemmaToolCallParser` reads. Every accept
+/// case here must also parse; every reject case is either outside the parser's
+/// language or inside it but decoded to something other than what was
+/// generated.
+@Suite struct GemmaArgumentDialectTests {
+
+    private func feedBytes(_ automaton: inout JSONByteAutomaton, _ bytes: [UInt8]) -> Bool {
+        for byte in bytes {
+            guard automaton.consume(byte) else { return false }
+        }
+        return true
+    }
+
+    private func step(_ automaton: inout JSONByteAutomaton, _ byte: UInt8) -> Bool {
+        automaton.consume(byte)
+    }
+
+    private func accepts(_ bytes: [UInt8]) -> JSONByteAutomaton? {
+        var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+        return feedBytes(&automaton, bytes) ? automaton : nil
+    }
+
+    private func completes(_ text: String) -> Bool {
+        accepts(Array(text.utf8))?.isComplete == true
+    }
+
+    private func rejects(_ text: String) -> Bool {
+        accepts(Array(text.utf8)) == nil
+    }
+
+    // MARK: - Structure
+
+    @Test func emptyObjectCompletes() {
+        #expect(completes("{}"))
+    }
+
+    @Test func bareKeysAtEveryDepth() throws {
+        let body = "{a:1,b:{c:[1,{d:true}],e:null},f:false}"
+        #expect(completes(body))
+        let call = try GemmaToolCallParser().parse(
+            "call:f\(body)", allowedTools: ["f"], id: "x")
+        #expect(call.arguments.objectValue?.count == 3)
+    }
+
+    @Test func exoticKeyAlphabetAccepted() {
+        #expect(completes("{a_b-c.d$e:1}"))
+        #expect(completes("{0:1}"))
+        #expect(completes("{$:1}"))
+        #expect(completes("{-:1}"))
+    }
+
+    @Test func whitespaceAtJunctionsAccepted() throws {
+        let body = "{ a : 1 , b : [ 1 , 2 ] }"
+        #expect(completes(body))
+        let call = try GemmaToolCallParser().parse(
+            "call:f\(body)", allowedTools: ["f"], id: "x")
+        #expect(call.arguments == .object(["a": .integer(1),
+                                           "b": .array([.integer(1), .integer(2)])]))
+    }
+
+    @Test func quotedKeyRejected() {
+        // Failure cause #1 in the upstream report: the model drifts to
+        // canonical JSON and the parser rejects the quoted key.
+        #expect(rejects(#"{"a":1}"#))
+    }
+
+    @Test func quotedStringValueRejected() {
+        // Accepted by the parser but silently whitespace-mangled by it.
+        #expect(rejects(#"{a:"x"}"#))
+    }
+
+    @Test func arrayRootRejected() {
+        #expect(rejects("[1]"))
+        #expect(rejects("1"))
+        #expect(rejects(#"<|"|>x<|"|>"#))
+    }
+
+    @Test func trailingCommaAndEmptyMemberRejected() {
+        #expect(rejects("{a:1,}"))
+        #expect(rejects("{,"))
+        #expect(rejects("{:1}"))
+    }
+
+    @Test func depthIsBounded() {
+        let opens = String(repeating: "[", count: JSONByteAutomaton.maxDepth)
+        #expect(accepts(Array("{a:\(opens)".utf8)) == nil)
+        let fits = String(repeating: "[", count: JSONByteAutomaton.maxDepth - 1)
+        #expect(accepts(Array("{a:\(fits)".utf8)) != nil)
+    }
+
+    // MARK: - Numbers
+
+    @Test func boundedNumbersAccepted() throws {
+        let body = "{a:0.000000000000001,b:999999999999999.999999999999999,c:-0,d:0}"
+        #expect(completes(body))
+        let call = try GemmaToolCallParser().parse(
+            "call:f\(body)", allowedTools: ["f"], id: "x")
+        #expect(call.arguments.objectValue?["c"] == .integer(0))
+    }
+
+    @Test func exponentsAndMalformedNumbersRejected() {
+        #expect(rejects("{a:1e5}"))
+        #expect(rejects("{a:1E5}"))
+        #expect(rejects("{a:1.5e-3}"))
+        #expect(rejects("{a:01}"))
+        #expect(rejects("{a:.5}"))
+        #expect(rejects("{a:1.}"))
+        #expect(rejects("{a:+1}"))
+        #expect(rejects("{a:NaN}"))
+    }
+
+    @Test func digitCountIsCapped() {
+        #expect(completes("{a:999999999999999}"))          // 15 integer digits
+        #expect(rejects("{a:9999999999999999}"))           // 16
+        #expect(completes("{a:0.999999999999999}"))        // 15 fraction digits
+        #expect(rejects("{a:0.9999999999999999}"))         // 16
+    }
+
+    // MARK: - Strings
+
+    @Test func gemmaStringsAcceptContentAndEscapes() throws {
+        // Raw quotes, a raw tab and a raw newline are legal content; the escape
+        // forms are the ones the parser's `escapedFragment` reads.
+        let raw = "{a:<|\"|>he said \"hi\"\t\nx<|\"|>,"
+        let escaped = #"b:<|"|>\"\\\/\b\f\n\r\t<|"|>,c:<|"|>\ud83d\ude00<|"|>}"#
+        let body = raw + escaped
+        #expect(completes(body))
+        let call = try GemmaToolCallParser().parse(
+            "call:f\(body)", allowedTools: ["f"], id: "x")
+        #expect(call.arguments.objectValue?["a"] == .string("he said \"hi\"\t\nx"))
+        #expect(call.arguments.objectValue?["b"] == .string("\"\\/\u{8}\u{c}\n\r\t"))
+        #expect(call.arguments.objectValue?["c"] == .string("\u{1F600}"))
+    }
+
+    @Test func delimiterMaySpellOutOneByteAtATime() {
+        var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+        #expect(feedBytes(&automaton, Array("{a:".utf8)))
+        for byte in Array(#"<|"|>"#.utf8) { #expect(step(&automaton, byte)) }
+        #expect(step(&automaton, UInt8(ascii: "x")))
+        for byte in Array(#"<|"|>"#.utf8) { #expect(step(&automaton, byte)) }
+        #expect(step(&automaton, UInt8(ascii: "}")))
+        #expect(automaton.isComplete)
+    }
+
+    @Test func multibyteScalarMaySplitAcrossBytes() {
+        var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+        #expect(feedBytes(&automaton, Array(#"{a:<|"|>"#.utf8)))
+        for byte in Array("ñ😀".utf8) { #expect(step(&automaton, byte)) }
+        // Mid-sequence the delimiter cannot start.
+        #expect(feedBytes(&automaton, [0xF0]))
+        #expect(!step(&automaton, UInt8(ascii: "<")))
+        #expect(feedBytes(&automaton, [0x9F, 0x98, 0x81]))
+        #expect(feedBytes(&automaton, Array(#"<|"|>}"#.utf8)))
+        #expect(automaton.isComplete)
+    }
+
+    @Test func invalidUTF8InsideStringRejected() {
+        for bad: [UInt8] in [[0xC0], [0xF5], [0x80], [0xE0, 0x80], [0xF4, 0x90], [0xED, 0xA0]] {
+            var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+            #expect(feedBytes(&automaton, Array(#"{a:<|"|>"#.utf8)))
+            #expect(!feedBytes(&automaton, bad))
+        }
+    }
+
+    @Test func controlBytesInsideStringRejected() {
+        var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+        #expect(feedBytes(&automaton, Array(#"{a:<|"|>"#.utf8)))
+        #expect(!step(&automaton, 0x07))
+        for byte: UInt8 in [0x09, 0x0A, 0x0D] { #expect(step(&automaton, byte)) }
+    }
+
+    @Test func loneSurrogateEscapesRejected() {
+        #expect(rejects(#"{a:<|"|>\ud83d<|"|>}"#))
+        #expect(rejects(#"{a:<|"|>\udc00x<|"|>}"#))
+        #expect(rejects(#"{a:<|"|>\ud83dx<|"|>}"#))
+    }
+
+    // MARK: - Delimiter scanning matches the parser's leftmost scan
+
+    @Test func partialDelimitersStayContent() throws {
+        for content in ["<|", #"<|"|"#, "<<", "|>", #""|>"#, #"<|"|<"#] {
+            let body = #"{a:<|"|>"# + content + #"<|"|>}"#
+            #expect(completes(body), "not accepted: \(content)")
+            let call = try GemmaToolCallParser().parse(
+                "call:f\(body)", allowedTools: ["f"], id: "x")
+            #expect(call.arguments.objectValue?["a"] == .string(content))
+        }
+    }
+
+    /// An embedded delimiter closes the string at the same byte the parser
+    /// closes it: the pattern has no proper border, so resetting to zero and
+    /// re-dispatching is the leftmost match.
+    @Test func embeddedDelimiterClosesWhereTheParserCloses() throws {
+        let body = #"{a:<|"|><|<|"|>}"#
+        #expect(completes(body))
+        let call = try GemmaToolCallParser().parse(
+            "call:f\(body)", allowedTools: ["f"], id: "x")
+        #expect(call.arguments.objectValue?["a"] == .string("<|"))
+    }
+
+    // MARK: - Grapheme-merge guard (Prepend scalars)
+
+    @Test func prependScalarBlocksDelimiterAndEscape() {
+        // U+0600 is Grapheme_Cluster_Break=Prepend: in the parser's
+        // `[Character]` lexer it fuses with the next `<`, hiding the closing
+        // delimiter, so the string never terminates.
+        for next: UInt8 in [UInt8(ascii: "<"), UInt8(ascii: "\\")] {
+            var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+            #expect(feedBytes(&automaton, Array(#"{a:<|"|>"#.utf8)))
+            #expect(feedBytes(&automaton, [0xD8, 0x80]))
+            #expect(!step(&automaton, next))
+            // Any other content clears the guard.
+            #expect(step(&automaton, UInt8(ascii: "x")))
+            #expect(step(&automaton, next))
+        }
+    }
+
+    @Test func prependGuardSurvivesTheRealParser() throws {
+        // The rejected form is exactly the one the parser cannot decode.
+        #expect(throws: GemmaToolCallParserError.malformed) {
+            try GemmaToolCallParser().parse(
+                "call:f{a:<|\"|>x\u{0600}<|\"|>}", allowedTools: ["f"], id: "x")
+        }
+        let call = try GemmaToolCallParser().parse(
+            "call:f{a:<|\"|>x\u{0600}y<|\"|>}", allowedTools: ["f"], id: "x")
+        #expect(call.arguments.objectValue?["a"] == .string("x\u{0600}y"))
+    }
+
+    /// A combining scalar joins onto whatever precedes it, so at the two
+    /// positions where the parser compares a literal ASCII character — the
+    /// opening delimiter's `>` and the last character of an escape — it would
+    /// hide that character and the parse falls apart.
+    /// A rejection can leave a partially consumed sequence behind, so each case
+    /// starts from a fresh automaton parked at the guarded position.
+    private func atGuardedPosition(_ prefix: String) -> JSONByteAutomaton {
+        var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+        #expect(feedBytes(&automaton, Array(prefix.utf8)))
+        return automaton
+    }
+
+    @Test func combiningScalarCannotHideTheOpeningDelimiter() throws {
+        for mark in ["\u{0618}", "\u{0301}", "\u{200D}"] {
+            var automaton = atGuardedPosition(#"{a:<|"|>"#)
+            #expect(!feedBytes(&automaton, Array(mark.utf8)), "accepted \(mark)")
+        }
+        // A base scalar is fine, and clears the guard for a following mark.
+        var automaton = atGuardedPosition(#"{a:<|"|>"#)
+        #expect(feedBytes(&automaton, Array("é\u{0301}".utf8)))
+        #expect(feedBytes(&automaton, Array(#"<|"|>}"#.utf8)))
+        #expect(automaton.isComplete)
+
+        #expect(throws: GemmaToolCallParserError.malformed) {
+            try GemmaToolCallParser().parse(
+                "call:f{a:<|\"|>\u{0618}x<|\"|>}", allowedTools: ["f"], id: "x")
+        }
+    }
+
+    @Test func combiningScalarCannotHideAnEscape() throws {
+        for prefix in [#"{a:<|"|>\n"#, #"{a:<|"|>\\"#, #"{a:<|"|>\u0041"#] {
+            var automaton = atGuardedPosition(prefix)
+            #expect(!feedBytes(&automaton, Array("\u{0301}".utf8)), "accepted after \(prefix)")
+        }
+        // Ordinary content is not a guarded position: a mark joining onto a
+        // base character changes nothing the parser reads.
+        var plain = atGuardedPosition(#"{a:<|"|>A"#)
+        #expect(feedBytes(&plain, Array("\u{0301}".utf8)))
+        var automaton = atGuardedPosition(#"{a:<|"|>\n"#)
+        #expect(feedBytes(&automaton, Array(#"x<|"|>}"#.utf8)))
+        #expect(automaton.isComplete)
+
+        #expect(throws: GemmaToolCallParserError.malformed) {
+            try GemmaToolCallParser().parse(
+                "call:f{a:<|\"|>\\n\u{0301}<|\"|>}", allowedTools: ["f"], id: "x")
+        }
+    }
+
+    /// A sequence prefix whose every completion is a combining mark must be
+    /// refused at the prefix, not at the last byte — otherwise the fallback
+    /// scan is stranded mid-codepoint with the whole vocabulary vetoed.
+    @Test func allCombiningSequencePrefixesAreRefusedEarly() {
+        // 0xCC covers U+0300...U+033F, combining diacriticals throughout.
+        var dead = atGuardedPosition(#"{a:<|"|>"#)
+        #expect(!feedBytes(&dead, [0xCC]))
+        // 0xC3 covers U+00C0...U+00FF, which has bases, so the lead passes and
+        // the verdict lands on the completed scalar instead.
+        var live = atGuardedPosition(#"{a:<|"|>"#)
+        #expect(feedBytes(&live, [0xC3, 0xA9]))
+        #expect(feedBytes(&live, Array(#"<|"|>}"#.utf8)))
+        #expect(live.isComplete)
+    }
+
+    /// Every state the guard can reach must still have a legal next byte.
+    @Test func guardedPositionsAreNeverDeadEnds() {
+        for prefix in [#"{a:<|"|>"#, #"{a:<|"|>\n"#, #"{a:<|"|>A"#] {
+            var frontier = [atGuardedPosition(prefix)]
+            for _ in 0..<3 {
+                var next: [JSONByteAutomaton] = []
+                for state in frontier {
+                    var reachable = false
+                    for byte in UInt8.min...UInt8.max {
+                        var candidate = state
+                        guard candidate.consume(byte) else { continue }
+                        reachable = true
+                        // Only unfinished sequences can still be guarded.
+                        if byte >= 0x80 { next.append(candidate) }
+                    }
+                    #expect(reachable, "dead end under the guard after \(prefix)")
+                }
+                frontier = next
+            }
+        }
+    }
+
+    @Test func escapedPrependAndZeroWidthJoinerDoNotGuard() {
+        // `\u0600` is ASCII in the raw text, and ZWJ merges backwards.
+        #expect(completes(#"{a:<|"|>\u0600<|"|>}"#))
+        var automaton = JSONByteAutomaton(dialect: .gemmaToolArguments)
+        #expect(feedBytes(&automaton, Array(#"{a:<|"|>"#.utf8)))
+        #expect(feedBytes(&automaton, Array("x\u{200D}".utf8)))
+        #expect(feedBytes(&automaton, Array(#"<|"|>}"#.utf8)))
+        #expect(automaton.isComplete)
+    }
+
+    // MARK: - Strict dialect is untouched
+
+    @Test func strictDialectStillAcceptsCanonicalJSON() {
+        var automaton = JSONByteAutomaton()
+        #expect(feedBytes(&automaton, Array(#"{"a":1e5,"b":[0.5]}"#.utf8)))
+        #expect(automaton.isComplete)
+        #expect(automaton.dialect == .strict)
+    }
+}

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/JSONConstraintTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/JSONConstraintTests.swift
@@ -439,33 +439,58 @@ import Foundation
         #expect(step(&automaton, UInt8(ascii: "u")))
     }
 
-    @Test func loneLowSurrogateRejectedAtFinalDigit() {
+    @Test func loneLowSurrogateRejectedAsEarlyAsPossible() {
         var automaton = JSONByteAutomaton()
-        #expect(feed(&automaton, #"{"s": "\udc0"#))
-        #expect(!step(&automaton, UInt8(ascii: "0")))
-        // A non-surrogate completion from the same prefix stays legal:
-        // \udc0 can't be saved, but the rejection must not corrupt state —
-        // hex digits beyond the range are equally rejected…
-        #expect(!step(&automaton, UInt8(ascii: "f")))
+        #expect(feed(&automaton, #"{"s": "\ud"#))
+        // Every completion of `\udc` is a lone low surrogate, so the verdict
+        // lands here instead of two digits later. Waiting would park the
+        // automaton on a prefix no byte can extend, and the grammar-driven
+        // fallback would have nothing left to pick.
+        for dead in "cdef" {
+            #expect(!step(&automaton, dead.asciiValue!))
+        }
+        // Prefixes that can still reach a non-surrogate stay open.
+        #expect(step(&automaton, UInt8(ascii: "7")))
+        #expect(feed(&automaton, "ff\"}"))
+        #expect(automaton.isComplete)
     }
 
-    @Test func highSurrogateFollowedByNonLowEscapeRejected() {
+    @Test func pairCompletionIsPrunedToTheLowSurrogateRange() {
         var automaton = JSONByteAutomaton()
-        #expect(feed(&automaton, #"{"s": "\ud800\u004"#))
-        #expect(!step(&automaton, UInt8(ascii: "1")))   // A is not low
+        #expect(feed(&automaton, #"{"s": "\ud800\u"#))
+        // Only DC...DF can still land on a low surrogate.
         #expect(!step(&automaton, UInt8(ascii: "0")))
+        #expect(step(&automaton, UInt8(ascii: "d")))
+        #expect(!step(&automaton, UInt8(ascii: "8")))   // D8xx is high, not low
+        #expect(step(&automaton, UInt8(ascii: "c")))
+        #expect(feed(&automaton, "00\"}"))
+        #expect(automaton.isComplete)
     }
 
-    @Test func highSurrogateFollowedByHighRejected() {
-        var automaton = JSONByteAutomaton()
-        // The verdict lands on the fourth hex digit: \ud80_ can only be a
-        // high surrogate, which is not a valid pair completion.
-        #expect(feed(&automaton, #"{"s": "\ud800\ud80"#))
-        #expect(!step(&automaton, UInt8(ascii: "0")))
-        // A proper pair from scratch works: \ud800 + \udc00 = U+10000.
-        var paired = JSONByteAutomaton()
-        #expect(feed(&paired, "{\"s\": \"\\ud800\\udc00\"}"))
-        #expect(paired.isComplete)
+    /// No `\uXXXX` prefix may be a dead end. This is the escape-level form of
+    /// the guarantee the tool-call fuzz asserts globally: a state the fallback
+    /// scan cannot leave turns a generation into a thrown error.
+    @Test func noEscapePrefixIsADeadEnd() {
+        let digits = Array("0123456789abcdef".utf8)
+        for opening in [#"{"s": "\u"#, #"{"s": "\ud800\u"#] {
+            var root = JSONByteAutomaton()
+            #expect(feed(&root, opening))
+            var frontier = [root]
+            for _ in 0..<4 {
+                var next: [JSONByteAutomaton] = []
+                for state in frontier {
+                    var reachable = false
+                    for digit in digits {
+                        var candidate = state
+                        guard candidate.consume(digit) else { continue }
+                        reachable = true
+                        next.append(candidate)
+                    }
+                    #expect(reachable, "dead escape prefix after \(opening)")
+                }
+                frontier = next
+            }
+        }
     }
 
     @Test func nonSurrogateEscapesUnaffected() {

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/JSONConstraintTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/JSONConstraintTests.swift
@@ -404,3 +404,74 @@ import Foundation
         #expect(assembler.push([UInt8(ascii: "b")]) == "b")
     }
 }
+
+/// Surrogate pairing in \uXXXX escapes: Foundation's JSON parsers reject
+/// lone surrogates, so the automaton must too.
+@Suite struct JSONAutomatonSurrogateTests {
+
+    private func feed(_ automaton: inout JSONByteAutomaton, _ text: String) -> Bool {
+        for byte in Array(text.utf8) {
+            guard automaton.consume(byte) else { return false }
+        }
+        return true
+    }
+
+    private func step(_ automaton: inout JSONByteAutomaton, _ byte: UInt8) -> Bool {
+        automaton.consume(byte)
+    }
+
+    @Test func pairedSurrogatesAccepted() {
+        var automaton = JSONByteAutomaton()
+        // Escaped pair for U+1F600 (😀): high \ud83d + low \ude00.
+        #expect(feed(&automaton, "{\"s\": \"\\ud83d\\ude00\"}"))
+        #expect(automaton.isComplete)
+    }
+
+    @Test func loneHighSurrogateCannotCloseString() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, #"{"s": "\ud800"#))
+        // After a high surrogate only `\` is legal — not a quote, not text.
+        #expect(!step(&automaton, UInt8(ascii: "\"")))
+        #expect(!step(&automaton, UInt8(ascii: "a")))
+        #expect(step(&automaton, UInt8(ascii: "\\")))
+        // …and after the backslash, only `u`.
+        #expect(!step(&automaton, UInt8(ascii: "n")))
+        #expect(step(&automaton, UInt8(ascii: "u")))
+    }
+
+    @Test func loneLowSurrogateRejectedAtFinalDigit() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, #"{"s": "\udc0"#))
+        #expect(!step(&automaton, UInt8(ascii: "0")))
+        // A non-surrogate completion from the same prefix stays legal:
+        // \udc0 can't be saved, but the rejection must not corrupt state —
+        // hex digits beyond the range are equally rejected…
+        #expect(!step(&automaton, UInt8(ascii: "f")))
+    }
+
+    @Test func highSurrogateFollowedByNonLowEscapeRejected() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, #"{"s": "\ud800\u004"#))
+        #expect(!step(&automaton, UInt8(ascii: "1")))   // A is not low
+        #expect(!step(&automaton, UInt8(ascii: "0")))
+    }
+
+    @Test func highSurrogateFollowedByHighRejected() {
+        var automaton = JSONByteAutomaton()
+        // The verdict lands on the fourth hex digit: \ud80_ can only be a
+        // high surrogate, which is not a valid pair completion.
+        #expect(feed(&automaton, #"{"s": "\ud800\ud80"#))
+        #expect(!step(&automaton, UInt8(ascii: "0")))
+        // A proper pair from scratch works: \ud800 + \udc00 = U+10000.
+        var paired = JSONByteAutomaton()
+        #expect(feed(&paired, "{\"s\": \"\\ud800\\udc00\"}"))
+        #expect(paired.isComplete)
+    }
+
+    @Test func nonSurrogateEscapesUnaffected() {
+        var automaton = JSONByteAutomaton()
+        // \u00e9 (é) and \ud7ff (last scalar before the surrogate range).
+        #expect(feed(&automaton, "{\"s\": \"\\u00e9\\ud7ff\"}"))
+        #expect(automaton.isComplete)
+    }
+}

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/JSONConstraintTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/JSONConstraintTests.swift
@@ -189,8 +189,10 @@ import Foundation
         14: "}",
         15: "Hola",
         16: "▁no",
-        17: "<0xF0>",       // first byte of a 4-byte emoji
+        17: "<0xF0>",       // 4-byte emoji, one byte-fallback token per byte
         18: "<0x9F>",
+        23: "<0x87>",
+        24: "<0xA6>",
         19: "<unused12>",
         20: "",
         21: "▁",
@@ -231,15 +233,30 @@ import Foundation
         #expect(filter.isComplete)
     }
 
-    @Test func byteFallbackPairInsideString() {
+    @Test func byteFallbackSequenceInsideString() {
         let filter = makeFilter()
         #expect(filter.tryAccept(10))   // {"
-        // Raw UTF-8 lead + continuation bytes are valid string content.
-        #expect(filter.tryAccept(17))
-        #expect(filter.tryAccept(18))
-        // …but not outside a string: close key/value, then reject at "}".
+        // A 4-byte emoji arriving one byte-fallback token at a time.
+        #expect(filter.tryAccept(17))   // F0 lead
+        // Mid-sequence, closing the key is forbidden (would leave broken UTF-8)…
+        #expect(!filter.tryAccept(12))  // ":
+        #expect(filter.tryAccept(18))   // 9F
+        #expect(filter.tryAccept(23))   // 87
+        #expect(filter.tryAccept(24))   // A6 — sequence complete
+        // …now it isn't.
         #expect(filter.tryAccept(12))   // ":
+        // A raw lead byte outside a string is never valid JSON.
         #expect(!filter.tryAccept(17))
+    }
+
+    @Test func lastAcceptedBytesTracksCommittedToken() {
+        let filter = makeFilter()
+        #expect(filter.tryAccept(10))               // {"
+        #expect(filter.lastAcceptedBytes == Array("{\"".utf8))
+        #expect(filter.tryAccept(11))               // urgencia (key content)
+        #expect(filter.lastAcceptedBytes == Array("urgencia".utf8))
+        #expect(filter.tryAccept(21))               // "▁" → mapped to a space
+        #expect(filter.lastAcceptedBytes == Array(" ".utf8))
     }
 
     @Test func markerAndEmptyPiecesBlocked() {
@@ -261,5 +278,129 @@ import Foundation
         #expect(filter.tryAccept(13))   // ▁"alta" still accepted from same state
         #expect(filter.tryAccept(14))   // }
         #expect(filter.isComplete)
+    }
+}
+
+/// UTF-8 structural validation inside strings: the automaton must reject any
+/// byte sequence that would leave the emitted document undecodable.
+@Suite struct JSONAutomatonUTF8Tests {
+
+    private func stringOpen() -> JSONByteAutomaton {
+        var automaton = JSONByteAutomaton()
+        for byte in Array("{\"k\": \"".utf8) {
+            precondition(automaton.consume(byte))
+        }
+        return automaton
+    }
+
+    private func step(_ automaton: inout JSONByteAutomaton, _ byte: UInt8) -> Bool {
+        automaton.consume(byte)
+    }
+
+    @Test func validSequencesAccepted() {
+        for text in ["é", "ñandú", "€", "🇦🇷", "\u{10FFFF}", "日本語"] {
+            var automaton = stringOpen()
+            for byte in Array(text.utf8) {
+                #expect(step(&automaton, byte), "byte of \(text) rejected")
+            }
+            #expect(step(&automaton, UInt8(ascii: "\"")))
+        }
+    }
+
+    @Test func bareContinuationRejected() {
+        var automaton = stringOpen()
+        #expect(!step(&automaton, 0x80))
+        #expect(!step(&automaton, 0xBF))
+    }
+
+    @Test func leadFollowedByNonContinuationRejected() {
+        var automaton = stringOpen()
+        #expect(step(&automaton, 0xC3))
+        #expect(!step(&automaton, UInt8(ascii: "a")))
+        #expect(!step(&automaton, 0xC3))          // another lead: also invalid
+    }
+
+    @Test func quoteAndEscapeMidSequenceRejected() {
+        var automaton = stringOpen()
+        #expect(step(&automaton, 0xF0))
+        #expect(step(&automaton, 0x9F))
+        #expect(!step(&automaton, UInt8(ascii: "\"")))
+        #expect(!step(&automaton, UInt8(ascii: "\\")))
+        // Completing the sequence re-enables both.
+        #expect(step(&automaton, 0x87))
+        #expect(step(&automaton, 0xA6))
+        #expect(step(&automaton, UInt8(ascii: "\"")))
+    }
+
+    @Test func invalidLeadBytesRejected() {
+        for lead: UInt8 in [0xC0, 0xC1, 0xF5, 0xFE, 0xFF] {
+            var automaton = stringOpen()
+            #expect(!step(&automaton, lead), "lead \(lead) must be rejected")
+        }
+    }
+
+    @Test func surrogateAndRangeBoundaries() {
+        // ED 9F BF (U+D7FF, last before surrogates) is legal; ED A0 is not.
+        var legal = stringOpen()
+        #expect(step(&legal, 0xED))
+        #expect(step(&legal, 0x9F))
+        #expect(step(&legal, 0xBF))
+        var surrogate = stringOpen()
+        #expect(step(&surrogate, 0xED))
+        #expect(!step(&surrogate, 0xA0))
+        // F4 8F is legal (up to U+10FFFF); F4 90 overflows.
+        var top = stringOpen()
+        #expect(step(&top, 0xF4))
+        #expect(step(&top, 0x8F))
+        var beyond = stringOpen()
+        #expect(step(&beyond, 0xF4))
+        #expect(!step(&beyond, 0x90))
+        // E0 80 would be overlong.
+        var overlong = stringOpen()
+        #expect(step(&overlong, 0xE0))
+        #expect(!step(&overlong, 0x80))
+    }
+
+    @Test func multibyteOutsideStringsRejected() {
+        var automaton = JSONByteAutomaton()
+        #expect(!step(&automaton, 0xC3))
+    }
+}
+
+/// The byte-stream assembler that replaces detokenizer text under forceJSON.
+@Suite struct UTF8StreamAssemblerTests {
+
+    @Test func asciiPassesThrough() {
+        var assembler = UTF8StreamAssembler()
+        #expect(assembler.push(Array("{\"a\": 1".utf8)) == "{\"a\": 1")
+        #expect(assembler.push(Array("}".utf8)) == "}")
+        #expect(assembler.flush() == "")
+    }
+
+    @Test func splitCodepointHeldUntilComplete() {
+        var assembler = UTF8StreamAssembler()
+        #expect(assembler.push([0xF0, 0x9F]) == "")
+        #expect(assembler.push([0x87]) == "")
+        #expect(assembler.push([0xA6, 0x21]) == "\u{1F1E6}!")
+        #expect(assembler.flush() == "")
+    }
+
+    @Test func completeTailEmittedOnPush() {
+        var assembler = UTF8StreamAssembler()
+        #expect(assembler.push(Array("é".utf8)) == "é")
+    }
+
+    @Test func mixedAsciiAndPendingSequence() {
+        var assembler = UTF8StreamAssembler()
+        #expect(assembler.push([UInt8(ascii: "\""), 0xC3]) == "\"")
+        #expect(assembler.push([0xA9, UInt8(ascii: "\"")]) == "é\"")
+    }
+
+    @Test func flushDropsIncompleteTail() {
+        var assembler = UTF8StreamAssembler()
+        #expect(assembler.push([UInt8(ascii: "a"), 0xE2, 0x82]) == "a")
+        #expect(assembler.flush() == "")
+        // After flush the pending tail is gone for good.
+        #expect(assembler.push([UInt8(ascii: "b")]) == "b")
     }
 }

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/JSONConstraintTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/JSONConstraintTests.swift
@@ -1,0 +1,265 @@
+import Testing
+import Foundation
+@testable import TurboFieldfare
+
+/// Byte-level automaton coverage: acceptance criteria cases from the Tikum
+/// handoff — nesting, escapes, unicode split across tokens, numbers,
+/// truncation — plus the structural rejections that make forced JSON safe.
+@Suite struct JSONByteAutomatonTests {
+
+    private func feed(_ automaton: inout JSONByteAutomaton, _ text: String) -> Bool {
+        feedBytes(&automaton, Array(text.utf8))
+    }
+
+    private func feedBytes(_ automaton: inout JSONByteAutomaton, _ bytes: [UInt8]) -> Bool {
+        for byte in bytes {
+            guard automaton.consume(byte) else { return false }
+        }
+        return true
+    }
+
+    /// `#expect` cannot call mutating members inline; route single bytes here.
+    private func step(_ automaton: inout JSONByteAutomaton, _ byte: UInt8) -> Bool {
+        automaton.consume(byte)
+    }
+
+    private func accepts(_ text: String) -> JSONByteAutomaton? {
+        var automaton = JSONByteAutomaton()
+        return feed(&automaton, text) ? automaton : nil
+    }
+
+    @Test func flatObjectCompletes() {
+        let automaton = accepts(#"{"urgencia": "alta", "derivar": true, "score": 0.87}"#)
+        #expect(automaton?.isComplete == true)
+    }
+
+    @Test func nestedContainersComplete() {
+        let automaton = accepts(
+            #"{"a": [1, {"b": [true, null]}, -2.5e+3], "c": {"d": {}}}"#)
+        #expect(automaton?.isComplete == true)
+    }
+
+    @Test func leadingWhitespaceAllowed() {
+        let automaton = accepts(" \n\t {\"a\": 1}")
+        #expect(automaton?.isComplete == true)
+    }
+
+    @Test func trailingWhitespaceAfterCompleteAllowed() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, "{\"a\": 1} \n"))
+        #expect(automaton.isComplete)
+        #expect(!step(&automaton, UInt8(ascii: "x")))
+    }
+
+    @Test func proseIsRejectedAtRoot() {
+        var automaton = JSONByteAutomaton()
+        #expect(!step(&automaton, UInt8(ascii: "H")))
+        // The rejection must not corrupt state: a valid document still passes.
+        #expect(feed(&automaton, "{}"))
+        #expect(automaton.isComplete)
+    }
+
+    @Test func stringEscapes() {
+        let automaton = accepts(#"{"s": "a\"b\\c\/d\n\té"}"#)
+        #expect(automaton?.isComplete == true)
+    }
+
+    @Test func invalidEscapeRejected() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, #"{"s": "a\"#))
+        #expect(!step(&automaton, UInt8(ascii: "x")))
+    }
+
+    @Test func incompleteUnicodeEscapeRejectsNonHex() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, #"{"s": "\u00"#))
+        #expect(!step(&automaton, UInt8(ascii: "g")))
+        #expect(step(&automaton, UInt8(ascii: "e")))
+    }
+
+    /// A multi-byte codepoint split across tokens arrives as bare
+    /// continuation bytes; inside a string each byte must be accepted.
+    @Test func splitUTF8InsideString() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, #"{"s": ""#))
+        let emoji = Array("🇦🇷ñ".utf8)
+        let first = emoji[..<3]
+        let second = emoji[3...]
+        for byte in first { #expect(step(&automaton, byte)) }
+        for byte in second { #expect(step(&automaton, byte)) }
+        #expect(feed(&automaton, "\"}"))
+        #expect(automaton.isComplete)
+    }
+
+    @Test func controlByteInsideStringRejected() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, #"{"s": ""#))
+        #expect(!step(&automaton, 0x07))
+    }
+
+    @Test func numberForms() {
+        for doc in ["[0]", "[-0]", "[42]", "[0.5]", "[-12.25]",
+                    "[1e9]", "[1E-9]", "[0.5e+10]", "[123, -4.5]"] {
+            #expect(accepts(doc)?.isComplete == true, "expected \(doc) to parse")
+        }
+    }
+
+    @Test func malformedNumbersRejected() {
+        for doc in ["[01", "[1.e", "[--1", "[.5", "[+1", "[1..", "[0x"] {
+            #expect(accepts(doc) == nil, "expected \(doc) to be rejected")
+        }
+        // "[1e+" is a legal prefix (extendable to "[1e+5]") — but it can
+        // neither stop nor close the array here.
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, "[1e+"))
+        #expect(!automaton.canStop)
+        #expect(!step(&automaton, UInt8(ascii: "]")))
+    }
+
+    @Test func literals() {
+        #expect(accepts("[true, false, null]")?.isComplete == true)
+        #expect(accepts("[tru]") == nil)
+        #expect(accepts("[nulll") == nil)
+    }
+
+    @Test func structuralMistakesRejected() {
+        for doc in ["{\"a\" 1", "{\"a\": 1,}", "{,", "[1,]", "{\"a\": 1}}",
+                    "{]", "[}", "{\"a\":: 1", "{1: 2"] {
+            #expect(accepts(doc) == nil || accepts(doc)?.isComplete == false,
+                    "expected \(doc) to be rejected or incomplete")
+        }
+        #expect(accepts("{,") == nil)
+        #expect(accepts("{\"a\" 1") == nil)
+    }
+
+    /// Truncation by max-new: a prefix of a valid document is accepted but
+    /// never complete, and mid-string it cannot stop.
+    @Test func truncatedDocumentIsIncomplete() {
+        let automaton = accepts(#"{"urgencia": "al"#)
+        #expect(automaton != nil)
+        #expect(automaton?.isComplete == false)
+        #expect(automaton?.canStop == false)
+    }
+
+    @Test func rootBareNumberCanStopButIsNotComplete() {
+        var automaton = JSONByteAutomaton()
+        #expect(feed(&automaton, "12"))
+        #expect(!automaton.isComplete)
+        #expect(automaton.canStop)
+        // A digit may still extend it…
+        #expect(step(&automaton, UInt8(ascii: "3")))
+        // …and a terminator closes it.
+        #expect(step(&automaton, UInt8(ascii: " ")))
+        #expect(automaton.isComplete)
+    }
+
+    @Test func depthLimitEnforced() {
+        var automaton = JSONByteAutomaton()
+        for _ in 0..<JSONByteAutomaton.maxDepth {
+            #expect(step(&automaton, UInt8(ascii: "[")))
+        }
+        #expect(!step(&automaton, UInt8(ascii: "[")))
+        #expect(step(&automaton, UInt8(ascii: "]")))
+    }
+
+    @Test func emptyContainers() {
+        #expect(accepts("{}")?.isComplete == true)
+        #expect(accepts("[]")?.isComplete == true)
+        #expect(accepts("[[], {}]")?.isComplete == true)
+        #expect(accepts("[,") == nil)
+    }
+}
+
+/// Token-level filter: SentencePiece piece mapping (▁, byte-fallback),
+/// special-token blocking, stop-token gating on `canStop`, and state commit
+/// on acceptance.
+@Suite struct JSONTokenFilterTests {
+
+    private static let eos: Int32 = 1
+    private static let endOfTurn: Int32 = 106
+
+    /// Tiny fake vocabulary exercising every piece shape the filter handles.
+    private static let pieces: [Int32: String] = [
+        eos: "<eos>",
+        endOfTurn: "<turn|>",
+        10: "{\"",
+        11: "urgencia",
+        12: "\":",
+        13: "▁\"alta\"",
+        14: "}",
+        15: "Hola",
+        16: "▁no",
+        17: "<0xF0>",       // first byte of a 4-byte emoji
+        18: "<0x9F>",
+        19: "<unused12>",
+        20: "",
+        21: "▁",
+        22: "123",
+    ]
+
+    private func makeFilter() -> JSONTokenFilter {
+        JSONTokenFilter(pieceLookup: { Self.pieces[$0] },
+                        blockedIDs: [],
+                        stopIDs: [Self.eos, Self.endOfTurn])
+    }
+
+    @Test func buildsObjectAndForcesCompletion() {
+        let filter = makeFilter()
+        // Prose openers and stop tokens are vetoed before the root opens.
+        #expect(!filter.tryAccept(15))
+        #expect(!filter.tryAccept(Self.eos))
+        #expect(filter.tryAccept(10))   // {"
+        #expect(filter.tryAccept(11))   // urgencia
+        #expect(filter.tryAccept(12))   // ":
+        #expect(filter.tryAccept(13))   // ▁"alta"
+        #expect(!filter.isComplete)
+        #expect(filter.tryAccept(14))   // }
+        #expect(filter.isComplete)
+        // Once complete, EOS is legal and content is not.
+        #expect(filter.tryAccept(Self.eos))
+        #expect(!filter.tryAccept(15))
+    }
+
+    @Test func spaceMarkerMapsToSpace() {
+        let filter = makeFilter()
+        #expect(filter.tryAccept(10))   // {"
+        #expect(filter.tryAccept(11))   // key
+        #expect(filter.tryAccept(12))   // ":
+        #expect(filter.tryAccept(21))   // "▁" alone → structural space
+        #expect(filter.tryAccept(22))   // 123
+        #expect(filter.tryAccept(14))   // }
+        #expect(filter.isComplete)
+    }
+
+    @Test func byteFallbackPairInsideString() {
+        let filter = makeFilter()
+        #expect(filter.tryAccept(10))   // {"
+        // Raw UTF-8 lead + continuation bytes are valid string content.
+        #expect(filter.tryAccept(17))
+        #expect(filter.tryAccept(18))
+        // …but not outside a string: close key/value, then reject at "}".
+        #expect(filter.tryAccept(12))   // ":
+        #expect(!filter.tryAccept(17))
+    }
+
+    @Test func markerAndEmptyPiecesBlocked() {
+        let filter = makeFilter()
+        #expect(filter.tryAccept(10))
+        // Inside a string "<unused12>" bytes WOULD be legal — the filter must
+        // still block marker-shaped pieces (the detokenizer strips them).
+        #expect(!filter.tryAccept(19))
+        #expect(!filter.tryAccept(20))  // empty piece can't make progress
+        #expect(!filter.tryAccept(99))  // unknown id
+    }
+
+    @Test func rejectionDoesNotAdvanceState() {
+        let filter = makeFilter()
+        #expect(filter.tryAccept(10))   // {"
+        #expect(filter.tryAccept(11))   // urgencia
+        #expect(filter.tryAccept(12))   // ":
+        #expect(!filter.tryAccept(11))  // a bare identifier is not a value
+        #expect(filter.tryAccept(13))   // ▁"alta" still accepted from same state
+        #expect(filter.tryAccept(14))   // }
+        #expect(filter.isComplete)
+    }
+}

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/RawCompletionLoopTests+ToolGrammar.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/RawCompletionLoopTests+ToolGrammar.swift
@@ -1,0 +1,174 @@
+import Testing
+import Foundation
+import Metal
+@testable import TurboFieldfare
+
+/// The tool-call constraint inside the real decode loop: the fallback recovers
+/// a derailed call, an in-grammar generation is bit-identical with the filter
+/// off, and the two grammars refuse to share a generation.
+extension RawCompletionLoopTests {
+
+    /// Writes one scripted logit distribution per decode step, so a test can
+    /// put an illegal token at the top and a legal one just below it and watch
+    /// the grammar fallback choose.
+    final class WeightedLogitProducer: LogitProducer, @unchecked Sendable {
+        let vocabSize: Int
+        private let steps: [[Int32: Float]]
+        private let firstDecodeCall: Int
+        private var calls = 0
+
+        init(vocabSize: Int, promptTokens: Int, steps: [[Int32: Float]]) {
+            self.vocabSize = vocabSize
+            self.steps = steps
+            self.firstDecodeCall = promptTokens - 1
+        }
+
+        func reset() { calls = 0 }
+
+        func produce(token: Int32, position: Int, into logits: MTLBuffer) async throws {
+            let index = min(max(calls - firstDecodeCall, 0), steps.count - 1)
+            calls += 1
+            let pointer = logits.contents().bindMemory(to: Float16.self, capacity: vocabSize)
+            for i in 0..<vocabSize { pointer[i] = Float16(-30.0) }
+            for (id, weight) in steps[index] { pointer[Int(id)] = Float16(weight) }
+        }
+    }
+
+    private struct ToolRun {
+        var ids: [Int32] = []
+        var text = ""
+        var events: [StructuredAssistantEvent] = []
+        var result: RawDecodeResult
+    }
+
+    private func runToolLoop(steps: [[Int32: Float]],
+                             tools: Set<String>,
+                             constrained: Bool,
+                             maxNewTokens: Int = 32) async throws -> ToolRun {
+        let context = try MetalContext()
+        let tokenizer = try await GFTokenizer.load()
+        let promptIDs = tokenizer.encode("go", addBOS: true)
+        let producer = WeightedLogitProducer(vocabSize: tokenizer.vocabSize,
+                                             promptTokens: promptIDs.count,
+                                             steps: steps)
+        let scratch = try RawCompletionScratch(context: context, vocab: tokenizer.vocabSize)
+        let filter = constrained
+            ? ToolCallTokenFilter(tokenizer: tokenizer, allowedNames: tools)
+            : nil
+        let decoder = StructuredAssistantDecoder(tokenizer: tokenizer,
+                                                 allowedTools: tools,
+                                                 idGenerator: { "call_fixed" })
+        var ids: [Int32] = []
+        var text = ""
+        var events: [StructuredAssistantEvent] = []
+        var decodeError: Error?
+        let result = try await runRawCompletion(
+            producer: producer,
+            tokenizer: tokenizer,
+            promptIds: promptIDs,
+            config: GenerationConfig(maxNewTokens: maxNewTokens, temperature: 0),
+            context: context,
+            scratch: scratch,
+            prefillConfig: .off,
+            toolFilter: filter) { progress in
+                guard case .token(_, let id, let delta) = progress else { return }
+                ids.append(id)
+                text += delta
+                guard decodeError == nil else { return }
+                do {
+                    events += try decoder.consume(tokenID: id,
+                                                  delta: delta,
+                                                  validatedBody: filter?.closedCallBody)
+                } catch {
+                    decodeError = error
+                }
+        }
+        if let decodeError { throw decodeError }
+        return ToolRun(ids: ids, text: text, events: events, result: result)
+    }
+
+    /// The Gemma pieces of `call:read{path:<|"|>/tmp<|"|>}`, plus the markers.
+    private static let inGrammarCall: [Int32] =
+        [48, 6639, 236787, 1399, 236782, 2337, 236787, 52, 236786, 11935, 52, 236783, 49, 50]
+
+    @Test func toolGrammarRecoversFromACanonicalJSONDerail() async throws {
+        // Step 4 wants `{"` — the quoted-key drift behind the upstream report.
+        // `{` sits just below it, so the fallback has somewhere to land.
+        var steps = Self.inGrammarCall.map { [$0: Float(30)] }
+        steps[4] = [14937: 30, 236782: 20]
+        let run = try await runToolLoop(steps: steps, tools: ["read"], constrained: true)
+
+        #expect(run.result.toolGrammarVetoes == 1)
+        #expect(run.result.toolNameVetoes == 0)
+        #expect(run.result.reason == .toolCalls)
+        #expect(run.ids == Array(Self.inGrammarCall.dropLast()))
+        guard case .toolCall(let call)? = run.events.first else {
+            Issue.record("no tool call decoded: \(run.events)")
+            return
+        }
+        #expect(call.name == "read")
+        #expect(call.arguments == .object(["path": .string("/tmp")]))
+    }
+
+    /// Without the constraint the same derail is exactly the upstream failure:
+    /// the region closes on a quoted key and the parser refuses it.
+    @Test func theSameDerailIsUndecodableWithoutTheConstraint() async throws {
+        var steps = Self.inGrammarCall.map { [$0: Float(30)] }
+        steps[4] = [14937: 30, 236782: 20]
+        await #expect(throws: GemmaToolCallParserError.malformed) {
+            try await runToolLoop(steps: steps, tools: ["read"], constrained: false)
+        }
+    }
+
+    @Test func inGrammarGenerationIsBitIdenticalWithTheFilterOff() async throws {
+        let steps = Self.inGrammarCall.map { [$0: Float(30)] }
+        let constrained = try await runToolLoop(steps: steps, tools: ["read"], constrained: true)
+        let plain = try await runToolLoop(steps: steps, tools: ["read"], constrained: false)
+
+        #expect(constrained.ids == plain.ids)
+        #expect(constrained.text == plain.text)
+        #expect(constrained.result.reason == plain.result.reason)
+        #expect(constrained.result.newTokens == plain.result.newTokens)
+        #expect(constrained.result.toolGrammarVetoes == 0)
+        #expect(plain.result.toolGrammarVetoes == 0)
+        #expect(constrained.events == plain.events)
+    }
+
+    /// An undeclared tool is reported apart from ordinary vetoes: it says the
+    /// prompt and the declared set disagree, not that the grammar is working.
+    @Test func undeclaredToolNameIsVetoedAndCounted() async throws {
+        var steps = Self.inGrammarCall.map { [$0: Float(30)] }
+        // `write` outranks `read`, but only `read` is declared.
+        steps[3] = [4374: 30, 1399: 20]
+        let run = try await runToolLoop(steps: steps, tools: ["read"], constrained: true)
+        #expect(run.result.toolNameVetoes >= 1)
+        #expect(run.result.toolGrammarVetoes == run.result.toolNameVetoes)
+        guard case .toolCall(let call)? = run.events.first else {
+            Issue.record("no tool call decoded: \(run.events)")
+            return
+        }
+        #expect(call.name == "read")
+    }
+
+    @Test func forceJSONAndTheToolGrammarCannotShareAGeneration() async throws {
+        let context = try MetalContext()
+        let tokenizer = try await GFTokenizer.load()
+        let promptIDs = tokenizer.encode("go", addBOS: true)
+        let producer = WeightedLogitProducer(vocabSize: tokenizer.vocabSize,
+                                             promptTokens: promptIDs.count,
+                                             steps: [[tokenizer.eosID: 30]])
+        let scratch = try RawCompletionScratch(context: context, vocab: tokenizer.vocabSize)
+        await #expect(throws: GeneratorError.self) {
+            _ = try await runRawCompletion(
+                producer: producer,
+                tokenizer: tokenizer,
+                promptIds: promptIDs,
+                config: GenerationConfig(maxNewTokens: 4, temperature: 0, forceJSON: true),
+                context: context,
+                scratch: scratch,
+                prefillConfig: .off,
+                toolFilter: ToolCallTokenFilter(tokenizer: tokenizer,
+                                                allowedNames: ["read"])) { _ in }
+        }
+    }
+}

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/RawCompletionLoopTests+ToolGrammar.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/RawCompletionLoopTests+ToolGrammar.swift
@@ -37,8 +37,18 @@ extension RawCompletionLoopTests {
     private struct ToolRun {
         var ids: [Int32] = []
         var text = ""
+        var tails: [String] = []
         var events: [StructuredAssistantEvent] = []
+        /// The server's `truncatedByBudget` predicate: the generation ended
+        /// with a `<|tool_call>` region the decoder never got to close.
+        var openToolRegion = false
         var result: RawDecodeResult
+
+        var decodedContent: String {
+            events.reduce(into: "") { text, event in
+                if case .content(let delta) = event { text += delta }
+            }
+        }
     }
 
     private func runToolLoop(steps: [[Int32: Float]],
@@ -60,6 +70,7 @@ extension RawCompletionLoopTests {
                                                  idGenerator: { "call_fixed" })
         var ids: [Int32] = []
         var text = ""
+        var tails: [String] = []
         var events: [StructuredAssistantEvent] = []
         var decodeError: Error?
         let result = try await runRawCompletion(
@@ -71,6 +82,7 @@ extension RawCompletionLoopTests {
             scratch: scratch,
             prefillConfig: .off,
             toolFilter: filter) { progress in
+                if case .tail(let tail) = progress { tails.append(tail) }
                 guard case .token(_, let id, let delta) = progress else { return }
                 ids.append(id)
                 text += delta
@@ -84,7 +96,12 @@ extension RawCompletionLoopTests {
                 }
         }
         if let decodeError { throw decodeError }
-        return ToolRun(ids: ids, text: text, events: events, result: result)
+        return ToolRun(ids: ids,
+                       text: text,
+                       tails: tails,
+                       events: events,
+                       openToolRegion: decoder.hasOpenToolRegion,
+                       result: result)
     }
 
     /// The Gemma pieces of `call:read{path:<|"|>/tmp<|"|>}`, plus the markers.
@@ -148,6 +165,93 @@ extension RawCompletionLoopTests {
             return
         }
         #expect(call.name == "read")
+    }
+
+    /// The budget can land in the middle of a multi-byte scalar of a string
+    /// argument. The detokenizer holds those byte-fallback pieces back until a
+    /// stop, and the flush would then hand them over as ordinary text — the
+    /// `é` tail of a path arriving as assistant content the model never wrote
+    /// as prose, past the decoder that suppresses everything else in the
+    /// region.
+    @Test func aCutArgumentDoesNotFlushItsBytesAsContent() async throws {
+        let tokenizer = try await GFTokenizer.load()
+        let eAcute = try ["<0xC3>", "<0xA9>"].map {
+            Int32(try #require(tokenizer.tokenizer.convertTokenToId($0)))
+        }
+        // `Sure.` + `<|tool_call>call:read{path:<|"|>` + `/tmp` + `é` spelled
+        // one raw byte at a time, and then the budget runs out.
+        let scripted = tokenizer.encode("Sure.", addBOS: false)
+            + Array(Self.inGrammarCall.prefix(10))
+            + eAcute
+        let run = try await runToolLoop(steps: scripted.map { [$0: Float(30)] },
+                                        tools: ["read"],
+                                        constrained: true,
+                                        maxNewTokens: scripted.count)
+
+        #expect(run.result.reason == .maxTokens)
+        #expect(run.openToolRegion)
+        #expect(run.decodedContent == "Sure.")
+        #expect(run.tails.isEmpty)
+
+        // Not vacuous: the same two pieces through a bare detokenizer are the
+        // `é` that used to reach the caller.
+        var detok = GFDetokenizer(tokenizer: tokenizer)
+        for id in scripted { _ = detok.push(id) }
+        #expect(detok.flush().hasSuffix("é"))
+    }
+
+    /// At the 256 KiB region cap the grammar has no move left: every token
+    /// overflows the cap and `<tool_call|>` cannot close an argument object
+    /// that is still open. Ending the generation there is the honest report —
+    /// the region is abandoned exactly like one cut by the token budget — and
+    /// it keeps the request off the 500 path the fallback used to take.
+    @Test func theRegionByteCapEndsTheGenerationInsteadOfFailingIt() async throws {
+        let context = try MetalContext()
+        let tokenizer = try await GFTokenizer.load()
+        let promptIDs = tokenizer.encode("go", addBOS: true)
+        let head: Int32 = 900
+        let filler: Int32 = 901
+        let headBody = #"call:read{path:<|"|>"#
+        let chunk = (GemmaToolCallParser.maximumBytes - headBody.utf8.count) / 4
+        #expect(headBody.utf8.count + 4 * chunk == GemmaToolCallParser.maximumBytes)
+        // Only these three pieces spell bytes, so at the cap the fallback scan
+        // has nowhere to go — the state the real vocabulary reaches by writing
+        // a quarter-megabyte string argument.
+        let pieces: [Int32: String] = [
+            tokenizer.escapeTokenID: #"<|"|>"#,
+            head: #"call:read{path:"#,
+            filler: String(repeating: "a", count: chunk),
+        ]
+        let filter = ToolCallTokenFilter(pieceLookup: { pieces[$0] },
+                                         markers: ToolCallMarkerIDs(tokenizer: tokenizer),
+                                         allowedNames: ["read"])
+        let scripted: [Int32] = [tokenizer.toolCallStartID, head, tokenizer.escapeTokenID]
+            + Array(repeating: filler, count: 4)
+        let producer = WeightedLogitProducer(vocabSize: tokenizer.vocabSize,
+                                             promptTokens: promptIDs.count,
+                                             steps: scripted.map { [$0: Float(30)] })
+        let scratch = try RawCompletionScratch(context: context, vocab: tokenizer.vocabSize)
+        var tails: [String] = []
+        let result = try await runRawCompletion(
+            producer: producer,
+            tokenizer: tokenizer,
+            promptIds: promptIDs,
+            config: GenerationConfig(maxNewTokens: 64, temperature: 0),
+            context: context,
+            scratch: scratch,
+            prefillConfig: .off,
+            toolFilter: filter) { progress in
+                if case .tail(let tail) = progress { tails.append(tail) }
+        }
+
+        #expect(result.reason == .maxTokens)
+        #expect(result.newTokens == scripted.count)
+        #expect(result.newTokens < 64)
+        #expect(result.toolGrammarVetoes == 1)
+        #expect(filter.isInsideCall)
+        #expect(tails.isEmpty)
+        // Nothing was left dangling for the prompt cache to resume from either.
+        #expect(result.uncommittedBoundaryTokenIDs.isEmpty)
     }
 
     @Test func forceJSONAndTheToolGrammarCannotShareAGeneration() async throws {

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/ToolCallGrammarFuzzTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/ToolCallGrammarFuzzTests.swift
@@ -316,6 +316,52 @@ import TurboFieldfareValidationSupport
         #expect(coverage.bodiesWithMultibyteScalar >= 1)
     }
 
+    /// The walks stop at 96 steps, so they never come within three orders of
+    /// magnitude of the 256 KiB region cap — which is why property 2 above
+    /// reads as "the scan is never empty" when the truth is "never empty below
+    /// the cap". At the cap it IS empty, unavoidably: every token overflows it
+    /// and `<tool_call|>` cannot close a string that is still open. That state
+    /// is the one dead end the grammar has, and it is admissible only because
+    /// `runRawCompletion` reads it as the budget running out inside a call —
+    /// hence the `isInsideCall` assertion, which is what routes it to the
+    /// `.maxTokens` stop instead of a failed request.
+    @Test func theRegionByteCapIsTheGrammarsOnlyDeadEnd() {
+        let filler: Int32 = 9_000
+        let opening = #"call:read{path:<|"|>"#
+        let chunk = (GemmaToolCallParser.maximumBytes - opening.utf8.count) / 4
+        #expect(opening.utf8.count + 4 * chunk == GemmaToolCallParser.maximumBytes)
+
+        func fill(_ count: Int) -> ToolCallTokenFilter {
+            let filter = ToolCallTokenFilter(
+                pieceLookup: { $0 == filler ? String(repeating: "a", count: chunk)
+                                            : Self.pieces[$0] },
+                markers: Self.markerIDs,
+                allowedNames: Self.declaredNames)
+            for id in [Self.markerIDs.toolCallStart, Self.id("call:"), Self.id("read"),
+                       Self.id("{"), Self.id("path"), Self.id(":"), Self.markerIDs.escape] {
+                #expect(filter.tryAccept(id))
+            }
+            for step in 0..<count {
+                #expect(filter.tryAccept(filler), "filler \(step) did not fit under the cap")
+            }
+            return filter
+        }
+
+        // One filler short of the cap the sweep still finds a move, so the cap
+        // is what closes the door and not the argument shape.
+        let roomy = fill(3)
+        #expect(Self.ids.contains { roomy.tryAccept($0) })
+
+        let stuck = fill(4)
+        #expect(!Self.ids.contains { stuck.tryAccept($0) })
+        #expect(!stuck.tryAccept(filler))
+        #expect(stuck.isInsideCall)
+    }
+
+    private static func id(_ piece: String) -> Int32 {
+        pieces.first { $0.value == piece }!.key
+    }
+
     /// Seeds that previously exposed a bug stay pinned as ordinary cases.
     @Test(arguments: [0, 1, 2, 3, 7, 42, 4_999])
     func pinnedSeedsReplayCleanly(index: Int) {

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/ToolCallGrammarFuzzTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/ToolCallGrammarFuzzTests.swift
@@ -1,0 +1,326 @@
+import Testing
+import Foundation
+@testable import TurboFieldfare
+import TurboFieldfareValidationSupport
+
+/// The property that makes the tool-call constraint a fix rather than a filter:
+/// **every region the grammar closes parses**. The walk emulates
+/// `sampleOnce` + `grammarFallbackToken` — a random "GPU" proposal, a capped
+/// random retry standing in for the top-256 probability scan, then an
+/// exhaustive vocabulary sweep — over a vocabulary built to spell every known
+/// way the model derails.
+///
+/// No Metal, no model, no network. Seeds are derived from the walk index, so
+/// any failure prints a seed and a token trace that reproduce it exactly.
+@Suite struct ToolCallGrammarFuzzTests {
+
+    // MARK: - Adversarial vocabulary
+
+    private static let markerIDs = ToolCallMarkerIDs(
+        toolCallStart: 48, toolCallEnd: 49, toolResponse: 50, toolResponseEnd: 51,
+        channelStart: 100, channelEnd: 101, escape: 52, endOfTurn: 106,
+        eos: 1, bos: 2, pad: 0)
+
+    private static let declaredNames: Set<String> =
+        ["get-weather", "get", "get_all", "read", "read-file"]
+
+    private static let byteFallbackBytes: [UInt8] = {
+        var bytes = Set(Array(#"{}[],:"\<|>aclerdfginostuw0129.-+$_ "#.utf8))
+        // The real vocabulary has a byte-fallback piece for all 256 bytes, so
+        // every declared name is spellable one byte at a time; a trie node with
+        // no reachable continuation would be a false deadlock.
+        bytes.formUnion(Array(declaredNames.joined().utf8))
+        // Leads and continuations of U+0600 (Prepend), U+0D4E (Prepend),
+        // U+1F601, U+00F1 — plus bytes that can never start or continue a
+        // sequence.
+        bytes.formUnion([0xD8, 0x80, 0xE0, 0xB5, 0x8E, 0xF0, 0x9F, 0x98, 0x81,
+                         0xC3, 0xB1, 0xC0, 0xF5, 0xBF, 0xFF, 0x07, 0x09, 0x0A])
+        return bytes.sorted()
+    }()
+
+    private static let pieces: [Int32: String] = {
+        var pieces: [Int32: String] = [
+            0: "<pad>", 1: "<eos>", 2: "<bos>",
+            48: "<|tool_call>", 49: "<tool_call|>", 50: "<|tool_response>",
+            51: "<tool_response|>", 52: "<|\"|>", 100: "<|channel>",
+            101: "<channel|>", 106: "<turn|>",
+        ]
+        var next: Int32 = 200
+        func add(_ text: String) {
+            pieces[next] = text
+            next += 1
+        }
+        for byte in byteFallbackBytes { add(String(format: "<0x%02X>", byte)) }
+        // The canonical-JSON drift that causes the upstream failures.
+        for text in ["{\"", "\":", "\", \"", "\"", "\":\"", "\"}"] { add(text) }
+        // Grammar symbols, including the delimiter spelled in fragments.
+        for text in ["call", "call:", ":", "{", "}", "[", "]", ",",
+                     "<", "<|", "<|\"", "|>", "\"|>", "<|\"|>"] { add(text) }
+        // Numbers and number traps.
+        for text in ["0", "01", "1", "9", ".", "-", "+", "e", "E",
+                     "1e999", "123456789012345678", "0.5"] { add(text) }
+        // Literals and literal traps.
+        for text in ["true", "truex", "false", "null", "nulll", "NaN", "True"] { add(text) }
+        // Escapes and escape traps.
+        for text in ["\\", "\\u", "\\n", "d83d", "dc00", "d800", "ffff", "zz",
+                     "0600", "u0600"] { add(text) }
+        // Whitespace, including a multi-byte one the parser skips but the
+        // dialect does not accept.
+        for text in ["\u{2581}", "\n", "\t", "\u{00A0}"] { add(text) }
+        // Declared names and near misses.
+        for text in ["get-weather", "get", "get_all", "read", "read-file",
+                     "weather", "getweather", "reader", "file", "-weather",
+                     "_all", "city", "path", "units"] { add(text) }
+        // Junk markers the detokenizer would strip.
+        for text in ["<unused12>", "<td>", "<|tool>", "<start_of_image>"] { add(text) }
+        // Ordinary prose.
+        for text in ["Hola", " I will call", "\u{1F601}", "ñ"] { add(text) }
+        return pieces
+    }()
+
+    private static let ids: [Int32] = pieces.keys.sorted()
+
+    /// The byte mapping `TokenByteTable` performs, mirrored here so the walk can
+    /// keep an independent copy of the region and cross-check it against
+    /// `closedCallBody`.
+    private static func contentBytes(_ id: Int32) -> [UInt8]? {
+        guard let piece = pieces[id] else { return nil }
+        if piece.count == 6, piece.hasPrefix("<0x"), piece.hasSuffix(">"),
+           let byte = UInt8(piece.dropFirst(3).dropLast(), radix: 16) {
+            return [byte]
+        }
+        if id != markerIDs.escape, piece.count > 2,
+           piece.hasPrefix("<"), piece.hasSuffix(">"),
+           !piece.dropFirst().dropLast().contains(where: { $0 == "<" || $0 == ">" }) {
+            return nil
+        }
+        return Array(piece.replacingOccurrences(of: "\u{2581}", with: " ").utf8)
+    }
+
+    /// True when the region ends inside an unterminated `<|"|>` string. Outside
+    /// a string the dialect admits `<` only as a delimiter opener and `\` only
+    /// inside one, so this left-to-right scan is exact.
+    private static func endsInsideGemmaString(_ region: [UInt8]) -> Bool {
+        let delimiter = Array(#"<|"|>"#.utf8)
+        var index = 0
+        var inside = false
+        while index < region.count {
+            if inside, region[index] == UInt8(ascii: "\\") {
+                index += 2
+                continue
+            }
+            if region[index...].starts(with: delimiter) {
+                inside.toggle()
+                index += delimiter.count
+                continue
+            }
+            index += 1
+        }
+        return inside
+    }
+
+    // MARK: - Walk
+
+    private struct Coverage {
+        var walks = 0
+        var walksWithCall = 0
+        var closedCalls = 0
+        var nameVetoes = 0
+        var argumentVetoes = 0
+        var vetoesInsideGemmaString = 0
+        var exhaustiveSweeps = 0
+        var bodiesWithGemmaString = 0
+        var bodiesWithNesting = 0
+        var bodiesWithNumber = 0
+        var bodiesWithMultibyteScalar = 0
+    }
+
+    private static let maximumSteps = 96
+    private static let randomRetries = 32
+
+    private func walk(index: Int, coverage: inout Coverage) {
+        let seed = 0x9E37_79B9_7F4A_7C15 &* UInt64(index) &+ 1
+        var rng = SplitMix64(seed: seed)
+        // The real fallback walks the vocabulary in probability order; a
+        // per-walk shuffle stands in for it, so the sweep does not always land
+        // on the same lowest id and the traces stay diverse.
+        let order = Self.ids.shuffled(using: &rng)
+        let filter = ToolCallTokenFilter(pieceLookup: { Self.pieces[$0] },
+                                         markers: Self.markerIDs,
+                                         allowedNames: Self.declaredNames)
+        var trace: [Int32] = []
+        var region: [UInt8] = []
+        var openRegion = false
+        var justClosed = false
+        var closedCalls = 0
+
+        func fail(_ message: String) {
+            Issue.record("\(message) seed=\(seed) trace=\(trace)")
+        }
+
+        // Half the walks open with the marker so the region grammar — not the
+        // free-prose passthrough — is what the budget is spent on.
+        var forcedOpener: Int32? = index.isMultiple(of: 2) ? Self.markerIDs.toolCallStart : nil
+
+        for _ in 0..<Self.maximumSteps {
+            var chosen: Int32?
+            if let forced = forcedOpener {
+                forcedOpener = nil
+                guard filter.tryAccept(forced) else {
+                    fail("the opening marker was vetoed in free prose")
+                    return
+                }
+                chosen = forced
+            } else {
+                let proposal = order.randomElement(using: &rng)!
+                if filter.tryAccept(proposal) {
+                    chosen = proposal
+                } else {
+                    let namesBefore = filter.nameVetoCount
+                    let insideString = openRegion && Self.endsInsideGemmaString(region)
+                    filter.noteVeto()
+                    if filter.nameVetoCount > namesBefore {
+                        coverage.nameVetoes += 1
+                    } else if openRegion {
+                        coverage.argumentVetoes += 1
+                        if insideString { coverage.vetoesInsideGemmaString += 1 }
+                    }
+                }
+            }
+            if chosen == nil {
+                for _ in 0..<Self.randomRetries {
+                    let candidate = order.randomElement(using: &rng)!
+                    if filter.tryAccept(candidate) {
+                        chosen = candidate
+                        break
+                    }
+                }
+            }
+            if chosen == nil {
+                coverage.exhaustiveSweeps += 1
+                for candidate in order where filter.tryAccept(candidate) {
+                    chosen = candidate
+                    break
+                }
+            }
+            // Property 2: the fallback scan can never come back empty, which is
+            // what keeps `grammarFallbackToken` from throwing.
+            guard let token = chosen else {
+                fail("no token in the vocabulary can extend the region")
+                return
+            }
+            trace.append(token)
+
+            // Property 4: marker invariants.
+            if justClosed, token != Self.markerIDs.toolCallStart,
+               token != Self.markerIDs.toolResponse {
+                fail("free content followed <tool_call|>")
+                return
+            }
+            justClosed = false
+
+            if token == Self.markerIDs.toolCallStart {
+                if openRegion {
+                    fail("nested <|tool_call>")
+                    return
+                }
+                openRegion = true
+                region = []
+            } else if token == Self.markerIDs.toolCallEnd {
+                guard openRegion else {
+                    fail("<tool_call|> with no region open")
+                    return
+                }
+                guard let body = filter.closedCallBody else {
+                    fail("the closing token produced no validated body")
+                    return
+                }
+                if body != region {
+                    fail("validated body diverged from the mirrored region")
+                    return
+                }
+                let text = String(decoding: body, as: UTF8.self)
+                // Property 3: the bytes are valid UTF-8, so no U+FFFD was spliced in.
+                if Array(text.utf8) != body {
+                    fail("the region is not valid UTF-8: \(body)")
+                    return
+                }
+                // Property 1: the grammar is a subset of the parser.
+                do {
+                    let call = try GemmaToolCallParser().parse(
+                        text, allowedTools: Self.declaredNames, id: "fuzz")
+                    if !Self.declaredNames.contains(call.name) {
+                        fail("undeclared tool \(call.name)")
+                        return
+                    }
+                } catch {
+                    fail("parse failed on \(String(reflecting: text)): \(error)")
+                    return
+                }
+                openRegion = false
+                justClosed = true
+                closedCalls += 1
+                coverage.closedCalls += 1
+                if body.contains(UInt8(ascii: "<")) { coverage.bodiesWithGemmaString += 1 }
+                if body.filter({ $0 == UInt8(ascii: "{") }).count > 1
+                    || body.contains(UInt8(ascii: "[")) {
+                    coverage.bodiesWithNesting += 1
+                }
+                if body.contains(where: { (UInt8(ascii: "0")...UInt8(ascii: "9")).contains($0) }) {
+                    coverage.bodiesWithNumber += 1
+                }
+                if body.contains(where: { $0 >= 0x80 }) { coverage.bodiesWithMultibyteScalar += 1 }
+                region = []
+                if closedCalls == 2 { break }
+            } else if token == Self.markerIDs.toolResponse {
+                if closedCalls == 0 {
+                    fail("<|tool_response> before any call closed")
+                    return
+                }
+                break
+            } else if token == Self.markerIDs.eos || token == Self.markerIDs.endOfTurn {
+                break
+            } else if openRegion {
+                guard let bytes = Self.contentBytes(token) else {
+                    fail("a marker-shaped piece entered the region: \(token)")
+                    return
+                }
+                region.append(contentsOf: bytes)
+            }
+        }
+        coverage.walks += 1
+        if closedCalls > 0 { coverage.walksWithCall += 1 }
+    }
+
+    @Test(.timeLimit(.minutes(3)))
+    func grammarIsASubsetOfTheParser() {
+        let requested = ProcessInfo.processInfo.environment["TURBO_FIELDFARE_FUZZ_WALKS"]
+            .flatMap(Int.init)
+        let walks = max(requested ?? 5_000, 5_000)
+        var coverage = Coverage()
+        for index in 0..<walks {
+            walk(index: index, coverage: &coverage)
+        }
+        #expect(coverage.walks == walks)
+        // Anti-vacuity: a fuzz that never reaches the interesting states proves
+        // nothing, so the shape of the exploration is asserted too.
+        #expect(coverage.walksWithCall >= 500)
+        #expect(coverage.closedCalls >= 500)
+        #expect(coverage.nameVetoes >= 1)
+        #expect(coverage.argumentVetoes >= 1)
+        #expect(coverage.exhaustiveSweeps >= 1)
+        #expect(coverage.vetoesInsideGemmaString >= 1)
+        #expect(coverage.bodiesWithGemmaString >= 1)
+        #expect(coverage.bodiesWithNesting >= 1)
+        #expect(coverage.bodiesWithNumber >= 1)
+        #expect(coverage.bodiesWithMultibyteScalar >= 1)
+    }
+
+    /// Seeds that previously exposed a bug stay pinned as ordinary cases.
+    @Test(arguments: [0, 1, 2, 3, 7, 42, 4_999])
+    func pinnedSeedsReplayCleanly(index: Int) {
+        var coverage = Coverage()
+        walk(index: index, coverage: &coverage)
+        #expect(coverage.walks == 1)
+    }
+}

--- a/Tests/TurboFieldfare/Core/Runtime/Generation/ToolCallTokenFilterTests.swift
+++ b/Tests/TurboFieldfare/Core/Runtime/Generation/ToolCallTokenFilterTests.swift
@@ -1,0 +1,366 @@
+import Testing
+import Foundation
+@testable import TurboFieldfare
+
+/// Token-level tool-call grammar over a fake vocabulary: marker discipline,
+/// name forcing through the trie, the argument dialect, and the byte handoff to
+/// the decoder. Same fake-piece pattern as `JSONTokenFilterTests`.
+@Suite struct ToolCallTokenFilterTests {
+
+    private enum ID {
+        static let bos: Int32 = 2
+        static let eos: Int32 = 1
+        static let pad: Int32 = 0
+        static let toolCallStart: Int32 = 48
+        static let toolCallEnd: Int32 = 49
+        static let toolResponse: Int32 = 50
+        static let toolResponseEnd: Int32 = 51
+        static let escape: Int32 = 52
+        static let channelStart: Int32 = 100
+        static let channelEnd: Int32 = 101
+        static let endOfTurn: Int32 = 106
+    }
+
+    private static let markers = ToolCallMarkerIDs(
+        toolCallStart: ID.toolCallStart,
+        toolCallEnd: ID.toolCallEnd,
+        toolResponse: ID.toolResponse,
+        toolResponseEnd: ID.toolResponseEnd,
+        channelStart: ID.channelStart,
+        channelEnd: ID.channelEnd,
+        escape: ID.escape,
+        endOfTurn: ID.endOfTurn,
+        eos: ID.eos,
+        bos: ID.bos,
+        pad: ID.pad)
+
+    private static let pieces: [Int32: String] = [
+        ID.pad: "<pad>",
+        ID.eos: "<eos>",
+        ID.bos: "<bos>",
+        ID.toolCallStart: "<|tool_call>",
+        ID.toolCallEnd: "<tool_call|>",
+        ID.toolResponse: "<|tool_response>",
+        ID.toolResponseEnd: "<tool_response|>",
+        ID.escape: "<|\"|>",
+        ID.channelStart: "<|channel>",
+        ID.channelEnd: "<channel|>",
+        ID.endOfTurn: "<turn|>",
+        200: "call:",
+        201: "call",
+        202: ":",
+        203: "get-weather",
+        204: "get",
+        205: "get_all",
+        206: "getweather",
+        207: "weather{",
+        208: "{",
+        209: "}",
+        210: "city",
+        211: "[",
+        212: "]",
+        213: ",",
+        214: "1",
+        215: "0",
+        216: "01",
+        217: "1e5",
+        218: "Rosario",
+        219: "\"",
+        220: "{\"",
+        221: "\":",
+        222: "l:",
+        223: "<unused12>",
+        224: "Hola",
+        225: "<0xD8>",
+        226: "<0x80>",
+        227: "x",
+        228: "true",
+        229: "<0xF0>",
+        230: "<0x9F>",
+        231: "<0x98>",
+        232: "<0x81>",
+        233: "<",
+        234: "|",
+        235: "\"|>",
+        236: "9999999999999999",
+        237: "▁",
+        238: "call:get-weather{",
+        239: "}\u{2581}",
+    ]
+
+    private func makeFilter(
+        names: Set<String> = ["get-weather", "get", "get_all"]
+    ) -> ToolCallTokenFilter {
+        ToolCallTokenFilter(pieceLookup: { Self.pieces[$0] },
+                            markers: Self.markers,
+                            allowedNames: names)
+    }
+
+    private func accept(_ filter: ToolCallTokenFilter, _ ids: [Int32]) {
+        for id in ids {
+            #expect(filter.tryAccept(id), "rejected \(id) (\(Self.pieces[id] ?? "?"))")
+        }
+    }
+
+    // MARK: - Free prose
+
+    @Test func proseIsUnconstrained() {
+        let filter = makeFilter()
+        accept(filter, [224, 237, 223, ID.channelStart, 224, ID.channelEnd, ID.escape])
+        #expect(filter.tryAccept(ID.endOfTurn))
+        #expect(filter.tryAccept(ID.eos))
+        #expect(!filter.isInsideCall)
+    }
+
+    @Test func strayClosingMarkersAreVetoedInProse() {
+        let filter = makeFilter()
+        #expect(!filter.tryAccept(ID.toolCallEnd))
+        #expect(!filter.tryAccept(ID.toolResponseEnd))
+        // The orphan tool response the server currently turns into a 500.
+        #expect(!filter.tryAccept(ID.toolResponse))
+    }
+
+    @Test func noDeclaredToolsBlocksTheBlockEntirely() {
+        let filter = makeFilter(names: [])
+        #expect(!filter.tryAccept(ID.toolCallStart))
+        #expect(filter.tryAccept(224))
+    }
+
+    @Test func nonASCIINamesAreDroppedRatherThanForced() {
+        let filter = makeFilter(names: ["hérramienta", "bad name", ""])
+        #expect(!filter.tryAccept(ID.toolCallStart))
+    }
+
+    // MARK: - Name forcing
+
+    @Test func undeclaredNameIsVetoedAndCountedSeparately() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200])
+        #expect(!filter.tryAccept(206))          // getweather
+        filter.noteVeto()
+        #expect(filter.nameVetoCount == 1)
+        #expect(filter.vetoCount == 1)
+        accept(filter, [203, 208, 209])          // get-weather{}
+        #expect(filter.tryAccept(ID.toolCallEnd))
+        #expect(filter.emittedCalls == 1)
+    }
+
+    @Test func sharedPrefixNamesAreBothReachable() {
+        for name in ["get", "get_all"] {
+            let filter = makeFilter()
+            accept(filter, [ID.toolCallStart, 200])
+            let id: Int32 = name == "get" ? 204 : 205
+            accept(filter, [id, 208, 209])
+            #expect(filter.tryAccept(ID.toolCallEnd))
+            #expect(String(decoding: filter.closedCallBody ?? [], as: UTF8.self)
+                        == "call:\(name){}")
+        }
+    }
+
+    @Test func piecesMayStraddlePhaseBoundaries() throws {
+        // "call" + ":" splits the prefix; one piece can also carry the prefix,
+        // the whole name and the opening brace; and `}` + the space marker
+        // crosses out of the argument object into trailing whitespace.
+        let spellings: [[Int32]] = [
+            [201, 202, 203, 208, 209],
+            [238, 209],
+            [200, 203, 208, 239],
+        ]
+        for spelling in spellings {
+            let filter = makeFilter()
+            accept(filter, [ID.toolCallStart])
+            accept(filter, spelling)
+            #expect(filter.tryAccept(ID.toolCallEnd))
+            let body = String(decoding: filter.closedCallBody ?? [], as: UTF8.self)
+            let call = try GemmaToolCallParser().parse(
+                body, allowedTools: ["get-weather"], id: "x")
+            #expect(call.name == "get-weather")
+        }
+    }
+
+    @Test func namePieceMayNotOvershootTheDeclaredSet() {
+        let filter = makeFilter(names: ["weather"])
+        accept(filter, [ID.toolCallStart, 200])
+        #expect(filter.tryAccept(207))           // "weather{" — terminal then `{`
+        accept(filter, [209])
+        #expect(filter.tryAccept(ID.toolCallEnd))
+    }
+
+    // MARK: - Argument dialect at token level
+
+    @Test func canonicalJSONDerailIsVetoed() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203])
+        #expect(!filter.tryAccept(220))          // `{"` — quoted key
+        accept(filter, [208])
+        #expect(!filter.tryAccept(219))          // bare `"` in key position
+        accept(filter, [210, 202])               // city:
+        #expect(!filter.tryAccept(219))          // `"` in value position
+        #expect(!filter.tryAccept(216))          // 01
+        #expect(!filter.tryAccept(217))          // 1e5
+        #expect(!filter.tryAccept(236))          // 16 integer digits
+        accept(filter, [214, 213])               // 1,
+        #expect(!filter.tryAccept(209))          // trailing comma before `}`
+        #expect(!filter.tryAccept(219))          // and still no quoted key
+        accept(filter, [210, 202, 214, 209])
+        #expect(filter.tryAccept(ID.toolCallEnd))
+    }
+
+    @Test func delimiterIsAcceptedAsOneTokenOrFivePieces() {
+        for spelling: [Int32] in [[ID.escape], [233, 234, 235]] {
+            let filter = makeFilter()
+            accept(filter, [ID.toolCallStart, 200, 203, 208, 210, 202])
+            accept(filter, spelling)
+            accept(filter, [218])
+            accept(filter, spelling)
+            accept(filter, [209])
+            #expect(filter.tryAccept(ID.toolCallEnd))
+            #expect(String(decoding: filter.closedCallBody ?? [], as: UTF8.self)
+                        == #"call:get-weather{city:<|"|>Rosario<|"|>}"#)
+        }
+    }
+
+    @Test func byteFallbackSequenceCrossesTheDelimiter() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203, 208, 210, 202, ID.escape])
+        accept(filter, [229, 230, 231, 232])     // 😀 one byte-fallback at a time
+        // Mid-sequence the delimiter cannot start.
+        accept(filter, [229])
+        #expect(!filter.tryAccept(ID.escape))
+        accept(filter, [230, 231, 232, ID.escape, 209])
+        #expect(filter.tryAccept(ID.toolCallEnd))
+        #expect(String(decoding: filter.closedCallBody ?? [], as: UTF8.self)
+                    == "call:get-weather{city:<|\"|>\u{1F601}\u{1F601}<|\"|>}")
+    }
+
+    @Test func prependScalarCannotHideTheClosingDelimiter() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203, 208, 210, 202, ID.escape])
+        accept(filter, [225, 226])               // U+0600, Prepend
+        #expect(!filter.tryAccept(ID.escape))
+        #expect(!filter.tryAccept(233))          // bare `<`
+        accept(filter, [227, ID.escape, 209])    // any content clears the guard
+        #expect(filter.tryAccept(ID.toolCallEnd))
+    }
+
+    // MARK: - Marker discipline inside a region
+
+    @Test func markersInsideARegionAreVetoed() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203, 208])
+        for marker in [ID.toolCallStart, ID.toolResponse, ID.toolResponseEnd,
+                       ID.channelStart, ID.channelEnd, ID.endOfTurn,
+                       ID.eos, ID.bos, ID.pad] {
+            #expect(!filter.tryAccept(marker), "marker \(marker) leaked into a region")
+        }
+        // `<tool_call|>` too, until the object closes.
+        #expect(!filter.tryAccept(ID.toolCallEnd))
+        accept(filter, [209])
+        #expect(filter.tryAccept(ID.toolCallEnd))
+    }
+
+    @Test func afterACallOnlyTheTwoContinuationsPass() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203, 208, 209, ID.toolCallEnd])
+        for rejected in [ID.toolCallEnd, ID.toolResponseEnd, ID.channelStart,
+                         ID.channelEnd, ID.endOfTurn, ID.eos, 224] {
+            #expect(!filter.tryAccept(rejected))
+        }
+        #expect(filter.tryAccept(ID.toolResponse))
+        #expect(filter.tryAccept(ID.toolCallStart))
+    }
+
+    @Test func toolResponseIsLegalOnceACallExists() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203, 208, 209, ID.toolCallEnd,
+                        ID.toolResponse])
+        #expect(filter.emittedCalls == 1)
+    }
+
+    // MARK: - Handoff and bookkeeping
+
+    @Test func closedCallBodyOnlyLandsOnTheClosingToken() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203, 208, 209])
+        #expect(filter.closedCallBody == nil)
+        #expect(filter.tryAccept(ID.toolCallEnd))
+        #expect(String(decoding: filter.closedCallBody ?? [], as: UTF8.self)
+                    == "call:get-weather{}")
+        #expect(filter.tryAccept(ID.toolResponse))
+        #expect(filter.closedCallBody == nil)
+    }
+
+    @Test func closedBodyParsesAsTheDeclaredTool() throws {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203, 208, 210, 202, ID.escape,
+                        218, ID.escape, 213, 210, 202, 228, 209])
+        #expect(filter.tryAccept(ID.toolCallEnd))
+        let body = String(decoding: filter.closedCallBody ?? [], as: UTF8.self)
+        let call = try GemmaToolCallParser().parse(
+            body, allowedTools: ["get-weather", "get", "get_all"], id: "x")
+        #expect(call.name == "get-weather")
+    }
+
+    @Test func rejectionDoesNotAdvanceState() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203, 208, 210])
+        #expect(!filter.tryAccept(220))
+        #expect(!filter.tryAccept(219))
+        // The key is still open, so the colon still lands.
+        accept(filter, [202, 214, 209])
+        #expect(filter.tryAccept(ID.toolCallEnd))
+        #expect(String(decoding: filter.closedCallBody ?? [], as: UTF8.self)
+                    == "call:get-weather{city:1}")
+    }
+
+    /// A token that clears the trie and then breaks the argument grammar says
+    /// nothing about the tool name, even though the committed phase is `.name`.
+    @Test func aVetoPastTheNameIsNotANameVeto() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart, 200, 203])
+        #expect(!filter.tryAccept(220))          // `{"` — enters, then dies
+        filter.noteVeto()
+        #expect(filter.vetoCount == 1)
+        #expect(filter.nameVetoCount == 0)
+        #expect(!filter.tryAccept(206))          // getweather — dies in the trie
+        filter.noteVeto()
+        #expect(filter.nameVetoCount == 1)
+    }
+
+    @Test func vetoCountsAttributePhaseCorrectly() {
+        let filter = makeFilter()
+        accept(filter, [ID.toolCallStart])
+        filter.noteVeto()                        // prefix
+        accept(filter, [200, 203, 208])
+        filter.noteVeto()                        // arguments
+        #expect(filter.vetoCount == 2)
+        #expect(filter.nameVetoCount == 1)
+    }
+
+    @Test func isInsideCallTracksTheRegion() {
+        let filter = makeFilter()
+        #expect(!filter.isInsideCall)
+        accept(filter, [ID.toolCallStart])
+        #expect(filter.isInsideCall)
+        accept(filter, [200, 203, 208, 209])
+        #expect(filter.isInsideCall)
+        #expect(filter.tryAccept(ID.toolCallEnd))
+        #expect(!filter.isInsideCall)
+    }
+
+    /// The region body is exactly what the parser will see, so capping it here
+    /// makes `GemmaToolCallParserError.oversized` unreachable.
+    @Test func regionBytesAreCapped() {
+        let filler = String(repeating: "a", count: 1024)
+        let big: Int32 = 900
+        let filter = ToolCallTokenFilter(
+            pieceLookup: { id in id == big ? filler : Self.pieces[id] },
+            markers: Self.markers,
+            allowedNames: ["get-weather"])
+        accept(filter, [ID.toolCallStart, 200, 203, 208, 210, 202, ID.escape])
+        var accepted = 0
+        while filter.tryAccept(big) { accepted += 1 }
+        #expect(accepted * filler.utf8.count <= GemmaToolCallParser.maximumBytes)
+        #expect(accepted > 200)
+    }
+}

--- a/Tests/TurboFieldfare/Core/Tokenization/GemmaToolCallParserTests.swift
+++ b/Tests/TurboFieldfare/Core/Tokenization/GemmaToolCallParserTests.swift
@@ -1,0 +1,61 @@
+import Testing
+import Foundation
+@testable import TurboFieldfare
+
+/// Parser-level regressions for the dialect the Gemma 4 chat template renders:
+/// hyphenated tool names (legal per `OpenAIToolName.isValid`) and string
+/// arguments whose interior whitespace must survive verbatim.
+@Suite struct GemmaToolCallParserTests {
+
+    private func parse(_ text: String, tools: Set<String>) throws -> ParsedToolCall {
+        try GemmaToolCallParser().parse(text, allowedTools: tools, id: "call_test")
+    }
+
+    @Test func hyphenatedToolNameDecodes() throws {
+        let call = try parse(#"call:get-weather{city:<|"|>Rosario<|"|>}"#,
+                             tools: ["get-weather"])
+        #expect(call.name == "get-weather")
+        #expect(call.arguments == .object(["city": .string("Rosario")]))
+    }
+
+    @Test func hyphenatedNameIsNotTruncatedAtTheHyphen() throws {
+        // Before the fix the identifier stopped at `-`, so a declared `read`
+        // matched `read-file` and the leftover `-file` failed as arguments.
+        #expect(throws: GemmaToolCallParserError.unknownTool("read-file")) {
+            try parse(#"call:read-file{path:<|"|>/a<|"|>}"#, tools: ["read"])
+        }
+        let call = try parse(#"call:read-file{path:<|"|>/a<|"|>}"#,
+                             tools: ["read", "read-file"])
+        #expect(call.name == "read-file")
+    }
+
+    @Test func mixedSeparatorNameDecodes() throws {
+        let call = try parse(#"call:web_search-v2{q:<|"|>x<|"|>}"#,
+                             tools: ["web_search-v2"])
+        #expect(call.name == "web_search-v2")
+    }
+
+    @Test func gemmaStringPreservesWhitespaceAndPunctuation() throws {
+        let call = try parse(#"call:f{s:<|"|>a , b 's c<|"|>}"#, tools: ["f"])
+        #expect(call.arguments == .object(["s": .string("a , b 's c")]))
+    }
+
+    /// The `"`-delimited path used to run every character through a
+    /// whitespace-skipping helper, so interior spaces vanished from the decoded
+    /// argument while the request still looked successful.
+    @Test func quotedStringPreservesInteriorWhitespace() throws {
+        let call = try parse(#"call:f{path:"/tmp/a b c"}"#, tools: ["f"])
+        #expect(call.arguments == .object(["path": .string("/tmp/a b c")]))
+    }
+
+    @Test func quotedStringPreservesTabsNewlinesAndEscapes() throws {
+        let call = try parse("call:f{s:\" a\tb\nc \",t:\"x \\n y\"}", tools: ["f"])
+        #expect(call.arguments == .object(["s": .string(" a\tb\nc "),
+                                           "t": .string("x \n y")]))
+    }
+
+    @Test func quotedEmptyStringStillDecodes() throws {
+        let call = try parse(#"call:f{s:""}"#, tools: ["f"])
+        #expect(call.arguments == .object(["s": .string("")]))
+    }
+}

--- a/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
@@ -95,6 +95,30 @@ struct OpenAIValidationTests {
         }
     }
 
+    /// The validator accepts hyphens, so the decoder has to as well: the chat
+    /// template renders the declared name verbatim into `call:<name>{`.
+    @Test func hyphenatedToolNameSurvivesValidationAndDecoding() throws {
+        let data = Data(#"""
+        {
+          "model":"m",
+          "messages":[{"role":"user","content":"x"}],
+          "tools":[{
+            "type":"function",
+            "function":{"name":"resolve-library-id","parameters":{"type":"object"}}
+          }]
+        }
+        """#.utf8)
+        let request = try JSONDecoder().decode(OpenAIChatRequest.self, from: data)
+        let validated = try OpenAIRequestValidator.validate(request, modelID: "m")
+        let names = Set(validated.tools.map(\.name))
+        #expect(names == ["resolve-library-id"])
+        let call = try GemmaToolCallParser().parse(
+            #"call:resolve-library-id{name:<|"|>swift<|"|>}"#,
+            allowedTools: names,
+            id: "call_test")
+        #expect(call.name == "resolve-library-id")
+    }
+
     @Test func acceptsLeadingSystemAndDeveloperGuidance() throws {
         let data = Data(#"""
         {"model":"m","messages":[
@@ -449,6 +473,44 @@ struct GemmaToolCallTests {
         #expect(parsed.argumentsJSON.contains(#""note":"a\b\f""#))
     }
 
+    /// The library decode runs swift-transformers' `cleanUp` pass, which
+    /// rewrites ` ,` → `,` and ` 's` → `'s` — inside a string argument that is
+    /// silent corruption. Grammar-validated bytes bypass it.
+    @Test func validatedBodyBypassesDetokenizerCleanUp() async throws {
+        let tokenizer = try await GFTokenizer.load()
+        let body = #"call:read{path:<|"|>a , b 's c<|"|>}"#
+        let decoder = StructuredAssistantDecoder(
+            tokenizer: tokenizer, allowedTools: ["read"], idGenerator: { "call_fixed" })
+        #expect(try decoder.consume(tokenID: tokenizer.toolCallStartID, delta: "").isEmpty)
+        #expect(decoder.hasOpenToolRegion)
+        for id in tokenizer.encode(body, addBOS: false) {
+            #expect(try decoder.consume(tokenID: id, delta: "").isEmpty)
+        }
+        let events = try decoder.consume(tokenID: tokenizer.toolCallEndID,
+                                         delta: "",
+                                         validatedBody: Array(body.utf8))
+        #expect(!decoder.hasOpenToolRegion)
+        guard case .toolCall(let call)? = events.first else {
+            Issue.record("expected a tool call, got \(events)")
+            return
+        }
+        #expect(call.arguments == .object(["path": .string("a , b 's c")]))
+
+        // Without the validated bytes the same token stream loses the spaces.
+        let plain = StructuredAssistantDecoder(
+            tokenizer: tokenizer, allowedTools: ["read"], idGenerator: { "call_fixed" })
+        _ = try plain.consume(tokenID: tokenizer.toolCallStartID, delta: "")
+        for id in tokenizer.encode(body, addBOS: false) {
+            _ = try plain.consume(tokenID: id, delta: "")
+        }
+        let cleaned = try plain.consume(tokenID: tokenizer.toolCallEndID, delta: "")
+        guard case .toolCall(let corrupted)? = cleaned.first else {
+            Issue.record("expected a tool call, got \(cleaned)")
+            return
+        }
+        #expect(corrupted.arguments != call.arguments)
+    }
+
     @Test func suppressesThoughtBlockAndExposesTextAfterChannelClose() async throws {
         let tokenizer = try await GFTokenizer.load()
         let decoder = StructuredAssistantDecoder(tokenizer: tokenizer, allowedTools: [])
@@ -488,6 +550,27 @@ struct ServerArgumentTests {
         #expect(arguments.maxContext == 16_384)
         #expect(arguments.queueLimit == 4)
         #expect(arguments.promptCacheMode == .singlePrefix)
+        #expect(arguments.toolCallGrammar == .on)
+    }
+
+    @Test func parsesToolCallGrammarModeAndRejectsUnknownMode() throws {
+        let off = try ServerArguments.parse([
+            "--model", "model.gturbo",
+            "--tool-call-grammar", "off",
+        ])
+        #expect(off.toolCallGrammar == .off)
+        let on = try ServerArguments.parse([
+            "--model", "model.gturbo",
+            "--tool-call-grammar", "on",
+        ])
+        #expect(on.toolCallGrammar == .on)
+        #expect(throws: ServerArgumentError.self) {
+            try ServerArguments.parse([
+                "--model", "model.gturbo",
+                "--tool-call-grammar", "strict",
+            ])
+        }
+        #expect(ServerArguments.usage.contains("--tool-call-grammar"))
     }
 
     @Test func parsesSinglePrefixModeAndRejectsUnknownMode() throws {

--- a/Tests/TurboFieldfareServer/ServerPromptCacheTests.swift
+++ b/Tests/TurboFieldfareServer/ServerPromptCacheTests.swift
@@ -195,6 +195,65 @@ struct ServerPromptCacheTests {
         #expect(cache.entry == nil)
     }
 
+    /// A tool call cut off by the completion budget answers 200 with
+    /// `finish_reason: "length"`, but its KV ends inside a `<|tool_call>` the
+    /// response never revealed. The client continues from the transcript it
+    /// received — which cannot contain that call — so the entry has to be
+    /// refused: a hit would resume generation inside an invisible call.
+    @Test func kvEndingInsideAnOpenToolCallIsNeverPublished() async throws {
+        let tokenizer = try await GFTokenizer.load()
+        let initial = request(messages: [
+            GFTokenizer.Message(role: .user, content: "first"),
+        ])
+        let prompt = tokenizer.encode(
+            try tokenizer.applyChatTemplate(initial.messages),
+            addBOS: false)
+        // `Sure.<|tool_call>call:read{path:<|"|>` — the budget ran out with the
+        // path argument half spelled.
+        let generated = tokenizer.encode("Sure.", addBOS: false)
+            + [tokenizer.toolCallStartID]
+            + tokenizer.encode("call:read{path:", addBOS: false)
+            + [tokenizer.escapeTokenID]
+        let cut = rawResult(
+            prompt: prompt,
+            kvBacked: prompt + generated,
+            boundary: try #require(tokenizer.encode("/tmp", addBOS: false).first),
+            reason: .maxTokens)
+        let continuation = request(messages: initial.messages + [
+            GFTokenizer.Message(role: .assistant, content: "Sure."),
+            GFTokenizer.Message(role: .user, content: "go on"),
+        ])
+        let rendered = tokenizer.encode(
+            try tokenizer.applyChatTemplate(continuation.messages),
+            addBOS: false)
+        var cache = ServerPromptCache()
+
+        // Nothing else about the turn stops it: as a plain length stop it is a
+        // textbook text continuation, which is exactly why the region has to be
+        // reported separately.
+        cache.publish(domain: domain, request: initial, content: "Sure.",
+                      calls: [], result: cut)
+        guard case .hit(let effective, _) = cache.match(
+            domain: domain,
+            request: continuation,
+            renderedPromptIDs: rendered,
+            tokenizer: tokenizer) else {
+            Issue.record("expected the unguarded entry to hit")
+            return
+        }
+        #expect(effective.contains(tokenizer.toolCallStartID))
+        #expect(!rendered.contains(tokenizer.toolCallStartID))
+
+        cache.publish(domain: domain, request: initial, content: "Sure.",
+                      calls: [], result: cut, toolRegionOpen: true)
+        #expect(cache.entry == nil)
+        #expect(cache.match(
+            domain: domain,
+            request: continuation,
+            renderedPromptIDs: rendered,
+            tokenizer: tokenizer) == .miss)
+    }
+
     private func request(
         messages: [GFTokenizer.Message],
         tools: [GFTokenizer.FunctionDefinition] = []

--- a/Tests/TurboFieldfareServer/StructuredOutputDiagnosticsTests.swift
+++ b/Tests/TurboFieldfareServer/StructuredOutputDiagnosticsTests.swift
@@ -89,6 +89,32 @@ struct StructuredOutputDiagnosticsTests {
         }
     }
 
+    /// The grammar's veto counters ride along with the existing evidence: a
+    /// failure that still happens with the constraint on means the grammar has
+    /// a hole, and the counters say how hard it was fighting the model.
+    @Test func vetoCountersAreReportedInTheLogLine() {
+        var result = makeResult()
+        result.toolGrammarVetoes = 7
+        result.toolNameVetoes = 3
+        let diagnostics = StructuredOutputFailureDiagnostics(
+            renderedPromptIDs: [8, 10, 11, 12],
+            effectivePromptIDs: [10, 11, 12],
+            result: result,
+            maxCompletionTokens: 8,
+            decodedCalls: 0,
+            visibleBytes: 0,
+            stopStringMatched: false,
+            toolStartID: 48,
+            toolEndID: 49,
+            toolResponseID: 102,
+            toolResponseEndID: 103)
+        #expect(diagnostics.toolGrammarVetoes == 7)
+        #expect(diagnostics.toolNameVetoes == 3)
+        #expect(diagnostics.logDescription.contains("tool_grammar_vetoes=7"))
+        #expect(diagnostics.logDescription.contains("tool_name_vetoes=3"))
+        #expect(makeDiagnostics().logDescription.contains("tool_grammar_vetoes=0"))
+    }
+
     @Test func tokenHashUsesUInt32LittleEndianBytes() {
         let tokens: [Int32] = [1, -1]
         #expect(StructuredOutputFailureDiagnostics.i32leSHA256([tokens[...]])
@@ -102,11 +128,8 @@ struct StructuredOutputDiagnosticsTests {
         #expect(!diagnostics.prefillAccountingMatches)
     }
 
-    private func makeDiagnostics(prefillTokens: Int = 3)
-        -> StructuredOutputFailureDiagnostics {
-        let renderedPrompt: [Int32] = [8, 10, 11, 12]
-        let effectivePrompt: [Int32] = [10, 11, 12]
-        let result = RawDecodeResult(
+    private func makeResult(prefillTokens: Int = 3) -> RawDecodeResult {
+        RawDecodeResult(
             prefillTokens: prefillTokens,
             cachedPromptTokens: 1,
             computedPrefillTokens: 2,
@@ -115,8 +138,15 @@ struct StructuredOutputDiagnosticsTests {
             decodeSeconds: 0,
             reason: .toolCalls,
             kvPosition: 5,
-            kvBackedTokenIDs: effectivePrompt + [20, 21],
+            kvBackedTokenIDs: [10, 11, 12, 20, 21],
             uncommittedBoundaryTokenIDs: [102])
+    }
+
+    private func makeDiagnostics(prefillTokens: Int = 3)
+        -> StructuredOutputFailureDiagnostics {
+        let renderedPrompt: [Int32] = [8, 10, 11, 12]
+        let effectivePrompt: [Int32] = [10, 11, 12]
+        let result = makeResult(prefillTokens: prefillTokens)
         return StructuredOutputFailureDiagnostics(
             renderedPromptIDs: renderedPrompt,
             effectivePromptIDs: effectivePrompt,

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -185,7 +185,11 @@ Consequences worth knowing:
   what the decoder needs to return `C:\Users`.
 - Numbers are written out (`100000`, not `1e5`).
 - A call cut off by `max_completion_tokens` returns `finish_reason: "length"`
-  with whatever was decoded before it, instead of failing the request.
+  with whatever was decoded before it, instead of failing the request. The
+  unfinished call is dropped whole: no fragment of its arguments appears in
+  `content`, and the turn is never cached, so the next request re-prefills
+  instead of resuming inside a call the response never showed. A string
+  argument that reaches the 256 KiB limit ends the same way.
 
 Use `--tool-call-grammar off` to restore the unconstrained token stream. The
 flag is a rollback control: with it off the server generates exactly the tokens

--- a/docs/OPENAI_SERVER.md
+++ b/docs/OPENAI_SERVER.md
@@ -47,6 +47,10 @@ requests for preparation or queueing. The limit is enforced before prompt
 rendering and tokenization. Use `--queue-limit` to change it. Press Control-C
 to stop the server.
 
+Tool calls are decoded under a grammar constraint by default; see
+[Constrained tool-call decoding](#constrained-tool-call-decoding) for what that
+changes and how to turn it off with `--tool-call-grammar off`.
+
 ## Connect a client
 
 The base URL is `http://127.0.0.1:8080/v1`. Some client libraries require an
@@ -160,6 +164,32 @@ forms. Unions of string constants are also supported. Overlapping `oneOf`,
 mixed-type unions such as `string | object`, and `allOf` return HTTP 400 with
 `invalid_tool_schema`; the server does not guess which branch the model should
 use.
+
+### Constrained tool-call decoding
+
+Tool calls are generated under a byte-level grammar. Once the model emits
+`<|tool_call>`, every candidate token is checked before it is accepted: if it
+would break the call, the highest-probability token that does not is used
+instead. The grammar accepts exactly the argument dialect the chat template
+renders and the decoder reads back — bare object keys at every depth, strings
+delimited by the `<|"|>` escape token, and plain numbers without exponents —
+which is what removes the failure mode where a long generation ends in
+`finish_reason: "tool_calls"` with no decodable call.
+
+Consequences worth knowing:
+
+- The function name is forced to one of the names declared in `tools`. If the
+  request declares no tools, `<|tool_call>` cannot open at all and the model
+  answers with text.
+- Backslashes in string arguments are emitted escaped (`C:\\Users`), which is
+  what the decoder needs to return `C:\Users`.
+- Numbers are written out (`100000`, not `1e5`).
+- A call cut off by `max_completion_tokens` returns `finish_reason: "length"`
+  with whatever was decoded before it, instead of failing the request.
+
+Use `--tool-call-grammar off` to restore the unconstrained token stream. The
+flag is a rollback control: with it off the server generates exactly the tokens
+it generated before the constraint existed.
 
 ## Supported API
 

--- a/docs/RUNTIME_CONTROLS.md
+++ b/docs/RUNTIME_CONTROLS.md
@@ -15,6 +15,7 @@ The Mac app and CLI expose these generation controls:
 | Temperature | 0...2 in 0.05 steps | `--temperature` | 0.2 | `0` is greedy; positive values sample. |
 | Top-K | Off or 1...256 | `--top-k` | 64 | Keeps at most K candidates. CLI `0` turns it off. |
 | Top-P | Off or 0.01...1 | `--top-p` | 0.95 | Applies nucleus truncation before Top-K and is effective only while Top-K is enabled. |
+| Forced JSON | CLI only | `--force-json` | Off | Constrains decoding to grammar-valid JSON (RFC 8259); the sampler can only pick tokens a byte-level JSON automaton accepts. Cannot be combined with `--stop`. |
 
 With positive temperature, a CLI Top-P below `1` requires Top-K between `1`
 and `256`. To disable both truncation controls, pass `--top-k 0 --top-p 1`.


### PR DESCRIPTION
this adds grammar-constrained decoding and uses it two ways: --force-json on
the cli, which forces the whole response to valid json, and
--tool-call-grammar on the server (default on), which fixes #84.

the engine is a byte-level json automaton (string/escape/number/literal
states, depth cap 128). the sampler can only pick a token whose bytes the
automaton accepts; if the top candidate would break the grammar it walks the
probs buffer in probability order and takes the first legal one. bytes are
emitted through a utf-8 validating assembler rather than the detokenizer,
whose cleanup step (on by default) can swallow valid bytes. --force-json and
--stop are mutually exclusive.

#84: long tool-calling turns end with finish_reason=toolCalls and zero
decodable calls, so ServerInference throws GemmaToolCallParserError.malformed
and the request 500s. the model drifts to canonical json inside <|tool_call>
and the parser refuses it. ToolCallTokenFilter constrains the region between
<|tool_call> and <tool_call|> to a strict subset of what GemmaToolCallParser
accepts, so any region the grammar closes will parse. the function name is
forced through a trie over the declared tools, so unknownTool is unreachable
and a request with no tools cant open a call. #90 added the diagnostics, this
is the root-cause fix. --tool-call-grammar off restores the old token stream.

turning the tool-call constraint on created three failures that the follow-up
commit fixes, all reachable only with it on:
- the KV for an unclosed call outlived the response, so the next turn resumed
  inside an invisible call with wrong prompt_tokens.
- argument bytes leaked to content: a request cut inside "/tmp/café" answered
  content:"Sure.é".
- hitting the byte cap (reachable at --max-context 65536, or a 256 KiB
  degenerate string argument) swept the whole vocab and threw a generic 500.
  it now ends the generation as .maxTokens.

it also fixes two parser bugs reachable with the constraint off: identifier()
stopped at a hyphen, so hyphenated OpenAI tool names were undecodable, and
jsonString() ran each character through a whitespace-skipping helper, so
"/tmp/a b c" decoded as "/tmp/abc".

both flags are documented, --force-json in docs/RUNTIME_CONTROLS.md and
--tool-call-grammar in docs/OPENAI_SERVER.md.

real-model check, M5 Pro 24GB, macOS 26.6.1, swift 6.3.3, gemma4.gturbo. a
triage prompt whose own text tells the model to ignore its instructions and
answer in prose, not json. without --force-json it obeys and writes a
paragraph. with it:

    [stop=eos prefill=1872tok new=74tok decode=2.15s tok/s=34.480 vetoes=1]

    [{"tipo":"pedido_documentacion","urgencia":"alta","requiere_accion":true,
      "resumen":"..."}]

one grammar veto, at the token where the model tried to leave json. peak
2.06 GB.

ToolCallGrammarFuzzTests walks the grammar 5,000 times (the env var
TURBO_FIELDFARE_FUZZ_WALKS raises it) and asserts every region the grammar
closes parses under GemmaToolCallParser. swift build -c release,
Scripts/test.sh (763 tests), and ruby Scripts/check_markdown_links.rb all
green on the machine above.

i also reproduced #84 end to end at the server level, off vs on, with a
tool-calling fixture that pushes the model out of the call format. that
driver isnt in the tree because its fixtures come from a private project;
the checked-in evidence is the fuzz property plus the unit tests above.

bounded-memory path preserved: the automaton is a small pod, no checkpoint or
tensor enters swift heap.