### PR TITLE
Render inline and display LaTeX as math images

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -1,5 +1,5 @@
 {
-  "originHash" : "794fbf949f0e97118a7640964bafcb54454e69c994c870b072392cd249f5f136",
+  "originHash" : "1fa47cdbd14cded0f37606c33777f2be57b4aa14f3e9d97497ddaf10dfe37a0d",
   "pins" : [
     {
       "identity" : "eventsource",
@@ -89,6 +89,15 @@
       "state" : {
         "revision" : "2fa33e1f5e7131a7fc64c28e6d161dcec0d24820",
         "version" : "1.3.3"
+      }
+    },
+    {
+      "identity" : "swiftmath",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/mgriebling/SwiftMath.git",
+      "state" : {
+        "revision" : "fa8244ed032f4a1ade4cb0571bf87d2f1a9fd2d7",
+        "version" : "1.7.3"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -18,6 +18,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/huggingface/swift-transformers", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", exact: "2.101.3"),
+        .package(url: "https://github.com/mgriebling/SwiftMath.git", exact: "1.7.3"),
     ],
     targets: [
         .target(
@@ -67,7 +68,10 @@ let package = Package(
         ),
         .target(
             name: "TurboFieldfareMacPresentation",
-            dependencies: ["TurboFieldfareAppCore"],
+            dependencies: [
+                "TurboFieldfareAppCore",
+                .product(name: "SwiftMath", package: "SwiftMath"),
+            ],
             path: "Sources/TurboFieldfareApp/MacPresentation"
         ),
         .target(

--- a/Sources/TurboFieldfareApp/MacPresentation/ResponseMarkdownRenderer.swift
+++ b/Sources/TurboFieldfareApp/MacPresentation/ResponseMarkdownRenderer.swift
@@ -1,5 +1,6 @@
 import AppKit
 import Foundation
+import SwiftMath
 
 @MainActor
 public struct ResponseMarkdownRenderer {
@@ -35,6 +36,26 @@ public struct ResponseMarkdownRenderer {
         let kind: BlockKind
     }
 
+    private struct MathSpan {
+        let latex: String
+        let displayMode: Bool
+    }
+
+    private struct MathExtraction {
+        let maskedSource: String
+        let spans: [MathSpan]
+    }
+
+    private static let mathPlaceholder = "\u{FFFC}"
+
+    private static let displayMathPattern = try! NSRegularExpression(
+        pattern: #"\$\$([^\$]+?)\$\$"#,
+        options: [.dotMatchesLineSeparators])
+
+    private static let inlineMathPattern = try! NSRegularExpression(
+        pattern: #"(?<!\$)\$(?!\$)(?!\s)([^\$\n]+?)(?<!\s)\$(?!\$)"#,
+        options: [])
+
     public init() {}
 
     public func render(_ source: String) -> Result {
@@ -42,7 +63,8 @@ public struct ResponseMarkdownRenderer {
             return Result(attributedString: NSAttributedString(), usedFallback: false)
         }
         guard !requiresRawFallback(source) else { return fallback(source) }
-        let presentationSource = source.replacingOccurrences(
+        let mathExtraction = extractMathSpans(from: source)
+        let presentationSource = mathExtraction.maskedSource.replacingOccurrences(
             of: #"(?m)^([ \t]*\*\*[^*\n]+\*\*[ \t]*)\n(?=\S)"#,
             with: "$1\n\n",
             options: .regularExpression)
@@ -86,6 +108,9 @@ public struct ResponseMarkdownRenderer {
             }
 
             guard output.length > 0 else { return fallback(source) }
+            if !mathExtraction.spans.isEmpty {
+                substituteMathPlaceholders(in: output, spans: mathExtraction.spans)
+            }
             return Result(attributedString: output, usedFallback: false)
         } catch {
             return fallback(source)
@@ -305,6 +330,93 @@ public struct ResponseMarkdownRenderer {
             break
         }
         return style
+    }
+
+    private func extractMathSpans(from source: String) -> MathExtraction {
+        var spans: [MathSpan] = []
+        var working = source as NSString
+
+        func replaceMatches(
+            _ regex: NSRegularExpression,
+            displayMode: Bool,
+            accept: (String) -> Bool = { _ in true }
+        ) {
+            let matches = regex.matches(
+                in: working as String,
+                range: NSRange(location: 0, length: working.length))
+            guard !matches.isEmpty else { return }
+
+            var result = ""
+            var lastEnd = 0
+            for match in matches {
+                let contentRange = match.range(at: 1)
+                guard contentRange.location != NSNotFound else { continue }
+                let content = working.substring(with: contentRange)
+                guard accept(content) else { continue }
+
+                result += working.substring(with: NSRange(location: lastEnd, length: match.range.location - lastEnd))
+                result += Self.mathPlaceholder
+                spans.append(MathSpan(latex: content, displayMode: displayMode))
+                lastEnd = match.range.location + match.range.length
+            }
+            result += working.substring(from: lastEnd)
+            working = result as NSString
+        }
+
+        replaceMatches(Self.displayMathPattern, displayMode: true)
+        replaceMatches(Self.inlineMathPattern, displayMode: false, accept: looksLikeMath)
+
+        return MathExtraction(maskedSource: working as String, spans: spans)
+    }
+
+    private func looksLikeMath(_ content: String) -> Bool {
+        let mathIndicators = CharacterSet(charactersIn: #"\^_{}=<>+"#)
+        if content.rangeOfCharacter(from: mathIndicators) != nil { return true }
+        if content.contains(" ") { return false }
+        return content.rangeOfCharacter(from: .letters) != nil
+    }
+
+    private func substituteMathPlaceholders(
+        in output: NSMutableAttributedString,
+        spans: [MathSpan]
+    ) {
+        var searchStart = 0
+        for span in spans {
+            let searchRange = NSRange(location: searchStart, length: output.length - searchStart)
+            let found = (output.string as NSString).range(
+                of: Self.mathPlaceholder, options: [], range: searchRange)
+            guard found.location != NSNotFound else { break }
+
+            let replacement = renderMathAttachment(latex: span.latex, displayMode: span.displayMode)
+            output.replaceCharacters(in: found, with: replacement)
+            searchStart = found.location + replacement.length
+        }
+    }
+
+    private func renderMathAttachment(latex: String, displayMode: Bool) -> NSAttributedString {
+        let trimmed = latex.trimmingCharacters(in: .whitespacesAndNewlines)
+        let rawFallback = displayMode ? "$$\(trimmed)$$" : "$\(trimmed)$"
+        guard !trimmed.isEmpty else {
+            return NSAttributedString(string: rawFallback, attributes: baseAttributes())
+        }
+
+        var mathImage = MathImage(
+            latex: trimmed,
+            fontSize: NSFont.systemFontSize + (displayMode ? 3 : 0),
+            textColor: NSColor.labelColor,
+            labelMode: displayMode ? .display : .text,
+            textAlignment: .center)
+        let (error, image, layout) = mathImage.asImage()
+        guard error == nil, let image, let layout, image.size.width > 0, image.size.height > 0 else {
+            return NSAttributedString(
+                string: rawFallback,
+                attributes: attributes(inlineIntent: .code, link: nil, block: .paragraph))
+        }
+
+        let attachment = NSTextAttachment()
+        attachment.image = image
+        attachment.bounds = CGRect(x: 0, y: -layout.descent, width: image.size.width, height: image.size.height)
+        return NSAttributedString(attachment: attachment)
     }
 
     private func fallback(_ source: String) -> Result {

--- a/THIRD_PARTY_NOTICES.md
+++ b/THIRD_PARTY_NOTICES.md
@@ -43,6 +43,7 @@ The following table covers the complete graph reported by
 | [swift-crypto](https://github.com/apple/swift-crypto) | 4.5.0 | Apache-2.0; upstream NOTICE applies |
 | [swift-asn1](https://github.com/apple/swift-asn1) | 1.7.0 | Apache-2.0; upstream NOTICE applies |
 | [yyjson](https://github.com/ibireme/yyjson) | 0.12.0 | MIT |
+| [SwiftMath](https://github.com/mgriebling/SwiftMath) | 1.7.3 | MIT |
 
 No copyleft or custom non-commercial license was found in this resolved graph.
 The dependency license files remain authoritative. For binary distribution,

--- a/Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift
+++ b/Tests/TurboFieldfareApp/MacPresentation/ResponseMarkdownRendererTests.swift
@@ -83,13 +83,59 @@ import Testing
         }
     }
 
-    @Test func latexRemainsReadableText() {
+    @Test func inlineLatexRendersAsMathAttachment() {
         let source = "Cosine is $\\frac{u \\cdot v}{||u|| ||v||}$."
         let result = ResponseMarkdownRenderer().render(source)
 
         #expect(!result.usedFallback)
-        #expect(result.attributedString.string.contains("\\frac"))
-        #expect(result.attributedString.string.contains("\\cdot"))
+        #expect(!result.attributedString.string.contains("\\frac"))
+        #expect(!result.attributedString.string.contains("\\cdot"))
+
+        let attachmentRange = (result.attributedString.string as NSString)
+            .range(of: "\u{FFFC}")
+        #expect(attachmentRange.location != NSNotFound)
+        let attachment = result.attributedString.attribute(
+            .attachment, at: attachmentRange.location, effectiveRange: nil) as? NSTextAttachment
+        #expect(attachment?.image != nil)
+    }
+
+    @Test func displayLatexRendersAsMathAttachment() {
+        let source = "The integral is $$\\int_0^1 x^2\\,dx$$ over the unit interval."
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        #expect(!result.attributedString.string.contains("\\int"))
+
+        let attachmentRange = (result.attributedString.string as NSString)
+            .range(of: "\u{FFFC}")
+        #expect(attachmentRange.location != NSNotFound)
+        let attachment = result.attributedString.attribute(
+            .attachment, at: attachmentRange.location, effectiveRange: nil) as? NSTextAttachment
+        #expect(attachment?.image != nil)
+    }
+
+    @Test func currencyLikeDollarSignsAreNotTreatedAsMath() {
+        let renderer = ResponseMarkdownRenderer()
+        let samples = [
+            "Prices ranged from $5 to $10 this week.",
+            "It costs $5 dollars today.",
+        ]
+
+        for source in samples {
+            let result = renderer.render(source)
+            #expect(!result.usedFallback)
+            #expect(result.attributedString.string == source)
+            #expect(!result.attributedString.string.contains("\u{FFFC}"))
+        }
+    }
+
+    @Test func malformedLatexFallsBackToRawDelimitedText() {
+        let source = "Broken math: $\\frac{1}{$ end."
+        let result = ResponseMarkdownRenderer().render(source)
+
+        #expect(!result.usedFallback)
+        #expect(!result.attributedString.string.contains("\u{FFFC}"))
+        #expect(result.attributedString.string.contains("\\frac{1}{"))
     }
 
     @Test func boldOnlyModelHeadingStaysOnItsOwnLine() {


### PR DESCRIPTION
## Summary

ResponseMarkdownRenderer showed LaTeX as raw text because AppKit has no native math typesetting, so a response like a cosine similarity formula was fed unrendered into the NSTextView (#86).

Detect $...$ and $$...$$ spans before the existing Markdown pass, mask them with a placeholder so Foundation's Markdown parser does not choke on the dollar signs, then render each span with SwiftMath's MathImage into an NSTextAttachment sized and baseline-aligned from its reported ascent/descent. A heuristic skips spans that look like currency (no math indicators and no single-token content) instead of math, and a span that fails to parse as LaTeX falls back to its raw delimited source instead of disappearing, matching the file's existing raw-text fallback style.

SwiftMath (MIT) is scoped to the Mac presentation target only; the CLI, server, and decode service do not link it.

## Validation

- `swift build -c release` — clean build, `TurboFieldfareMac` links against SwiftMath.
- `Scripts/test.sh` — full suite passes (703 tests, 127 suites).
- `ruby Scripts/check_markdown_links.rb` — passes.
- Manually launched the app and confirmed math renders correctly once generation finishes.

## Memory and performance

Not applicable — no model, importer, streaming, or Metal changes.
Rendering is a small offscreen image draw per math span, only on the
Mac presentation path.

## Remaining limitations

- The currency-vs-math heuristic is intentionally conservative pattern
  matching, not a full LaTeX-aware parser; some edge cases will
  misclassify (e.g. plain numeric inline math like `$100$` won't render).
- Display math (`$$...$$`) renders inline within its paragraph rather
  than with dedicated centered block styling like code blocks get.
- No visual regression testing of the rendered images themselves
  (light vs dark mode, font scaling).

- [x] The change does not load a complete checkpoint, shard, or large
      model tensor into Swift heap memory.
- [x] Logs and artifacts contain no credentials, private paths, or model
      weights.
