### PR TITLE
Bump the app version to 0.4.3 and allow one release of lag in the check

### DIFF
--- a/Sources/TurboFieldfareApp/MacPresentation/AboutPanelPresentation.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/AboutPanelPresentation.swift
@@ -17,7 +17,7 @@ public enum AboutPanelPresentation {
     // Most users build from a clone, where there is no Info.plist to read a
     // version from, so this constant is what they see. Scripts/check_app_version.rb
     // fails CI when it falls behind the newest published release.
-    public static let fallbackShortVersion = "0.4.2"
+    public static let fallbackShortVersion = "0.4.3"
 
     private static let licenseURL = URL(
         string: "https://github.com/drumih/turbo-fieldfare/blob/main/LICENSE")!


### PR DESCRIPTION
## Bump to 0.4.3

`fallbackShortVersion` moves 0.4.2 to 0.4.3, matching the published 0.4.3 release. The About panel reports this constant for builds made from a clone, which is how most users install.

## Allow one release of lag

The release flow is: merge work, tag main, then merge a follow-up PR that bumps the constant. Between the tag and that merge the constant is one release behind on purpose. The original check failed on any lag, which turned main and every open PR red during that window.

The check now compares against the release *before* the newest:

| Constant vs releases | Result |
| --- | --- |
| Ahead of latest | pass, "unreleased build" |
| Equal to latest | pass, "matches" |
| One release behind | pass, "bump pending" |
| Two or more behind | fail |

Verified against the live releases: 0.4.3 exit 0, 0.4.1 exit 0, 0.4 exit 1, 0.3 exit 1.

## Why this matters now

0.4.3 is already tagged and published while main still reports 0.4.2. Without this change, any open PR that re-runs CI fails on a version it did not touch.