### PR TITLE
Kickstart the decode service after launchd bootstrap

### DIFF
--- a/Sources/TurboFieldfareApp/Core/Inference/DecodeServiceInferenceClient.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/DecodeServiceInferenceClient.swift
@@ -235,7 +235,7 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
             let starter = Process()
             let starterErrors = Pipe()
             starter.executableURL = URL(fileURLWithPath: "/bin/launchctl")
-            starter.arguments = ["kickstart", "gui/\(getuid())/\(label)"]
+            starter.arguments = Self.kickstartArguments(uid: getuid(), label: label)
             starter.standardOutput = FileHandle.nullDevice
             starter.standardError = starterErrors
             try starter.run()
@@ -269,11 +269,22 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
             }
         }
         Self.removeLaunchJob(label: label)
+        throw AppInferenceError.modelLoadFailed(
+            Self.socketFailureMessage(
+                socketError: lastError.map(String.init(describing:)),
+                kickstartError: kickstartError))
+    }
+
+    static func kickstartArguments(uid: uid_t, label: String) -> [String] {
+        ["kickstart", "gui/\(uid)/\(label)"]
+    }
+
+    static func socketFailureMessage(socketError: String?, kickstartError: String?)
+        -> String {
         let kickstartDetail = kickstartError.map {
             "; launchctl kickstart failed: \($0)"
         } ?? ""
-        throw AppInferenceError.modelLoadFailed(
-            "decode service socket did not become ready: \(lastError.map(String.init(describing:)) ?? "unknown error")\(kickstartDetail)")
+        return "decode service socket did not become ready: \(socketError ?? "unknown error")\(kickstartDetail)"
     }
 
     private func currentHandles()

--- a/Sources/TurboFieldfareApp/Core/Inference/DecodeServiceInferenceClient.swift
+++ b/Sources/TurboFieldfareApp/Core/Inference/DecodeServiceInferenceClient.swift
@@ -229,6 +229,28 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
             throw AppInferenceError.modelLoadFailed(message)
         }
 
+        // Demand the job without restarting a RunAtLoad winner; the socket is authoritative.
+        var kickstartError: String?
+        do {
+            let starter = Process()
+            let starterErrors = Pipe()
+            starter.executableURL = URL(fileURLWithPath: "/bin/launchctl")
+            starter.arguments = ["kickstart", "gui/\(getuid())/\(label)"]
+            starter.standardOutput = FileHandle.nullDevice
+            starter.standardError = starterErrors
+            try starter.run()
+            starter.waitUntilExit()
+            if starter.terminationStatus != 0 {
+                let data = try? starterErrors.fileHandleForReading.readToEnd()
+                let detail = data.flatMap { String(data: $0, encoding: .utf8) }?
+                    .trimmingCharacters(in: .whitespacesAndNewlines)
+                kickstartError = detail.flatMap { $0.isEmpty ? nil : $0 }
+                    ?? "exit status \(starter.terminationStatus)"
+            }
+        } catch {
+            kickstartError = String(describing: error)
+        }
+
         var lastError: Error?
         for _ in 0..<200 {
             do {
@@ -247,8 +269,11 @@ public final class DecodeServiceInferenceClient: AppModelLifecycleClient,
             }
         }
         Self.removeLaunchJob(label: label)
+        let kickstartDetail = kickstartError.map {
+            "; launchctl kickstart failed: \($0)"
+        } ?? ""
         throw AppInferenceError.modelLoadFailed(
-            "decode service socket did not become ready: \(lastError.map(String.init(describing:)) ?? "unknown error")")
+            "decode service socket did not become ready: \(lastError.map(String.init(describing:)) ?? "unknown error")\(kickstartDetail)")
     }
 
     private func currentHandles()

--- a/Tests/TurboFieldfareApp/Core/Inference/DecodeServiceLaunchPolicyTests.swift
+++ b/Tests/TurboFieldfareApp/Core/Inference/DecodeServiceLaunchPolicyTests.swift
@@ -1,0 +1,31 @@
+import Testing
+@testable import TurboFieldfareAppCore
+
+@Suite struct DecodeServiceLaunchPolicyTests {
+    @Test func kickstartTargetsGUIJobWithoutRestartingIt() {
+        let arguments = DecodeServiceInferenceClient.kickstartArguments(
+            uid: 501, label: "com.turbofieldfare.decode.test")
+
+        #expect(arguments == [
+            "kickstart", "gui/501/com.turbofieldfare.decode.test",
+        ])
+        #expect(!arguments.contains("-k"))
+    }
+
+    @Test func socketFailureRemainsThePrimaryDiagnostic() {
+        let message = DecodeServiceInferenceClient.socketFailureMessage(
+            socketError: "No such file or directory", kickstartError: nil)
+
+        #expect(message ==
+            "decode service socket did not become ready: No such file or directory")
+    }
+
+    @Test func socketFailureIncludesKickstartDiagnosticWhenAvailable() {
+        let message = DecodeServiceInferenceClient.socketFailureMessage(
+            socketError: "No such file or directory",
+            kickstartError: "Operation not permitted")
+
+        #expect(message ==
+            "decode service socket did not become ready: No such file or directory; launchctl kickstart failed: Operation not permitted")
+    }
+}


### PR DESCRIPTION
## Summary

- explicitly kickstart the decode service after a successful launchd bootstrap
- omit `-k`, so a helper already started by `RunAtLoad` is not restarted
- keep Unix socket readiness authoritative and include kickstart diagnostics only if startup times out
- cover the launch command and timeout diagnostics with deterministic regression tests

Fixes #25.

## Why

On affected macOS 26 systems, `launchctl bootstrap` succeeds but launchd leaves the `RunAtLoad` spawn pending as speculative. The helper never creates its Unix socket, and the app eventually reports `NSPOSIXErrorDomain Code=2` for that missing socket.

An explicit kickstart supplies the launch demand that is missing in that state. This keeps launchd ownership and `ProcessType=Interactive`; it deliberately does not add the direct-process fallback proposed in #88.

The kickstart status is diagnostic rather than authoritative. If `RunAtLoad` wins the race and the socket becomes ready, startup still succeeds.

## Validation

- `swift build -c release`
- `Scripts/test.sh --filter DecodeServiceLaunchPolicyTests` — 3 focused tests passed
- `Scripts/test.sh` — 675 tests passed
- `ruby Scripts/check_markdown_links.rb` — 26 Markdown files passed
- 20 iterations of the production plist shape through bootstrap, kickstart, and socket readiness on macOS 26.5.1 / Swift 6.3.3
- a second no-`-k` kickstart preserved the running helper PID in all 20 iterations
- launched the real release `TurboFieldfareMac` from `c1cc0fd`, invoked **Model → Load Model**, and reached the app's **Ready** state
- verified the app-created Unix socket and launchd-owned decode service (`state = running`, `runs = 1`, `spawn type = interactive`)

## Remaining validation

- confirmation on an affected machine that previously showed `pended nondemand spawn = speculative`
