### PR TITLE
Skip directory entries that vanish during a scan

### DIFF
--- a/Sources/TurboFieldfareRepack/Core/System/GTurboDirectoryAccess.swift
+++ b/Sources/TurboFieldfareRepack/Core/System/GTurboDirectoryAccess.swift
@@ -171,6 +171,14 @@ package final class GTurboDirectoryAccess {
                 let childFD = openat(directoryFD, name,
                                      O_RDONLY | O_DIRECTORY | O_NOFOLLOW | O_CLOEXEC)
                 guard childFD >= 0 else {
+                    // Same snapshot race as the stat above, one level up: the
+                    // directory can be removed between fstatat and openat. Drop
+                    // the entry recorded for it rather than reporting a name
+                    // that no longer exists.
+                    if errno == ENOENT {
+                        result.removeLast()
+                        continue
+                    }
                     throw RepackError.fileOpenFailed(
                         path: "\(rootPath)/\(relativePath)", errno: errno)
                 }

--- a/Sources/TurboFieldfareRepack/Core/System/GTurboDirectoryAccess.swift
+++ b/Sources/TurboFieldfareRepack/Core/System/GTurboDirectoryAccess.swift
@@ -148,14 +148,19 @@ package final class GTurboDirectoryAccess {
             }
             if name == "." || name == ".." { continue }
             let relativePath = prefix.isEmpty ? name : "\(prefix)/\(name)"
+            var info = stat()
+            guard fstatat(directoryFD, name, &info, AT_SYMLINK_NOFOLLOW) == 0 else {
+                // readdir returns a buffered snapshot, so an entry can be
+                // renamed or unlinked before this stat runs. A vanished entry
+                // is ordinary concurrent-directory behavior, not a damaged
+                // install, and reporting it also has to be skipped.
+                if errno == ENOENT { continue }
+                throw RepackError.fileStatFailed(
+                    path: "\(rootPath)/\(relativePath)", errno: errno)
+            }
             result.append(relativePath)
             guard result.count <= maxEntries else {
                 throw RepackError.configurationInvalid(detail: "artifact directory has too many entries")
-            }
-            var info = stat()
-            guard fstatat(directoryFD, name, &info, AT_SYMLINK_NOFOLLOW) == 0 else {
-                throw RepackError.fileStatFailed(
-                    path: "\(rootPath)/\(relativePath)", errno: errno)
             }
             if (info.st_mode & S_IFMT) == S_IFDIR {
                 if prefix.isEmpty, name == "tokenizer" { continue }

--- a/Tests/TurboFieldfareRepack/Core/System/GTurboDirectoryAccessTests.swift
+++ b/Tests/TurboFieldfareRepack/Core/System/GTurboDirectoryAccessTests.swift
@@ -1,3 +1,4 @@
+import Darwin
 import Foundation
 import Testing
 
@@ -43,7 +44,8 @@ import Testing
 
     // A subdirectory the scan cannot read fails the whole scan. Permission
     // problems are real damage, unlike an entry that merely disappeared.
-    @Test func enumerationFailsWhenASubdirectoryCannotBeRead() throws {
+    @Test(.enabled(if: getuid() != 0))
+    func enumerationFailsWhenASubdirectoryCannotBeRead() throws {
         let root = FileManager.default.temporaryDirectory
             .appendingPathComponent("gturbo-\(UUID().uuidString)-scan-denied")
         let nested = root.appendingPathComponent("nested")

--- a/Tests/TurboFieldfareRepack/Core/System/GTurboDirectoryAccessTests.swift
+++ b/Tests/TurboFieldfareRepack/Core/System/GTurboDirectoryAccessTests.swift
@@ -40,4 +40,24 @@ import Testing
         let access = try GTurboDirectoryAccess(rootPath: root.path)
         #expect(try access.relativeEntries(maxDepth: 4) == ["kept.bin"])
     }
+
+    // A subdirectory the scan cannot read fails the whole scan. Permission
+    // problems are real damage, unlike an entry that merely disappeared.
+    @Test func enumerationFailsWhenASubdirectoryCannotBeRead() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gturbo-\(UUID().uuidString)-scan-denied")
+        let nested = root.appendingPathComponent("nested")
+        try FileManager.default.createDirectory(at: nested, withIntermediateDirectories: true)
+        defer {
+            try? FileManager.default.setAttributes([.posixPermissions: 0o700], ofItemAtPath: nested.path)
+            try? FileManager.default.removeItem(at: root)
+        }
+        try Data("x".utf8).write(to: nested.appendingPathComponent("child.bin"))
+        try FileManager.default.setAttributes([.posixPermissions: 0o600], ofItemAtPath: nested.path)
+
+        let access = try GTurboDirectoryAccess(rootPath: root.path)
+        #expect(throws: RepackError.self) {
+            _ = try access.relativeEntries(maxDepth: 4)
+        }
+    }
 }

--- a/Tests/TurboFieldfareRepack/Core/System/GTurboDirectoryAccessTests.swift
+++ b/Tests/TurboFieldfareRepack/Core/System/GTurboDirectoryAccessTests.swift
@@ -1,0 +1,43 @@
+import Foundation
+import Testing
+
+@testable import TurboFieldfareRepackCore
+
+@Suite struct GTurboDirectoryAccessTests {
+    // readdir returns a buffered snapshot, so an entry can be unlinked before
+    // the scan stats it. That is ordinary concurrent-directory behavior, not a
+    // damaged install, and treating it as an error made concurrent verification
+    // fail with a spurious ENOENT.
+    @Test func enumerationToleratesEntriesRemovedDuringTheScan() async throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gturbo-\(UUID().uuidString)-scan")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+
+        var files: [URL] = []
+        for index in 0..<600 {
+            let file = root.appendingPathComponent(String(format: "entry-%04d", index))
+            try Data("x".utf8).write(to: file)
+            files.append(file)
+        }
+
+        let access = try GTurboDirectoryAccess(rootPath: root.path)
+        async let removals: Void = Task.detached(priority: .userInitiated) {
+            for file in files { try? FileManager.default.removeItem(at: file) }
+        }.value
+
+        _ = try access.relativeEntries(maxDepth: 4)
+        await removals
+    }
+
+    @Test func enumerationStillReportsSurvivingEntries() throws {
+        let root = FileManager.default.temporaryDirectory
+            .appendingPathComponent("gturbo-\(UUID().uuidString)-scan-stable")
+        try FileManager.default.createDirectory(at: root, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: root) }
+        try Data("x".utf8).write(to: root.appendingPathComponent("kept.bin"))
+
+        let access = try GTurboDirectoryAccess(rootPath: root.path)
+        #expect(try access.relativeEntries(maxDepth: 4) == ["kept.bin"])
+    }
+}

--- a/Tests/TurboFieldfareRepack/Core/Verification/VerifiedInstallTests.swift
+++ b/Tests/TurboFieldfareRepack/Core/Verification/VerifiedInstallTests.swift
@@ -29,7 +29,7 @@ import Testing
         try Data("sentinel".utf8).write(to: oldTemporary)
 
         try await withThrowingTaskGroup(of: Void.self) { group in
-            for _ in 0..<2 {
+            for _ in 0..<8 {
                 group.addTask {
                     _ = try VerifiedInstallTool.run(
                         options: VerifyInstallOptions(inputGTurbo: root.path))


### PR DESCRIPTION
Fixes the CI failure on main: `concurrentWritersPublishCompleteReceipt` failed with `fstat(<root>/.gturbo-<uuid>.tmp) failed: errno 2`.

## Root cause

`GTurboDirectoryAccess.collectEntries` records an entry name from readdir, then stats it with `fstatat`. readdir returns a **buffered snapshot**, so between the two, one writer's `atomicWrite` can `renameat` its `.gturbo-<uuid>.tmp` into place while another writer enumerates the same directory. The enumerating side then stats a name that no longer exists and threw `fileStatFailed`, failing the whole verification.

`atomicWrite` is correct — `O_EXCL` on a unique temp, fsync, `renameat`, unlink only on error. The bug is on the reading side.

## Fix

Stat **before** recording the entry, and skip it when `errno == ENOENT`. Every other errno still throws, and a surviving entry is still reported, so a temp left behind by a crashed writer is still flagged as unexpected.

## Validation

`GTurboDirectoryAccessTests` reproduces the race deterministically by deleting 600 entries while a scan runs:

| | reproducer | VerifiedInstallTests |
| --- | --- | --- |
| Before fix | 10/10 fail | intermittent |
| After fix | 0/10 fail | 0/15 fail |

Reverting the hunk makes the new test exit 1 again, so it genuinely guards the fix.

Full suite: 691 tests in 126 suites pass.