### PR TITLE
Allow one release of lag in the app version check

### DIFF
--- a/Scripts/check_app_version.rb
+++ b/Scripts/check_app_version.rb
@@ -1,15 +1,18 @@
 #!/usr/bin/env ruby
 
-# Verifies that the version the Mac app shows is not behind the newest published
-# GitHub release.
+# Verifies that the version the Mac app shows has not fallen behind the
+# published GitHub releases.
 #
 # Most users build from a clone, where there is no Info.plist, so the compiled
 # constant in AboutPanelPresentation is the version they see. Nothing bumps it
 # automatically, so without this check it silently ages: the About panel would
 # claim an old version on a current checkout.
 #
-# Being ahead of the newest release is allowed. That is the normal state between
-# bumping the constant and publishing the release built from it.
+# The release flow is: merge work, tag main, then merge a follow-up PR that
+# bumps the constant. Between the tag and that follow-up, the constant is one
+# release behind on purpose, so exactly one release of lag is allowed. Two or
+# more means the bump was forgotten. Being ahead is allowed too, which is the
+# state after the bump merges and before the next tag.
 
 require "json"
 require "net/http"
@@ -17,7 +20,7 @@ require "uri"
 
 ROOT = File.expand_path("..", __dir__)
 SOURCE = File.join(ROOT, "Sources/TurboFieldfareApp/MacPresentation/AboutPanelPresentation.swift")
-RELEASES_URL = "https://api.github.com/repos/drumih/turbo-fieldfare/releases/latest"
+RELEASES_URL = "https://api.github.com/repos/drumih/turbo-fieldfare/releases?per_page=100"
 
 def compiled_version
   source = File.read(SOURCE)
@@ -27,7 +30,9 @@ def compiled_version
   match
 end
 
-def published_version
+# Published release versions, newest first. Returns nil when GitHub cannot be
+# reached, which skips the comparison rather than failing an offline run.
+def published_versions
   uri = URI(RELEASES_URL)
   request = Net::HTTP::Get.new(uri)
   request["Accept"] = "application/vnd.github+json"
@@ -39,11 +44,18 @@ def published_version
     http.request(request)
   end
   unless response.is_a?(Net::HTTPSuccess)
-    warn "warning: could not read the latest release (#{response.code}); skipping the comparison"
+    warn "warning: could not read releases (#{response.code}); skipping the comparison"
     return nil
   end
 
-  JSON.parse(response.body)["tag_name"].to_s.delete_prefix("v")
+  releases = JSON.parse(response.body)
+  return [] unless releases.is_a?(Array)
+
+  releases
+    .reject { |release| release["draft"] }
+    .map { |release| release["tag_name"].to_s.delete_prefix("v") }
+    .reject(&:empty?)
+    .sort { |left, right| compare(right, left) }
 rescue StandardError => error
   warn "warning: could not reach GitHub (#{error.class}); skipping the comparison"
   nil
@@ -62,23 +74,33 @@ def compare(left, right)
 end
 
 compiled = compiled_version
-published = published_version
+published = published_versions
 if published.nil?
-  puts "app version #{compiled}; latest release unknown"
+  puts "app version #{compiled}; releases unknown"
+  exit 0
+end
+if published.empty?
+  puts "app version #{compiled}; no releases published yet"
   exit 0
 end
 
-case compare(compiled, published)
-when -1
+latest = published.first
+# One release of lag is the tag-then-bump window. The release before the newest
+# is therefore the oldest version the constant may still report.
+floor = published[1] || latest
+
+if compare(compiled, floor) < 0
   abort <<~MESSAGE
-    app version #{compiled} is behind the latest release #{published}
+    app version #{compiled} is more than one release behind (latest #{latest})
 
     Update fallbackShortVersion in
     Sources/TurboFieldfareApp/MacPresentation/AboutPanelPresentation.swift
     so a clone build reports the version it actually corresponds to.
   MESSAGE
-when 0
-  puts "app version #{compiled} matches the latest release"
-else
-  puts "app version #{compiled} is ahead of the latest release #{published}; unreleased build"
+end
+
+case compare(compiled, latest)
+when 1 then puts "app version #{compiled} is ahead of the latest release #{latest}; unreleased build"
+when 0 then puts "app version #{compiled} matches the latest release"
+else puts "app version #{compiled} is one release behind #{latest}; bump pending"
 end


### PR DESCRIPTION
The release flow tags main first and bumps `fallbackShortVersion` in a follow-up PR, so the constant is one release behind on purpose during that window. The current check fails on any lag, which would turn main and every open PR red the next time a tag is cut before the bump.

The check now compares against the release *before* the newest:

| Constant vs releases | Result |
| --- | --- |
| Ahead of latest | pass, "unreleased build" |
| Equal to latest | pass, "matches" |
| One release behind | pass, "bump pending" |
| Two or more behind | fail |

Verified against the live releases: 0.4.3 exit 0, 0.4.1 exit 0, 0.4 exit 1, 0.3 exit 1. Offline behavior is unchanged — the check still skips itself when GitHub is unreachable.

This was meant to ship with #127 but was pushed to that branch after it had already merged.