### PR TITLE
Forward Authorization header to known HuggingFace CDN hosts on redirect

### DIFF
--- a/Sources/TurboFieldfareRepack/Core/Remote/RemoteDownloadSession.swift
+++ b/Sources/TurboFieldfareRepack/Core/Remote/RemoteDownloadSession.swift
@@ -120,22 +120,28 @@ struct RemoteMetadataRedirectPolicy {
     private let sourceHost: String?
     private let originalMethod: String?
     private let originalAuthorization: String?
+    private let allowedForwardHosts: Set<String>
     private let maximumRedirects: Int
     private var redirectCount = 0
 
-    init(originalRequest: URLRequest, maximumRedirects: Int) {
+    init(originalRequest: URLRequest,
+         maximumRedirects: Int,
+         allowedForwardHosts: Set<String> = RemoteRedirectPolicy.defaultForwardHosts) {
         self.sourceHost = originalRequest.url?.host?.lowercased()
         self.originalMethod = originalRequest.httpMethod
         self.originalAuthorization = originalRequest.value(
             forHTTPHeaderField: "Authorization")
+        self.allowedForwardHosts = allowedForwardHosts
         self.maximumRedirects = maximumRedirects
     }
 
     mutating func request(proposedRequest: URLRequest) -> URLRequest? {
         redirectCount += 1
+        let targetHost = proposedRequest.url?.host?.lowercased()
+        let isAllowedForward = targetHost.map(allowedForwardHosts.contains) ?? false
         guard redirectCount <= maximumRedirects,
               proposedRequest.url?.scheme?.lowercased() == "https",
-              proposedRequest.url?.host?.lowercased() == sourceHost else {
+              targetHost == sourceHost || isAllowedForward else {
             return nil
         }
         var redirected = proposedRequest

--- a/Sources/TurboFieldfareRepack/Core/Remote/RemoteRangeTransfer.swift
+++ b/Sources/TurboFieldfareRepack/Core/Remote/RemoteRangeTransfer.swift
@@ -301,17 +301,23 @@ struct RemoteRedirectPolicy {
     private let originalRange: String?
     private let originalAuthorization: String?
     private let sourceHost: String?
+    private let allowedForwardHosts: Set<String>
     private let maximumRedirects: Int
     private var redirectCount = 0
     private var authorizationMayBeForwarded = true
 
-    init(originalRequest: URLRequest, maximumRedirects: Int) {
+    init(originalRequest: URLRequest,
+         maximumRedirects: Int,
+         allowedForwardHosts: Set<String> = RemoteRedirectPolicy.defaultForwardHosts) {
         self.originalRange = originalRequest.value(forHTTPHeaderField: "Range")
         self.originalAuthorization = originalRequest.value(
             forHTTPHeaderField: "Authorization")
         self.sourceHost = originalRequest.url?.host?.lowercased()
+        self.allowedForwardHosts = allowedForwardHosts
         self.maximumRedirects = maximumRedirects
     }
+
+    static let defaultForwardHosts: Set<String> = ["cdn-lfs.huggingface.co"]
 
     mutating func request(
         response: HTTPURLResponse,
@@ -329,17 +335,18 @@ struct RemoteRedirectPolicy {
                 detail: "only HTTPS redirects are allowed")
         }
         let targetHost = proposedRequest.url?.host?.lowercased()
-        if targetHost != sourceHost {
+        let isAllowedForward = targetHost.map(allowedForwardHosts.contains) ?? false
+        if targetHost != sourceHost && !isAllowedForward {
             authorizationMayBeForwarded = false
         }
         var redirected = proposedRequest
         redirected.httpMethod = "GET"
         redirected.setValue(originalRange, forHTTPHeaderField: "Range")
         redirected.setValue("identity", forHTTPHeaderField: "Accept-Encoding")
+        let shouldForward = authorizationMayBeForwarded
+            && (targetHost == sourceHost || isAllowedForward)
         redirected.setValue(
-            authorizationMayBeForwarded && targetHost == sourceHost
-                ? originalAuthorization
-                : nil,
+            shouldForward ? originalAuthorization : nil,
             forHTTPHeaderField: "Authorization")
         return redirected
     }

--- a/Tests/TurboFieldfareRepack/Core/Remote/RemoteDownloadSessionTests.swift
+++ b/Tests/TurboFieldfareRepack/Core/Remote/RemoteDownloadSessionTests.swift
@@ -57,4 +57,23 @@ struct RemoteDownloadSessionTests {
         #expect(policy.request(proposedRequest: URLRequest(
             url: URL(string: "https://hf.test/too-many")!)) == nil)
     }
+
+    @Test func metadataRedirectForwardsAuthorizationToAllowedCDNHost() {
+        var original = URLRequest(url: URL(string: "https://hf.test/model/file")!)
+        original.httpMethod = "HEAD"
+        original.setValue("Bearer secret", forHTTPHeaderField: "Authorization")
+        var policy = RemoteMetadataRedirectPolicy(
+            originalRequest: original,
+            maximumRedirects: 2)
+
+        let cdn = policy.request(proposedRequest: URLRequest(
+            url: URL(string: "https://cdn-lfs.huggingface.co/repo/file.bin")!))
+        #expect(cdn?.httpMethod == "HEAD")
+        #expect(cdn?.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
+        #expect(cdn?.value(forHTTPHeaderField: "Accept-Encoding") == "identity")
+
+        let unknown = policy.request(proposedRequest: URLRequest(
+            url: URL(string: "https://evil.test/stolen")!))
+        #expect(unknown == nil)
+    }
 }

--- a/Tests/TurboFieldfareRepack/Core/Remote/RemoteRangeTransferTests.swift
+++ b/Tests/TurboFieldfareRepack/Core/Remote/RemoteRangeTransferTests.swift
@@ -278,6 +278,74 @@ extension RemotePayloadCopyTests {
         #expect(second.value(forHTTPHeaderField: "Range") == "bytes=0-3")
     }
 
+    @Test func redirectPolicyForwardsAuthorizationToAllowedCDNHost() throws {
+        var original = rangeRequest(length: 4)
+        original.setValue("Bearer secret", forHTTPHeaderField: "Authorization")
+        var policy = RemoteRedirectPolicy(
+            originalRequest: original,
+            maximumRedirects: 3)
+        let sourceResponse = HTTPURLResponse(
+            url: original.url!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: nil)!
+
+        var cdnRequest = URLRequest(
+            url: URL(string: "https://cdn-lfs.huggingface.co/signed?token=private")!)
+        cdnRequest.httpMethod = "GET"
+        let cdnRedirect = try policy.request(
+            response: sourceResponse,
+            proposedRequest: cdnRequest)
+        #expect(cdnRedirect?.value(forHTTPHeaderField: "Authorization") == "Bearer secret")
+        #expect(cdnRedirect?.value(forHTTPHeaderField: "Range") == "bytes=0-3")
+
+        let unknownResponse = HTTPURLResponse(
+            url: cdnRequest.url!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: nil)!
+        var unknownRequest = URLRequest(
+            url: URL(string: "https://evil.test/stolen")!)
+        unknownRequest.httpMethod = "GET"
+        let unknownRedirect = try policy.request(
+            response: unknownResponse,
+            proposedRequest: unknownRequest)
+        #expect(unknownRedirect?.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
+    @Test func redirectPolicyStripsAuthAfterAllowedCDNThenUnknownHost() throws {
+        var original = rangeRequest(length: 4)
+        original.setValue("Bearer secret", forHTTPHeaderField: "Authorization")
+        var policy = RemoteRedirectPolicy(
+            originalRequest: original,
+            maximumRedirects: 3)
+        let sourceResponse = HTTPURLResponse(
+            url: original.url!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: nil)!
+
+        var cdnRequest = URLRequest(
+            url: URL(string: "https://cdn-lfs.huggingface.co/signed")!)
+        cdnRequest.httpMethod = "GET"
+        _ = try policy.request(
+            response: sourceResponse,
+            proposedRequest: cdnRequest)
+
+        let cdnResponse = HTTPURLResponse(
+            url: cdnRequest.url!,
+            statusCode: 302,
+            httpVersion: nil,
+            headerFields: nil)!
+        var unknownRequest = URLRequest(
+            url: URL(string: "https://evil.test/stolen")!)
+        unknownRequest.httpMethod = "GET"
+        let result = try policy.request(
+            response: cdnResponse,
+            proposedRequest: unknownRequest)
+        #expect(result?.value(forHTTPHeaderField: "Authorization") == nil)
+    }
+
     @Test func redirectPolicyRejectsNonHTTPSAndExcessHops() throws {
         let original = rangeRequest(length: 1)
         let response = HTTPURLResponse(


### PR DESCRIPTION
The installer drops the Bearer token when HuggingFace redirects LFS downloads from huggingface.co to cdn-lfs.huggingface.co. The cross-host redirect policies unconditionally strip Authorization for any host change, which causes 403 Forbidden on gated repositories.

This change adds an `allowedForwardHosts` set to both `RemoteRedirectPolicy` and `RemoteMetadataRedirectPolicy`. Redirects to hosts in this set (currently `cdn-lfs.huggingface.co`) now keep the original Authorization header. Redirects to unknown hosts continue to be stripped, preserving the existing security posture.

Two new tests verify that authorization is forwarded to the known CDN host and stripped for unrecognized hosts.

Closes #109