### PR TITLE
Update SwiftNIO to 2.101.3

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "fcd8c6c7b3bdc1b2987889f5525974610779e7fe094361a13b5cd2b27afa046b",
+  "originHash" : "435ef526604b6fb89c51f42b4c73442dc24c9a35e166034fe34aeb32cd722db6",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -69,8 +69,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio.git",
       "state" : {
-        "revision" : "f71c8d2a5e74a2c6d11a0fbe324774b5d6084237",
-        "version" : "2.99.0"
+        "revision" : "0b18836bd8b0162e7e17a995a3fbee20ed8f3b2b",
+        "version" : "2.101.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -17,7 +17,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
-        .package(url: "https://github.com/apple/swift-nio.git", exact: "2.99.0"),
+        .package(url: "https://github.com/apple/swift-nio.git", exact: "2.101.3"),
     ],
     targets: [
         .target(


### PR DESCRIPTION
## Summary

- Update the exact SwiftNIO dependency pin from `2.99.0` to the latest stable release, `2.101.3`.
- Regenerate `Package.resolved` without changing any other dependency versions.
- Move past the affected range for the public SwiftNIO advisories [GHSA-rj37-6j9x-74q6](https://github.com/advisories/GHSA-rj37-6j9x-74q6), [GHSA-r3rc-9hpw-54v9](https://github.com/advisories/GHSA-r3rc-9hpw-54v9), and [GHSA-cq87-8r7h-962v](https://github.com/advisories/GHSA-cq87-8r7h-962v), all fixed in `2.100.0` or later.

Prepared and validated by OpenAI Codex (GPT-5.6 Sol), at @mariogeiger's request.

## Validation

- `swift build -c release`
- `Scripts/test.sh` — 648 tests in 122 suites passed
- `ruby Scripts/check_markdown_links.rb` — 22 Markdown files passed

No model was downloaded or loaded.

## Memory and performance

Not applicable. This only updates a server dependency and does not change model loading, importer behavior, streaming, or Metal code.

## Remaining limitations

None identified. The server remains loopback-only and unauthenticated as documented.

- [x] The change does not load a complete checkpoint, shard, or large model tensor into Swift heap memory.
- [x] Logs and artifacts contain no credentials, private paths, or model weights.