### PR TITLE
Resolve repeated tool-call boundary by position

### DIFF
--- a/Sources/TurboFieldfare/Tokenization/Tokenizer.swift
+++ b/Sources/TurboFieldfare/Tokenization/Tokenizer.swift
@@ -401,11 +401,26 @@ public struct GFTokenizer: @unchecked Sendable {
         let callStart = starts[starts.count - callCount]
         let callSequence = Array(prefix[callStart...callEnd])
         let matches = full.subsequenceStartIndices(matching: callSequence)
-        guard matches.count == 1 else {
+        // The boundary is unambiguous by POSITION even when the sequence repeats.
+        // `prefix` and `full` render the same leading history, and the generation
+        // prompt is appended past the boundary, so the occurrence at `callStart`
+        // is the cached call itself rather than an identical earlier twin.
+        //
+        // Requiring a unique match cost agentic loops their cache: as soon as a
+        // model repeated a call verbatim — `ls` of the same path, a re-read of
+        // the same file — the sequence occurred twice, the bridge refused to
+        // encode, and the cache stayed dead for the rest of the conversation,
+        // because every later request carried both twins too.
+        let boundary: Int
+        if matches.contains(callStart) {
+            boundary = callStart
+        } else if matches.count == 1 {
+            boundary = matches[0]
+        } else {
             throw GFTokenizerError.invalidChatTemplate(
                 "cached assistant tool-call boundary is ambiguous")
         }
-        let suffixStart = matches[0] + callSequence.count
+        let suffixStart = boundary + callSequence.count
         let suffix = Array(full[suffixStart...])
         guard suffix.first == toolResponseID else {
             throw GFTokenizerError.invalidChatTemplate(

--- a/Sources/TurboFieldfare/Tokenization/Tokenizer.swift
+++ b/Sources/TurboFieldfare/Tokenization/Tokenizer.swift
@@ -400,25 +400,26 @@ public struct GFTokenizer: @unchecked Sendable {
         }
         let callStart = starts[starts.count - callCount]
         let callSequence = Array(prefix[callStart...callEnd])
-        let matches = full.subsequenceStartIndices(matching: callSequence)
-        // The boundary is unambiguous by POSITION even when the sequence repeats.
-        // `prefix` and `full` render the same leading history, and the generation
-        // prompt is appended past the boundary, so the occurrence at `callStart`
-        // is the cached call itself rather than an identical earlier twin.
-        //
-        // Requiring a unique match cost agentic loops their cache: as soon as a
-        // model repeated a call verbatim — `ls` of the same path, a re-read of
-        // the same file — the sequence occurred twice, the bridge refused to
-        // encode, and the cache stayed dead for the rest of the conversation,
-        // because every later request carried both twins too.
+        // The cached call is located by position, not by unique occurrence: an
+        // agent that repeats a call verbatim renders an identical token
+        // sequence earlier in the history, so demanding a unique match refused
+        // the bridge and permanently dropped the cache from that turn on.
+        // Position is trustworthy exactly when both renders agree on
+        // everything up to and including the call block; a bare
+        // `matches.contains(callStart)` would also accept an identical twin
+        // that only coincidentally landed at `callStart` after a render
+        // divergence, and the tool-response guard below cannot tell twins
+        // apart because every twin is followed by its own tool response.
         let boundary: Int
-        if matches.contains(callStart) {
+        if full.count > callEnd, full[...callEnd] == prefix[...callEnd] {
             boundary = callStart
-        } else if matches.count == 1 {
-            boundary = matches[0]
         } else {
-            throw GFTokenizerError.invalidChatTemplate(
-                "cached assistant tool-call boundary is ambiguous")
+            let matches = full.subsequenceStartIndices(matching: callSequence)
+            guard matches.count == 1 else {
+                throw GFTokenizerError.invalidChatTemplate(
+                    "cached assistant tool-call boundary is ambiguous")
+            }
+            boundary = matches[0]
         }
         let suffixStart = boundary + callSequence.count
         let suffix = Array(full[suffixStart...])

--- a/Tests/TurboFieldfareServer/ServerPromptCacheTests.swift
+++ b/Tests/TurboFieldfareServer/ServerPromptCacheTests.swift
@@ -195,6 +195,55 @@ struct ServerPromptCacheTests {
         #expect(cache.entry == nil)
     }
 
+    /// A model that repeats a tool call verbatim must keep its cache.
+    ///
+    /// Agentic clients do this constantly — `ls` of the same directory, a
+    /// re-read of the same file — and a model looping on one call does nothing
+    /// else. The repeat renders to an identical token sequence, so the boundary
+    /// search finds it more than once; resolving that by position keeps the
+    /// bridge encodable, where demanding a unique match threw and left the
+    /// conversation uncached from that turn on.
+    @Test func repeatedIdenticalToolCallKeepsTheBoundaryResolvable() async throws {
+        let tokenizer = try await GFTokenizer.load()
+        let tools = [GFTokenizer.FunctionDefinition(
+            name: "ls",
+            description: "list a directory",
+            parameters: .object([
+                "type": .string("object"),
+                "properties": .object([
+                    "path": .object(["type": .string("string")]),
+                ]),
+            ]))]
+        let call = { (id: String) in
+            GFTokenizer.HistoricalToolCall(
+                id: id,
+                name: "ls",
+                arguments: .object(["path": .string(".")]))
+        }
+        let first = GFTokenizer.Message(
+            role: .assistant, content: nil, toolCalls: [call("call_1")])
+        let firstResult = GFTokenizer.Message(
+            role: .tool, content: "pkg/", toolCallID: "call_1", name: "ls")
+        // Byte-identical to the first call; only the call id differs.
+        let repeated = GFTokenizer.Message(
+            role: .assistant, content: nil, toolCalls: [call("call_2")])
+        let repeatedResult = GFTokenizer.Message(
+            role: .tool, content: "pkg/", toolCallID: "call_2", name: "ls")
+        let cachedMessages = [
+            GFTokenizer.Message(role: .user, content: "list the tree"),
+            first,
+            firstResult,
+        ]
+
+        let bridge = try tokenizer.encodeToolResultContinuation(
+            cachedMessages: cachedMessages,
+            assistant: repeated,
+            incomingMessages: cachedMessages + [repeated, repeatedResult],
+            tools: tools)
+
+        #expect(bridge.first == tokenizer.toolResponseID)
+    }
+
     private func request(
         messages: [GFTokenizer.Message],
         tools: [GFTokenizer.FunctionDefinition] = []

--- a/Tests/TurboFieldfareServer/ServerPromptCacheTests.swift
+++ b/Tests/TurboFieldfareServer/ServerPromptCacheTests.swift
@@ -241,7 +241,27 @@ struct ServerPromptCacheTests {
             incomingMessages: cachedMessages + [repeated, repeatedResult],
             tools: tools)
 
+        // The bridge must continue from the cached second call, not its
+        // earlier identical twin. Both twins are followed by a tool response,
+        // so the first-token check alone cannot tell them apart; a
+        // twin-anchored bridge would replay the first response and the second
+        // call turn, carrying two response openers and a call opener.
         #expect(bridge.first == tokenizer.toolResponseID)
+        #expect(bridge.filter { $0 == tokenizer.toolResponseID }.count == 1)
+        #expect(!bridge.contains(tokenizer.toolCallStartID))
+
+        // A cached history that diverged from the incoming one cannot anchor
+        // the repeated sequence by position, and the ambiguous fallback still
+        // refuses rather than guessing a twin.
+        let diverged = [GFTokenizer.Message(role: .user, content: "list the other tree")]
+            + cachedMessages.dropFirst()
+        #expect(throws: (any Error).self) {
+            try tokenizer.encodeToolResultContinuation(
+                cachedMessages: diverged,
+                assistant: repeated,
+                incomingMessages: cachedMessages + [repeated, repeatedResult],
+                tools: tools)
+        }
     }
 
     private func request(


### PR DESCRIPTION
## Problem

A model that repeats a tool call verbatim permanently loses the prompt cache
for the rest of the conversation.

`GFTokenizer.encodeToolResultContinuation` locates the cached assistant turn by
searching the full rendered history for that turn's token sequence, and requires
**exactly one** match:

```swift
let matches = full.subsequenceStartIndices(matching: callSequence)
guard matches.count == 1 else {
    throw GFTokenizerError.invalidChatTemplate(
        "cached assistant tool-call boundary is ambiguous")
}
```

An identical repeated call renders to an identical token sequence, so the second
occurrence makes `matches.count == 2`, the bridge fails to encode, and
`ServerPromptCache.match` returns `.miss`.

The miss is not a one-off. Every later request in the conversation carries both
identical calls, so the guard fails again on each turn — the cache is off for
good, while the server keeps reporting the ordinary `cached=0`.

This lands hardest exactly where the cache matters most. Agent clients repeat
calls constantly (`ls` of the same directory, a re-read of the same file), and a
model looping on one call does nothing else.

## Evidence

A 50-turn agent run against a local server, where the model repeated
`ls {"path":"pkg/src/"}` 24 times:

| | before | after |
| --- | --- | --- |
| `boundary is ambiguous` | every turn from the 6th request on | none |
| `cached` | `0`, permanently | grows 1261 → 2889, uninterrupted |
| time per turn | 26–48 s | ~1.8 s |

The break was reproducible: it always began on the request following the first
verbatim repeat.

## Fix

The boundary is unambiguous by **position**. `prefix` and `full` render the same
leading history, and `addGenerationPrompt` is appended past the boundary, so the
occurrence at `callStart` is the cached call itself rather than an identical
earlier twin.

The change prefers that positional match, keeps the unique-match rule as a
fallback when the position does not line up, and still throws when neither
resolves. The `suffix.first == toolResponseID` check downstream is untouched, so
a wrong boundary still cannot silently produce a bad bridge.

## Tests

Added `repeatedIdenticalToolCallKeepsTheBoundaryResolvable` to
`ServerPromptCacheTests`: a history whose assistant turn repeats a byte-identical
`ls` call, differing only in call id.

The test was verified to fail on the unfixed encoder, with the same error a live
server reports:

```
✘ Caught error: invalid chat messages: cached assistant tool-call boundary is ambiguous
```

Full suite per CONTRIBUTING:

- `swift build -c release` — clean
- `Scripts/test.sh` — 673 tests in 123 suites passed
- `ruby Scripts/check_markdown_links.rb` — 22 files, all links resolve
  (needs a UTF-8 locale; it raises `invalid byte sequence in US-ASCII` under
  `LANG=C`, unrelated to this change)

Live confirmation: server rebuilt from this branch, same workload replayed, zero
`ambiguous` errors across 100 turns and two conversations.

## Environment

- Mac17,2, 16 GB, macOS 26.5.2 (25F84)
- Apple Swift 6.3.3, target arm64-apple-macosx26.0
- `TurboFieldfareServer --max-context 65536`, model `gemma-4-26b-a4b-it`,
  `prompt_cache=single-prefix`

## Limitations

- The positional branch assumes `prefix` and `full` render the same leading
  history — true for the pinned template, and the unique-match fallback covers
  any renderer where it stops holding.
- Diagnostics that made this findable are not in this PR, to keep it narrow. A
  `TFF_LOG_CACHE=1` flag naming which cache condition failed is a natural
  follow-up; without it every miss looks identical from outside.
