### PR TITLE
Show application version in About panel

### DIFF
--- a/Sources/TurboFieldfareApp/Mac/App/TurboFieldfareMacApp.swift
+++ b/Sources/TurboFieldfareApp/Mac/App/TurboFieldfareMacApp.swift
@@ -1,5 +1,6 @@
 import AppKit
 import TurboFieldfareAppCore
+import TurboFieldfareMacPresentation
 import SwiftUI
 
 // Run as a regular foreground app even when launched as a bare SwiftPM
@@ -43,6 +44,14 @@ struct TurboFieldfareMacApp: App {
         .defaultSize(width: 1040, height: 720)
         .windowResizability(.contentMinSize)
         .commands {
+            CommandGroup(replacing: .appInfo) {
+                Button("About TurboFieldfare") {
+                    NSApp.orderFrontStandardAboutPanel(options: [
+                        .version: TurboFieldfareAppVersion.resolve(),
+                        .applicationName: "TurboFieldfare",
+                    ])
+                }
+            }
             CommandMenu("Generation") {
                 Button("Cancel Generation") { model.cancel() }
                     .keyboardShortcut(".", modifiers: .command)

--- a/Sources/TurboFieldfareApp/MacPresentation/TurboFieldfareAppVersion.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/TurboFieldfareAppVersion.swift
@@ -1,0 +1,15 @@
+import Foundation
+
+public enum TurboFieldfareAppVersion {
+    public static let fallback = "0.4.1"
+
+    public static func resolve(
+        bundle: Bundle = .main,
+        fallback: String = Self.fallback
+    ) -> String {
+        if let version = bundle.infoDictionary?["CFBundleShortVersionString"] as? String {
+            return version
+        }
+        return fallback
+    }
+}

--- a/Tests/TurboFieldfareApp/MacPresentation/TurboFieldfareAppVersionTests.swift
+++ b/Tests/TurboFieldfareApp/MacPresentation/TurboFieldfareAppVersionTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+@testable import TurboFieldfareMacPresentation
+
+@Suite struct TurboFieldfareAppVersionTests {
+    @Test func fallbackIsUsedWhenBundleHasNoVersion() {
+        let bundle = Bundle(for: BundleToken.self)
+        #expect(TurboFieldfareAppVersion.resolve(bundle: bundle) == "0.4.1")
+    }
+
+    @Test func bundleVersionTakesPrecedence() {
+        let bundle = Bundle(for: BundleToken.self)
+        let overrides: [String: Any] = ["CFBundleShortVersionString": "1.2.3"]
+        let overridden = OverrideBundle(inner: bundle, overrides: overrides)
+        #expect(TurboFieldfareAppVersion.resolve(bundle: overridden) == "1.2.3")
+    }
+
+    @Test func customFallbackIsHonored() {
+        let bundle = Bundle(for: BundleToken.self)
+        #expect(TurboFieldfareAppVersion.resolve(
+            bundle: bundle,
+            fallback: "0.0.0-beta") == "0.0.0-beta")
+    }
+}
+
+private final class BundleToken {}
+
+private final class OverrideBundle: Bundle {
+    private let overrides: [String: Any]
+
+    init(inner: Bundle, overrides: [String: Any]) {
+        self.overrides = overrides
+        super.init(for: type(of: BundleToken.self))
+    }
+
+    required init?(coder: NSCoder) {
+        fatalError("init(coder:) has not been implemented")
+    }
+
+    override var infoDictionary: [String: Any]? {
+        overrides
+    }
+}


### PR DESCRIPTION
Adds an "About TurboFieldfare" menu item under the application menu that displays the version in the native macOS About panel.

When running as a bare SwiftPM executable (no .app bundle),  has no . The resolver falls back to a compiled constant so the About panel always shows a version.

The version resolver lives in  so it can be unit tested. Three tests cover the fallback path, a bundle that supplies its own version, and a custom fallback string.

No model load, installation, inference, or runtime defaults are affected. The change is limited to the Mac presentation layer.

Closes #106