### PR TITLE
Add M2 Pro MacBook Pro benchmark report and bump the app version to 0.4.5

### DIFF
--- a/Sources/TurboFieldfareApp/MacPresentation/AboutPanelPresentation.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/AboutPanelPresentation.swift
@@ -17,7 +17,7 @@ public enum AboutPanelPresentation {
     // Most users build from a clone, where there is no Info.plist to read a
     // version from, so this constant is what they see. Scripts/check_app_version.rb
     // fails CI when it falls behind the newest published release.
-    public static let fallbackShortVersion = "0.4.3"
+    public static let fallbackShortVersion = "0.4.5"
 
     private static let licenseURL = URL(
         string: "https://github.com/drumih/turbo-fieldfare/blob/main/LICENSE")!

--- a/docs/COMMUNITY_BENCHMARKS.md
+++ b/docs/COMMUNITY_BENCHMARKS.md
@@ -159,6 +159,9 @@ all affect decode speed.
 | [Matt 'Smartis' W](https://github.com/0xSmartis) · [issue #69](https://github.com/drumih/turbo-fieldfare/issues/69) | M2 Pro Mac mini | 16 GB | Internal SSD | 61 / 511 | 15.713 tok/s | One submitted run |
 | [Matt 'Smartis' W](https://github.com/0xSmartis) · [issue #69](https://github.com/drumih/turbo-fieldfare/issues/69) | M2 Pro Mac mini | 16 GB | Internal SSD | 430 / 669 | 17.826 tok/s | One submitted run |
 | [Matt 'Smartis' W](https://github.com/0xSmartis) · [issue #69](https://github.com/drumih/turbo-fieldfare/issues/69) | M2 Pro Mac mini | 16 GB | Internal SSD | 3,015 / 604 | 15.755 tok/s | One submitted run |
+| [Eli Smith](https://github.com/eliliam) · [issue #139](https://github.com/drumih/turbo-fieldfare/issues/139) | M2 Pro MacBook Pro | 16 GB | Internal SSD | 61 / 511 | 11.749 tok/s | One submitted run |
+| [Eli Smith](https://github.com/eliliam) · [issue #139](https://github.com/drumih/turbo-fieldfare/issues/139) | M2 Pro MacBook Pro | 16 GB | Internal SSD | 430 / 669 | 10.428 tok/s | One submitted run |
+| [Eli Smith](https://github.com/eliliam) · [issue #139](https://github.com/drumih/turbo-fieldfare/issues/139) | M2 Pro MacBook Pro | 16 GB | Internal SSD | 3,015 / 604 | 9.384 tok/s | One submitted run |
 | [elroyonline](https://github.com/elroyonline) · [issue #59](https://github.com/drumih/turbo-fieldfare/issues/59) | M2 Max Mac Studio | 32 GB | External PCIe NVMe | 61 / 511 | 25.310 tok/s | One submitted run |
 | [elroyonline](https://github.com/elroyonline) · [issue #59](https://github.com/drumih/turbo-fieldfare/issues/59) | M2 Max Mac Studio | 32 GB | External PCIe NVMe | 430 / 669 | 25.172 tok/s | One submitted run |
 | [elroyonline](https://github.com/elroyonline) · [issue #59](https://github.com/drumih/turbo-fieldfare/issues/59) | M2 Max Mac Studio | 32 GB | External PCIe NVMe | 3,015 / 604 | 23.730 tok/s | One submitted run |


### PR DESCRIPTION
Adds the community benchmark submission from #139 and bumps the app version
constant ahead of the 0.4.5 tag.

- Records the M2 Pro MacBook Pro (16 GB, internal SSD) decode results from
  issue #139 in the community results table, placed with the other M2 Pro rows.
- Sets `fallbackShortVersion` to `0.4.5`.

The bump lands before the tag this time, so a clone built from `0.4.5` reports
`0.4.5` in the About panel. Release 0.4.4 was tagged before its bump merged,
which is what #140 reports.

Closes #139
Closes #140