### PR TITLE
feat: add support for expert cache, chunked prefill, and read-advice …

### DIFF
--- a/Sources/TurboFieldfareServer/Command/main.swift
+++ b/Sources/TurboFieldfareServer/Command/main.swift
@@ -16,10 +16,12 @@ do {
 do {
     let signals = ServerTerminationSignals()
     let modelURL = URL(fileURLWithPath: arguments.model).standardizedFileURL
+    let runtimeConfiguration = try arguments.resolvedRuntimeConfiguration(forceLogitsHead: true)
     let backend = try await ServerModelSession.load(
         modelDirectory: modelURL,
         maxContext: arguments.maxContext,
-        promptCacheMode: arguments.promptCacheMode)
+        promptCacheMode: arguments.promptCacheMode,
+        runtimeConfiguration: runtimeConfiguration)
     let server = TurboFieldfareHTTPServer(
         modelID: arguments.modelID,
         queueLimit: arguments.queueLimit,

--- a/Sources/TurboFieldfareServer/Core/ServerArguments.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerArguments.swift
@@ -1,4 +1,5 @@
 import Foundation
+import TurboFieldfare
 
 public struct ServerArguments: Equatable, Sendable {
     public let model: String
@@ -7,19 +8,51 @@ public struct ServerArguments: Equatable, Sendable {
     public let maxContext: Int
     public let queueLimit: Int
     public let promptCacheMode: ServerPromptCacheMode
+    public let expertCacheSlots: Int
+    public let expertCachePolicy: RuntimeExpertCachePolicy
+    public let prefillPolicy: RuntimePrefillPolicy
+    public let prefillChunkTokens: Int
+    public let rdadvisePolicy: RDAdvicePolicyMode
 
     public static let usage = """
     usage: TurboFieldfareServer --model <completed .gturbo directory> [options]
 
-      --model <dir>          Required model directory.
-      --port <1...65535>     Loopback port (default 8080).
-      --model-id <id>        API model identifier (default gemma-4-26b-a4b-it).
-      --max-context <tokens> 4096, 8192, 16384, 32768, or 65536 (default 16384).
-      --queue-limit <count>  Maximum queued requests (default 4).
+      --model <dir>             Required model directory.
+      --port <1...65535>        Loopback port (default 8080).
+      --model-id <id>           API model identifier (default gemma-4-26b-a4b-it).
+      --max-context <tokens>    4096, 8192, 16384, 32768, or 65536 (default 16384).
+      --queue-limit <count>     Maximum queued requests (default 4).
       --prompt-cache-mode <off|single-prefix>
-                             Prompt KV reuse mode (default single-prefix).
-      --help                 Show this help.
+                                Prompt KV reuse mode (default single-prefix).
+      --expert-cache-slots <n>  Expert-cache slots: 8, 16, 24, or 32 (default 16).
+      --expert-cache-policy <s> Expert-cache policy: lfu or lru (default lfu).
+      --prefill on|off          Enable or disable chunked prompt prefill (default on).
+                                Chunked prefill requires 16 or more cache slots.
+      --prefill-chunk-tokens <n> Prefill chunk size: 32, 64, or 128 (default 128).
+      --rdadvise <s>            Read-advice policy: off, default, bounded, or adaptive (default off).
+      --help                    Show this help.
     """
+
+    public func resolvedRuntimeConfiguration(forceLogitsHead: Bool = true) throws -> RuntimeConfiguration {
+        guard RuntimeConfiguration.allowedExpertCacheSlots.contains(expertCacheSlots) else {
+            throw ServerArgumentError.invalid("--expert-cache-slots must be 8, 16, 24, or 32")
+        }
+        guard RuntimeConfiguration.allowedPrefillChunkTokens.contains(prefillChunkTokens) else {
+            throw ServerArgumentError.invalid("--prefill-chunk-tokens must be 32, 64, or 128")
+        }
+        let chunkedPrefillSupported = expertCacheSlots >=
+            RuntimeConfiguration.minimumExpertCacheSlotsForChunkedPrefill
+        guard prefillPolicy == .off || chunkedPrefillSupported else {
+            throw ServerArgumentError.invalid("--expert-cache-slots \(expertCacheSlots) requires --prefill off")
+        }
+        return RuntimeConfiguration(
+            expertCacheSlots: expertCacheSlots,
+            expertCachePolicy: expertCachePolicy,
+            rdadvisePolicy: rdadvisePolicy,
+            prefillEnabled: prefillPolicy == .chunked,
+            prefillChunkTokens: prefillChunkTokens,
+            forceLogitsHead: forceLogitsHead)
+    }
 
     public static func parse(_ input: [String]) throws -> ServerArguments {
         var model: String?
@@ -28,6 +61,13 @@ public struct ServerArguments: Equatable, Sendable {
         var maxContext = 16_384
         var queueLimit = 4
         var promptCacheMode: ServerPromptCacheMode = .singlePrefix
+        let runtimeDefaults = RuntimeConfiguration.production
+        var expertCacheSlots = runtimeDefaults.expertCacheSlots
+        var expertCachePolicy = runtimeDefaults.expertCachePolicy
+        var prefillPolicy = runtimeDefaults.prefillPolicy
+        var prefillChunkTokens = runtimeDefaults.prefillChunkTokens
+        var rdadvisePolicy = runtimeDefaults.rdadvisePolicy
+
         var index = 0
         while index < input.count {
             let flag = input[index]
@@ -67,17 +107,52 @@ public struct ServerArguments: Equatable, Sendable {
                         "--prompt-cache-mode must be off or single-prefix")
                 }
                 promptCacheMode = parsed
+            case "--expert-cache-slots":
+                guard let parsed = Int(value),
+                      RuntimeConfiguration.allowedExpertCacheSlots.contains(parsed) else {
+                    throw ServerArgumentError.invalid("--expert-cache-slots must be 8, 16, 24, or 32")
+                }
+                expertCacheSlots = parsed
+            case "--expert-cache-policy":
+                guard let parsed = RuntimeExpertCachePolicy(rawValue: value) else {
+                    throw ServerArgumentError.invalid("--expert-cache-policy must be lfu or lru")
+                }
+                expertCachePolicy = parsed
+            case "--prefill":
+                switch value {
+                case "on": prefillPolicy = .chunked
+                case "off": prefillPolicy = .off
+                default: throw ServerArgumentError.invalid("--prefill must be on or off")
+                }
+            case "--prefill-chunk-tokens":
+                guard let parsed = Int(value),
+                      RuntimeConfiguration.allowedPrefillChunkTokens.contains(parsed) else {
+                    throw ServerArgumentError.invalid("--prefill-chunk-tokens must be 32, 64, or 128")
+                }
+                prefillChunkTokens = parsed
+            case "--rdadvise":
+                guard let parsed = RDAdvicePolicyMode(rawValue: value) else {
+                    throw ServerArgumentError.invalid("--rdadvise must be off, default, bounded, or adaptive")
+                }
+                rdadvisePolicy = parsed
             default:
                 throw ServerArgumentError.invalid("unknown flag: \(flag)")
             }
         }
         guard let model else { throw ServerArgumentError.invalid("--model is required") }
-        return ServerArguments(model: model,
-                               port: port,
-                               modelID: modelID,
-                               maxContext: maxContext,
-                               queueLimit: queueLimit,
-                               promptCacheMode: promptCacheMode)
+        let args = ServerArguments(model: model,
+                                   port: port,
+                                   modelID: modelID,
+                                   maxContext: maxContext,
+                                   queueLimit: queueLimit,
+                                   promptCacheMode: promptCacheMode,
+                                   expertCacheSlots: expertCacheSlots,
+                                   expertCachePolicy: expertCachePolicy,
+                                   prefillPolicy: prefillPolicy,
+                                   prefillChunkTokens: prefillChunkTokens,
+                                   rdadvisePolicy: rdadvisePolicy)
+        _ = try args.resolvedRuntimeConfiguration()
+        return args
     }
 }
 

--- a/Sources/TurboFieldfareServer/Core/ServerInference.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerInference.swift
@@ -388,7 +388,8 @@ public actor ServerModelSession: ServerInferenceBackend {
 
     public static func load(modelDirectory: URL,
                             maxContext: Int,
-                            promptCacheMode: ServerPromptCacheMode = .singlePrefix) async throws -> ServerModelSession {
+                            promptCacheMode: ServerPromptCacheMode = .singlePrefix,
+                            runtimeConfiguration: RuntimeConfiguration = RuntimeConfiguration(forceLogitsHead: true)) async throws -> ServerModelSession {
         let tokenizerFolder = GFTokenizer.tokenizerFolder(forModelDirectory: modelDirectory)
         guard let tokenizerFolder else {
             throw GFTokenizerError.missingToolTemplate
@@ -399,7 +400,7 @@ public actor ServerModelSession: ServerInferenceBackend {
         }
         let tokenizer = try await GFTokenizer.load(from: tokenizerFolder)
         let context = try MetalContext()
-        let runtime = RuntimeConfiguration(forceLogitsHead: true)
+        let runtime = runtimeConfiguration
         let model = try Model.load(
             directoryURL: modelDirectory,
             device: context.device,

--- a/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
@@ -564,6 +564,11 @@ struct ServerArgumentTests {
         #expect(arguments.maxContext == 16_384)
         #expect(arguments.queueLimit == 4)
         #expect(arguments.promptCacheMode == .singlePrefix)
+        #expect(arguments.expertCacheSlots == 16)
+        #expect(arguments.expertCachePolicy == .lfu)
+        #expect(arguments.prefillPolicy == .chunked)
+        #expect(arguments.prefillChunkTokens == 128)
+        #expect(arguments.rdadvisePolicy == .off)
     }
 
     @Test func parsesSinglePrefixModeAndRejectsUnknownMode() throws {
@@ -583,5 +588,46 @@ struct ServerArgumentTests {
                 "--prompt-cache-mode", "many",
             ])
         }
+    }
+
+    @Test func parsesRuntimeOptionsAndValidates() throws {
+        let arguments = try ServerArguments.parse([
+            "--model", "model.gturbo",
+            "--expert-cache-slots", "32",
+            "--expert-cache-policy", "lru",
+            "--prefill", "on",
+            "--prefill-chunk-tokens", "64",
+            "--rdadvise", "adaptive",
+        ])
+        #expect(arguments.expertCacheSlots == 32)
+        #expect(arguments.expertCachePolicy == .lru)
+        #expect(arguments.prefillPolicy == .chunked)
+        #expect(arguments.prefillChunkTokens == 64)
+        #expect(arguments.rdadvisePolicy == .adaptive)
+
+        let config = try arguments.resolvedRuntimeConfiguration()
+        #expect(config.expertCacheSlots == 32)
+        #expect(config.expertCachePolicy == .lru)
+        #expect(config.prefillPolicy == .chunked)
+        #expect(config.prefillChunkTokens == 64)
+        #expect(config.rdadvisePolicy == .adaptive)
+    }
+
+    @Test func rejectsIncompatibleChunkedPrefillWith8Slots() throws {
+        #expect(throws: ServerArgumentError.self) {
+            try ServerArguments.parse([
+                "--model", "model.gturbo",
+                "--expert-cache-slots", "8",
+                "--prefill", "on",
+            ])
+        }
+
+        let arguments = try ServerArguments.parse([
+            "--model", "model.gturbo",
+            "--expert-cache-slots", "8",
+            "--prefill", "off",
+        ])
+        #expect(arguments.expertCacheSlots == 8)
+        #expect(arguments.prefillPolicy == .off)
     }
 }


### PR DESCRIPTION
Add runtime configuration arguments to the local server.

## Summary

Exposed missing runtime options on `TurboFieldfareServer`: `--expert-cache-slots`, `--expert-cache-policy`, `--prefill`, `--prefill-chunk-tokens`, and `--rdadvise`. Previously, the server defaulted to standard production settings regardless of CLI invocation. Passing parsed options to `ServerModelSession` enables fine-grained expert-cache slot tuning, read-advice policy configuration, and custom chunked prompt prefill behavior.

## Validation

1. `Scripts/test.sh` — 674 tests passed across 123 suites (including new unit tests for `ServerArguments.parse` and parameter validation).
2. `swift build -c release` — Built release binaries cleanly.
3. Service Launch & Health Check — Updated `com.turbofieldfare.server.plist` with `--expert-cache-slots 32` and `--rdadvise default`, reloaded via `launchctl`, and verified `GET /health` returned `{"status":"ok"}`.
4. End-to-End Chat Completion — Sent a test prompt to `POST /v1/chat/completions` and received expected model generation output.

## Memory and performance

Not applicable

## Remaining limitations

None.

- [x] The change does not load a complete checkpoint, shard, or large model tensor into Swift heap memory.
- [x] Logs and artifacts contain no credentials, private paths, or model weights.

