### PR TITLE
Name the condition behind a prompt-cache miss

### DIFF
--- a/Sources/TurboFieldfareServer/Core/ServerPromptCache.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerPromptCache.swift
@@ -36,6 +36,21 @@ enum ServerPromptCacheMatch: Sendable, Equatable {
     case hit(effectivePromptIDs: [Int32], cachedPromptTokens: Int)
 }
 
+/// Names the condition behind a prompt-cache miss when `TFF_LOG_CACHE` is set.
+///
+/// A miss reaches the client as `cached=0` and nothing else, so a cold start, a
+/// changed tool set, a client that rewrote its history, and a bridge that
+/// failed to encode all read identically from outside — at very different
+/// costs. A miss never breaks a response; it silently pays full prefill, which
+/// is exactly why it goes unnoticed.
+///
+/// The reason is built lazily, so the conditions stay written as the single
+/// guards they are and nothing is computed when logging is off.
+private func logCacheMiss(_ reason: @autoclosure () -> String) {
+    guard ProcessInfo.processInfo.environment["TFF_LOG_CACHE"] != nil else { return }
+    FileHandle.standardError.write(Data("[cache-miss] \(reason())\n".utf8))
+}
+
 struct ServerPromptCache: Sendable {
     private(set) var entry: ServerPromptCacheEntry?
 
@@ -58,6 +73,15 @@ struct ServerPromptCache: Sendable {
               result.reason == .endOfTurn
                 || result.reason == .toolCalls
                 || result.reason == .maxTokens else {
+            // A rejected publish is the costliest case to leave unnamed: it
+            // leaves nothing for the next request to match, so a single event
+            // reads as a permanently dead cache.
+            logCacheMiss(
+                "publish rejected: kvPosition=\(result.kvPosition) "
+                + "kvBacked=\(result.kvBackedTokenIDs.count) "
+                + "boundary=\(result.uncommittedBoundaryTokenIDs.count) "
+                + "stopStringFiltered=\(stopStringFiltered) "
+                + "reason=\(result.reason)")
             entry = nil
             return
         }
@@ -95,6 +119,7 @@ struct ServerPromptCache: Sendable {
               entry.kvPosition == entry.kvBackedTokenIDs.count,
               entry.kvPosition > 0,
               entry.uncommittedBoundaryTokenIDs.count == 1 else {
+            logCacheMiss(entryMissReason(domain: domain, request: request))
             return .miss
         }
 
@@ -113,6 +138,7 @@ struct ServerPromptCache: Sendable {
               assistantMatches(
                 request.messages[inputCount],
                 entry.assistantTurn.message) else {
+            logCacheMiss(historyMissReason(entry: entry, request: request))
             return .miss
         }
         let continuation = Array(request.messages.dropFirst(inputCount + 1))
@@ -128,6 +154,45 @@ struct ServerPromptCache: Sendable {
             request: request,
             continuation: continuation,
             tokenizer: tokenizer)
+    }
+
+    /// Which part of the entry guard failed. Called only while logging.
+    /// Not private: the reasons must stay in sync with the guards above, and
+    /// a test is the only thing that notices when a new condition is added
+    /// to one and not the other.
+    func entryMissReason(
+        domain: ServerPromptCacheDomain,
+        request: ValidatedChatRequest
+    ) -> String {
+        guard let entry else {
+            return "no entry stored (cold start, or the previous publish was rejected)"
+        }
+        if entry.domain != domain {
+            return "domain changed (model, runtime profile, context, or template)"
+        }
+        if entry.tools != request.tools {
+            return "tool set changed"
+        }
+        return "entry inconsistent: kvPosition=\(entry.kvPosition) "
+            + "kvBacked=\(entry.kvBackedTokenIDs.count) "
+            + "boundary=\(entry.uncommittedBoundaryTokenIDs.count)"
+    }
+
+    /// Which part of the history guard failed. Called only while logging.
+    func historyMissReason(
+        entry: ServerPromptCacheEntry,
+        request: ValidatedChatRequest
+    ) -> String {
+        let inputCount = entry.inputMessages.count
+        if request.messages.count <= inputCount + 1 {
+            return "history did not extend: \(request.messages.count) messages arrived, "
+                + "entry holds \(inputCount) plus the assistant turn"
+        }
+        if !request.messages.prefix(inputCount).elementsEqual(entry.inputMessages) {
+            return "client rewrote the preceding \(inputCount) messages"
+        }
+        return "assistant turn in the history differs from the one generated "
+            + "(\(entry.assistantTurn.message.toolCalls.count) tool calls cached)"
     }
 
     private func assistantMatches(
@@ -160,12 +225,16 @@ struct ServerPromptCache: Sendable {
               continuation[0].toolCallID == nil,
               entry.assistantTurn.rawStopReason == .endOfTurn
                 || entry.assistantTurn.rawStopReason == .maxTokens else {
+            logCacheMiss(
+                "text continuation did not match: \(continuation.count) messages, "
+                + "stop=\(entry.assistantTurn.rawStopReason)")
             return .miss
         }
         var bridge = tokenizer.encodeTextContinuation(userContent: content)
         if entry.assistantTurn.rawStopReason == .maxTokens {
             bridge = entry.uncommittedBoundaryTokenIDs + bridge
         } else if bridge.first != entry.uncommittedBoundaryTokenIDs.first {
+            logCacheMiss("text bridge does not start at the KV boundary")
             return .miss
         }
         return .hit(
@@ -189,14 +258,30 @@ struct ServerPromptCache: Sendable {
                     && message.content != nil
                     && message.toolCalls.isEmpty
               }) else {
+            logCacheMiss(
+                "tool-result continuation did not match: \(continuation.count) results "
+                + "for \(calls.count) calls, stop=\(entry.assistantTurn.rawStopReason)")
             return .miss
         }
-        guard let bridge = try? tokenizer.encodeToolResultContinuation(
-            cachedMessages: entry.inputMessages,
-            assistant: entry.assistantTurn.message,
-            incomingMessages: request.messages,
-            tools: request.tools),
-              bridge.first == entry.uncommittedBoundaryTokenIDs.first else {
+        let bridge: [Int32]
+        do {
+            bridge = try tokenizer.encodeToolResultContinuation(
+                cachedMessages: entry.inputMessages,
+                assistant: entry.assistantTurn.message,
+                incomingMessages: request.messages,
+                tools: request.tools)
+        } catch {
+            // Naming the thrown error is what this flag is for: the encoder
+            // rejects for several distinct structural reasons, and the client
+            // sees the same `cached=0` for all of them.
+            logCacheMiss("tool-result bridge failed to encode: \(error)")
+            return .miss
+        }
+        guard bridge.first == entry.uncommittedBoundaryTokenIDs.first else {
+            logCacheMiss(
+                "tool-result bridge does not start at the KV boundary: "
+                + "\(String(describing: bridge.first)) vs "
+                + "\(String(describing: entry.uncommittedBoundaryTokenIDs.first))")
             return .miss
         }
         return .hit(

--- a/Tests/TurboFieldfareServer/ServerPromptCacheTests.swift
+++ b/Tests/TurboFieldfareServer/ServerPromptCacheTests.swift
@@ -195,6 +195,69 @@ struct ServerPromptCacheTests {
         #expect(cache.entry == nil)
     }
 
+    /// The logged reason must name the condition that actually failed.
+    ///
+    /// The reasons live beside the guards rather than inside them, so nothing
+    /// but a test notices when a condition is added to one and not the other —
+    /// and a diagnostic that names the wrong cause is worse than none.
+    @Test func missReasonsNameTheConditionThatFailed() async throws {
+        let tokenizer = try await GFTokenizer.load()
+        let initial = request(messages: [
+            GFTokenizer.Message(role: .user, content: "first"),
+        ])
+        var cache = ServerPromptCache()
+
+        #expect(cache.entryMissReason(domain: domain, request: initial)
+            .contains("no entry stored"))
+
+        let prompt = tokenizer.encode(
+            try tokenizer.applyChatTemplate(initial.messages),
+            addBOS: false)
+        cache.publish(
+            domain: domain,
+            request: initial,
+            content: "answer",
+            calls: [],
+            result: rawResult(
+                prompt: prompt,
+                kvBacked: prompt + tokenizer.encode("answer", addBOS: false),
+                boundary: tokenizer.endOfTurnID,
+                reason: .endOfTurn))
+        let entry = try #require(cache.entry)
+
+        var otherDomain = domain
+        otherDomain = ServerPromptCacheDomain(
+            modelID: "other",
+            sourceSnapshotHash: domain.sourceSnapshotHash,
+            runtimeProfileHash: domain.runtimeProfileHash,
+            maximumContext: domain.maximumContext,
+            kvStorage: domain.kvStorage,
+            fp16RingEnabled: domain.fp16RingEnabled,
+            templateSHA256: domain.templateSHA256)
+        #expect(cache.entryMissReason(domain: otherDomain, request: initial)
+            .contains("domain changed"))
+
+        let withTools = request(
+            messages: initial.messages,
+            tools: [GFTokenizer.FunctionDefinition(
+                name: "ls",
+                description: "list a directory",
+                parameters: .object(["type": .string("object")]))])
+        #expect(cache.entryMissReason(domain: domain, request: withTools)
+            .contains("tool set changed"))
+
+        #expect(cache.historyMissReason(entry: entry, request: initial)
+            .contains("history did not extend"))
+
+        let rewritten = request(messages: [
+            GFTokenizer.Message(role: .user, content: "rewritten"),
+            GFTokenizer.Message(role: .assistant, content: "answer"),
+            GFTokenizer.Message(role: .user, content: "second"),
+        ])
+        #expect(cache.historyMissReason(entry: entry, request: rewritten)
+            .contains("rewrote the preceding"))
+    }
+
     private func request(
         messages: [GFTokenizer.Message],
         tools: [GFTokenizer.FunctionDefinition] = []

--- a/docs/RUNTIME_CONTROLS.md
+++ b/docs/RUNTIME_CONTROLS.md
@@ -68,3 +68,29 @@ During chunked prefill, the phase label reports exact progress, for example
 `Prefill (128/514)`. Errors and unsupported configurations appear only when
 they occur. RDADVISE remains experimental and is off by default. A measured
 result is a data point, not a performance ceiling.
+
+## Prompt-cache diagnostics
+
+A prompt-cache miss reaches the client as `cached=0` and nothing else, so a
+cold start, a changed tool set, a client that rewrote its history, and a bridge
+that failed to encode all read identically from outside. A miss never breaks a
+response — it silently pays full prefill — which is why it goes unnoticed.
+
+Set `TFF_LOG_CACHE=1` to print the failed condition to stderr as
+`[cache-miss] <reason>`. The reasons cover both directions of the cache:
+
+| Stage | Example reason |
+| --- | --- |
+| Publish rejected | `publish rejected: kvPosition=… reason=…` |
+| Nothing stored | `no entry stored (cold start, or the previous publish was rejected)` |
+| Domain or tools changed | `tool set changed` |
+| History diverged | `client rewrote the preceding N messages` |
+| Bridge failed | `tool-result bridge failed to encode: <error>` |
+
+Publish failures matter most: a rejected publish leaves nothing for the next
+request to match, so a single event reads as a permanently dead cache rather
+than the one-off it was.
+
+Reasons name conditions and counts, never message content, so the variable is
+safe to leave on. It is read per miss, and the reason string is built only when
+the variable is set.


### PR DESCRIPTION
## Problem

A prompt-cache miss reaches the client as `cached=0` and nothing else. Twelve
distinct `return .miss` conditions produce that same output — cold start,
changed domain, changed tool set, a client that rewrote its history, a
continuation that did not line up, a bridge that failed to encode — and from
outside they are indistinguishable.

What makes this expensive is that a miss never breaks anything. The response is
correct; it just pays full prefill. So the symptom presents as *a slow model*,
not as a cache that stopped working.

The gap is not theoretical. Diagnosing #125 meant staring at `cached=0` with no
way to tell which of the twelve conditions had failed; several plausible
explanations were wrong before this flag named the real one in a single line:

```
[cache-miss] tool-result bridge failed to encode: invalid chat messages:
             cached assistant tool-call boundary is ambiguous
```

The measured cost of the miss it exposed was ~48s per turn against ~1.8s cached.

## Change

`TFF_LOG_CACHE=1` prints the failed condition to stderr as
`[cache-miss] <reason>`, in both directions of the cache.

Publish rejection is logged too, and is the most valuable line: a rejected
publish leaves nothing for the next request to match, so a single event reads
as a permanently dead cache rather than the one-off it was.

Kept deliberately cheap and quiet:

- Reasons are built lazily via `@autoclosure`, so the guards stay written as the
  single conditions they are and nothing is computed while the flag is off.
- Reasons name conditions and counts, never message content — so unlike raw
  prompt logging, this is safe to leave on.
- No behavior change: every `return .miss` returns exactly as before.

Sample from the existing suite with the flag set:

```
[cache-miss] publish rejected: kvPosition=14 kvBacked=14 boundary=1 stopStringFiltered=true reason=endOfTurn
[cache-miss] publish rejected: kvPosition=14 kvBacked=14 boundary=1 stopStringFiltered=false reason=stopString
[cache-miss] client rewrote the preceding 1 messages
```

## Tests

Added `missReasonsNameTheConditionThatFailed`, covering the no-entry, changed
domain, changed tool set, unextended history, and rewritten history branches.

The reasons live beside the guards rather than inside them, so nothing but a
test notices when a condition is added to one and not the other — and a
diagnostic that names the wrong cause is worse than none. That is what this test
pins.

Per CONTRIBUTING:

- `swift build -c release` — clean
- `Scripts/test.sh` — 673 tests in 123 suites passed
- `ruby Scripts/check_markdown_links.rb` — 22 files, all links resolve
  (needs a UTF-8 locale; under `LANG=C` it raises `invalid byte sequence in
  US-ASCII`, unrelated to this change)

Verified with the flag both set and unset: set, the reasons appear; unset, the
suite emits no `[cache-miss]` line at all.

## Environment

- Mac17,2, 16 GB, macOS 26.5.2 (25F84)
- Apple Swift 6.3.3, target arm64-apple-macosx26.0

## Notes

- Independent of #125 — different files, no shared hunks — but that PR is the
  case this flag was built to find.
- The new control is documented in `docs/RUNTIME_CONTROLS.md`, as CONTRIBUTING
  requires for public runtime controls.
- `entryMissReason` and `historyMissReason` are internal rather than private so
  the test can pin them; they are not part of any public surface.
