### PR TITLE
Render server flag rejections from the lists the guards test

### DIFF
--- a/Sources/TurboFieldfareServer/Core/ServerArguments.swift
+++ b/Sources/TurboFieldfareServer/Core/ServerArguments.swift
@@ -29,11 +29,11 @@ public struct ServerArguments: Equatable, Sendable {
       --queue-limit <count>      Maximum queued requests (default 4).
       --prompt-cache-mode <off|single-prefix>
                                  Prompt KV reuse mode (default single-prefix).
-      --expert-cache-slots <n>   Expert-cache slots: 8, 16, 24, or 32 (default 16).
+      --expert-cache-slots <n>   Expert-cache slots: \(allowedValueList(RuntimeConfiguration.allowedExpertCacheSlots)) (default 16).
       --expert-cache-policy <s>  Expert-cache policy: lfu or lru (default lfu).
       --prefill on|off           Enable or disable chunked prompt prefill (default on).
                                  Chunked prefill requires 16 or more cache slots.
-      --prefill-chunk-tokens <n> Prefill chunk size: 32, 64, 128, or 256
+      --prefill-chunk-tokens <n> Prefill chunk size: \(allowedValueList(RuntimeConfiguration.allowedPrefillChunkTokens))
                                  (default 128). Each chunk re-reads the routed
                                  expert pool, so larger chunks read less.
       --rdadvise <s>             Read-advice policy: off, default, bounded, or adaptive
@@ -49,13 +49,14 @@ public struct ServerArguments: Equatable, Sendable {
         forceLogitsHead: Bool = true
     ) throws -> RuntimeConfiguration {
         guard RuntimeConfiguration.allowedExpertCacheSlots.contains(expertCacheSlots) else {
-            throw ServerArgumentError.invalid("--expert-cache-slots must be 8, 16, 24, or 32")
+            throw ServerArgumentError.notAllowed(
+                flag: "--expert-cache-slots",
+                allowed: RuntimeConfiguration.allowedExpertCacheSlots)
         }
         guard RuntimeConfiguration.allowedPrefillChunkTokens.contains(prefillChunkTokens) else {
-            throw ServerArgumentError.invalid(
-                "--prefill-chunk-tokens must be one of "
-                    + RuntimeConfiguration.allowedPrefillChunkTokens
-                        .map(String.init).joined(separator: ", "))
+            throw ServerArgumentError.notAllowed(
+                flag: "--prefill-chunk-tokens",
+                allowed: RuntimeConfiguration.allowedPrefillChunkTokens)
         }
         guard prefillPolicy == .off
                 || expertCacheSlots >= RuntimeConfiguration.minimumExpertCacheSlotsForChunkedPrefill
@@ -136,7 +137,9 @@ public struct ServerArguments: Equatable, Sendable {
             case "--expert-cache-slots":
                 guard let parsed = Int(value),
                       RuntimeConfiguration.allowedExpertCacheSlots.contains(parsed) else {
-                    throw ServerArgumentError.invalid("--expert-cache-slots must be 8, 16, 24, or 32")
+                    throw ServerArgumentError.notAllowed(
+                        flag: flag,
+                        allowed: RuntimeConfiguration.allowedExpertCacheSlots)
                 }
                 expertCacheSlots = parsed
             case "--expert-cache-policy":
@@ -153,7 +156,9 @@ public struct ServerArguments: Equatable, Sendable {
             case "--prefill-chunk-tokens":
                 guard let parsed = Int(value),
                       RuntimeConfiguration.allowedPrefillChunkTokens.contains(parsed) else {
-                    throw ServerArgumentError.invalid("--prefill-chunk-tokens must be 32, 64, or 128")
+                    throw ServerArgumentError.notAllowed(
+                        flag: flag,
+                        allowed: RuntimeConfiguration.allowedPrefillChunkTokens)
                 }
                 prefillChunkTokens = parsed
             case "--rdadvise":
@@ -183,6 +188,23 @@ public struct ServerArguments: Equatable, Sendable {
     }
 }
 
+extension ServerArguments {
+    /// The one rendering shared by the help text and every rejection, so neither
+    /// can name a value the guard does not accept: the hardcoded
+    /// "32, 64, or 128" outlived the widening of the allowed set and told users
+    /// 256 was illegal while the guard accepted it.
+    static func allowedValueList(_ values: [Int]) -> String {
+        let words = values.map(String.init)
+        switch words.count {
+        case 0: return ""
+        case 1: return words[0]
+        case 2: return "\(words[0]) or \(words[1])"
+        default:
+            return words.dropLast().joined(separator: ", ") + ", or " + words[words.count - 1]
+        }
+    }
+}
+
 public enum ServerArgumentError: Error, Equatable, CustomStringConvertible {
     case help
     case invalid(String)
@@ -192,5 +214,11 @@ public enum ServerArgumentError: Error, Equatable, CustomStringConvertible {
         case .help: "help"
         case .invalid(let message): message
         }
+    }
+}
+
+extension ServerArgumentError {
+    static func notAllowed(flag: String, allowed: [Int]) -> ServerArgumentError {
+        .invalid("\(flag) must be \(ServerArguments.allowedValueList(allowed))")
     }
 }

--- a/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
+++ b/Tests/TurboFieldfareServer/OpenAIValidationTests.swift
@@ -764,6 +764,122 @@ struct ServerArgumentTests {
             try ServerArguments.parse(["--model", "model.gturbo"] + flag)
         }
     }
+
+    /// The integers a message names, in order. Comparing these against the
+    /// array the guard tests catches a message that omits a legal value and one
+    /// that names an illegal extra, and cannot be fooled the way a
+    /// `contains("256")` substring check is by "2560".
+    private func integers(in text: String) -> [Int] {
+        text.split { !$0.isNumber }.compactMap { Int($0) }
+    }
+
+    @Test func allowedValueListRendersChoices() {
+        #expect(ServerArguments.allowedValueList([8]) == "8")
+        #expect(ServerArguments.allowedValueList([8, 16]) == "8 or 16")
+        #expect(ServerArguments.allowedValueList([8, 16, 24, 32]) == "8, 16, 24, or 32")
+        #expect(ServerArguments.allowedValueList([]) == "")
+    }
+
+    /// Public 0.5.0 through 0.7.1 printed "--prefill-chunk-tokens must be 32,
+    /// 64, or 128" from a hardcoded string while the guard beside it already
+    /// accepted 256, so the rejection named a legal value as illegal. The
+    /// assertion is on the integer set rather than on the sentence, because the
+    /// invariant is that the message and the guard read the same array.
+    @Test(arguments: [
+        (flag: "--expert-cache-slots",
+         allowed: RuntimeConfiguration.allowedExpertCacheSlots,
+         badValue: "12"),
+        (flag: "--expert-cache-slots",
+         allowed: RuntimeConfiguration.allowedExpertCacheSlots,
+         badValue: "many"),
+        (flag: "--prefill-chunk-tokens",
+         allowed: RuntimeConfiguration.allowedPrefillChunkTokens,
+         badValue: "512"),
+        (flag: "--prefill-chunk-tokens",
+         allowed: RuntimeConfiguration.allowedPrefillChunkTokens,
+         badValue: "many"),
+    ])
+    func parseRejectionNamesExactlyTheAllowedValues(
+        testCase: (flag: String, allowed: [Int], badValue: String)
+    ) {
+        do {
+            _ = try ServerArguments.parse([
+                "--model", "model.gturbo", testCase.flag, testCase.badValue,
+            ])
+            Issue.record("\(testCase.flag) \(testCase.badValue) parsed")
+        } catch let error as ServerArgumentError {
+            let named = integers(in: error.description)
+            #expect(error.description.hasPrefix(testCase.flag),
+                    "the rejection does not lead with \(testCase.flag): \(error)")
+            #expect(named == testCase.allowed,
+                    "\(testCase.flag) rejection names \(named), guard accepts \(testCase.allowed)")
+        } catch {
+            Issue.record("unexpected error for \(testCase.flag): \(error)")
+        }
+    }
+
+    @Test func resolveRejectionNamesExactlyTheAllowedValues() {
+        let cases: [(flag: String, arguments: ServerArguments, allowed: [Int])] = [
+            (flag: "--expert-cache-slots",
+             arguments: ServerArguments(model: "model.gturbo",
+                                        port: 8080,
+                                        modelID: "gemma-4-26b-a4b-it",
+                                        maxContext: 16_384,
+                                        queueLimit: 4,
+                                        promptCacheMode: .singlePrefix,
+                                        expertCacheSlots: 12,
+                                        expertCachePolicy: .lfu,
+                                        prefillPolicy: .off,
+                                        prefillChunkTokens: 128,
+                                        rdadvisePolicy: .off,
+                                        visionPack: nil,
+                                        visionResidency: .onDemand),
+             allowed: RuntimeConfiguration.allowedExpertCacheSlots),
+            (flag: "--prefill-chunk-tokens",
+             arguments: ServerArguments(model: "model.gturbo",
+                                        port: 8080,
+                                        modelID: "gemma-4-26b-a4b-it",
+                                        maxContext: 16_384,
+                                        queueLimit: 4,
+                                        promptCacheMode: .singlePrefix,
+                                        expertCacheSlots: 16,
+                                        expertCachePolicy: .lfu,
+                                        prefillPolicy: .off,
+                                        prefillChunkTokens: 512,
+                                        rdadvisePolicy: .off,
+                                        visionPack: nil,
+                                        visionResidency: .onDemand),
+             allowed: RuntimeConfiguration.allowedPrefillChunkTokens),
+        ]
+        for testCase in cases {
+            do {
+                _ = try testCase.arguments.resolvedRuntimeConfiguration()
+                Issue.record("\(testCase.flag) resolved an unsupported value")
+            } catch let error as ServerArgumentError {
+                let named = integers(in: error.description)
+                #expect(error.description.hasPrefix(testCase.flag),
+                        "the rejection does not lead with \(testCase.flag): \(error)")
+                #expect(named == testCase.allowed,
+                        "\(testCase.flag) rejection names \(named), guard accepts \(testCase.allowed)")
+            } catch {
+                Issue.record("unexpected error for \(testCase.flag): \(error)")
+            }
+        }
+    }
+
+    @Test func usageNamesExactlyTheAllowedValues() throws {
+        let lines = ServerArguments.usage.split(separator: "\n", omittingEmptySubsequences: false)
+        let slotsLine = try #require(lines.first { $0.contains("--expert-cache-slots") })
+        let namedSlots = integers(in: String(slotsLine))
+        let defaultSlots = try ServerArguments.parse(["--model", "model.gturbo"]).expertCacheSlots
+        #expect(namedSlots == RuntimeConfiguration.allowedExpertCacheSlots + [defaultSlots],
+                "the --expert-cache-slots help line names \(namedSlots)")
+        let chunkLine = try #require(lines.first { $0.contains("--prefill-chunk-tokens") })
+        let namedChunks = integers(in: String(chunkLine))
+        #expect(namedChunks == RuntimeConfiguration.allowedPrefillChunkTokens,
+                "the --prefill-chunk-tokens help line names \(namedChunks)")
+    }
+
     @Test func imageDataURLPreservesOrderedMultimodalParts() throws {
         let dataURL = "data:image/png;base64,iVBORw0KGgo="
         let data = Data(#"""


### PR DESCRIPTION
Fixes #164.

`--prefill-chunk-tokens` rejected an invalid value with `must be 32, 64, or 128` while accepting 256. PR 144 widened `allowedPrefillChunkTokens` and derived the resolver-path message, but the parse-path literal stayed behind and no test read the message, so 0.5.0 through 0.7.1 all shipped it. `--expert-cache-slots` restated its list the same way at two sites.

## What changes

- `ServerArguments.allowedValueList(_:)` renders the choice list once; `ServerArgumentError.notAllowed(flag:allowed:)` builds every `--expert-cache-slots` and `--prefill-chunk-tokens` rejection from the array the guard tests. Both `--help` lines interpolate the same renderer, so help and errors cannot disagree.
- Accepted values are unchanged. The only message text that changes is `--prefill-chunk-tokens`: the parse path gains 256, and the resolver path reads `must be 32, 64, 128, or 256` instead of `must be one of 32, 64, 128, 256`. `--expert-cache-slots` text and the rendered `--help` are byte-identical to before.

## Tests

Four new tests in `ServerArgumentTests`: the renderer, the parse-path rejection (parameterized over both flags with numeric and non-numeric bad values), the resolver-path rejection, and the help lines. Each compares the integer set in the text against the allowed array, so an omitted legal value and a named illegal one both fail.

- `swift test --filter ServerArgumentTests`: 14/14.
- With the original parse-path literal restored, exactly the two `--prefill-chunk-tokens` cases fail (`[32, 64, 128]` vs `[32, 64, 128, 256]`).
- `TurboFieldfareServer --model /nonexistent --prefill-chunk-tokens 512` now prints `error: --prefill-chunk-tokens must be 32, 64, 128, or 256`; `--prefill-chunk-tokens 256` passes argument parsing as before.
