### PR TITLE
Add build script for packaging TurboFieldfare app

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,13 +48,12 @@ decode.
 ```bash
 git clone https://github.com/drumih/turbo-fieldfare.git
 cd turbo-fieldfare
-swift build -c release
-.build/release/TurboFieldfareMac
+Scripts/build_app.sh --install
+open /Applications/TurboFieldfare.app
 ```
 
-On the first run, Swift Package Manager downloads and builds the Swift packages
-required by the tokenizer. The complete release build includes the foreground
-Mac app and its sibling decode-service executable.
+The script downloads and builds the Swift packages required by the tokenizer,
+then packages the foreground Mac app and its sibling decode-service executable.
 
 When the app opens, choose **Download** and let TurboFieldfare fetch and repack
 the pinned model (about 15 GB). Once it is ready, choose **Load Model**, type
@@ -138,13 +137,21 @@ what it costs on an 8 GB machine.
 Clone the repository, then run the app from its root:
 
 ```bash
-swift build -c release
-.build/release/TurboFieldfareMac
+Scripts/build_app.sh
+open .build/TurboFieldfare.app
 ```
 
-Build the complete package so the app and its sibling decode service are both
-available. When launched from this checkout, the app stores the model in
-`scratch/gemma4.gturbo`.
+The script packages `TurboFieldfare.app` with its icon, resources, command-line
+tools, and sibling decode service. To copy it to `/Applications` instead, pass
+`--install` and open the installed app:
+
+```bash
+Scripts/build_app.sh --install
+open /Applications/TurboFieldfare.app
+```
+
+When launched from this checkout, the app stores the model in
+`/Users/<user>/Library/Application Support/TurboFieldfare/gemma4.gturbo`.
 
 #### Install the model
 

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -34,7 +34,9 @@ mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
 
 cp "$BUILD_DIR/TurboFieldfareMac" "$MACOS_DIR/TurboFieldfareMac"
 cp "$BUILD_DIR/TurboFieldfareDecodeService" "$MACOS_DIR/TurboFieldfareDecodeService"
-
+cp "$BUILD_DIR/TurboFieldfareCLI" "$MACOS_DIR/TurboFieldfareDecodeService"
+cp "$BUILD_DIR/TurboFieldfareRepack" "$MACOS_DIR/TurboFieldfareDecodeService"
+cp "$BUILD_DIR/TurboFieldfareServer" "$MACOS_DIR/TurboFieldfareDecodeService"
 cp -R "$BUILD_DIR"/*.bundle "$RESOURCES_DIR/"
 
 for size in 16 32 128 256 512; do

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -9,7 +9,10 @@ MACOS_DIR="$APP_DIR/Contents/MacOS"
 RESOURCES_DIR="$APP_DIR/Contents/Resources"
 ICON_SOURCE="$ROOT_DIR/Sources/TurboFieldfareApp/Mac/Resources/turbofieldfare-app-icon.png"
 ICON_FILE="$RESOURCES_DIR/TurboFieldfare.icns"
-ICONSET_DIR="$(mktemp -d "${TMPDIR:-/tmp}/turbofieldfare-icon.XXXXXX.iconset")"
+
+ICONSET_TMP="$(mktemp -d "${TMPDIR:-/tmp}/turbofieldfare-icon.XXXXXX")"
+ICONSET_DIR="${ICONSET_TMP}.iconset"
+mv "$ICONSET_TMP" "$ICONSET_DIR"
 
 cleanup() {
     rm -rf "$ICONSET_DIR"
@@ -34,9 +37,9 @@ mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
 
 cp "$BUILD_DIR/TurboFieldfareMac" "$MACOS_DIR/TurboFieldfareMac"
 cp "$BUILD_DIR/TurboFieldfareDecodeService" "$MACOS_DIR/TurboFieldfareDecodeService"
-cp "$BUILD_DIR/TurboFieldfareCLI" "$MACOS_DIR/TurboFieldfareDecodeService"
-cp "$BUILD_DIR/TurboFieldfareRepack" "$MACOS_DIR/TurboFieldfareDecodeService"
-cp "$BUILD_DIR/TurboFieldfareServer" "$MACOS_DIR/TurboFieldfareDecodeService"
+cp "$BUILD_DIR/TurboFieldfareCLI" "$MACOS_DIR/TurboFieldfareCLI"
+cp "$BUILD_DIR/TurboFieldfareRepack" "$MACOS_DIR/TurboFieldfareRepack"
+cp "$BUILD_DIR/TurboFieldfareServer" "$MACOS_DIR/TurboFieldfareServer"
 cp -R "$BUILD_DIR"/*.bundle "$RESOURCES_DIR/"
 
 for size in 16 32 128 256 512; do

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -7,6 +7,14 @@ BUILD_DIR="$ROOT_DIR/.build/release"
 APP_DIR="$ROOT_DIR/.build/TurboFieldfare.app"
 MACOS_DIR="$APP_DIR/Contents/MacOS"
 RESOURCES_DIR="$APP_DIR/Contents/Resources"
+ICON_SOURCE="$ROOT_DIR/Sources/TurboFieldfareApp/Mac/Resources/turbofieldfare-app-icon.png"
+ICON_FILE="$RESOURCES_DIR/TurboFieldfare.icns"
+ICONSET_DIR="$(mktemp -d "${TMPDIR:-/tmp}/turbofieldfare-icon.XXXXXX.iconset")"
+
+cleanup() {
+    rm -rf "$ICONSET_DIR"
+}
+trap cleanup EXIT
 
 INSTALL=false
 
@@ -29,11 +37,20 @@ cp "$BUILD_DIR/TurboFieldfareDecodeService" "$MACOS_DIR/TurboFieldfareDecodeServ
 
 cp -R "$BUILD_DIR"/*.bundle "$RESOURCES_DIR/"
 
+for size in 16 32 128 256 512; do
+    double_size=$((size * 2))
+    sips -z "$size" "$size" "$ICON_SOURCE" --out "$ICONSET_DIR/icon_${size}x${size}.png" >/dev/null
+    sips -z "$double_size" "$double_size" "$ICON_SOURCE" \
+        --out "$ICONSET_DIR/icon_${size}x${size}@2x.png" >/dev/null
+done
+iconutil -c icns "$ICONSET_DIR" -o "$ICON_FILE"
+
 plutil -create xml1 "$APP_DIR/Contents/Info.plist"
 plutil -insert CFBundleDisplayName -string TurboFieldfare "$APP_DIR/Contents/Info.plist"
 plutil -insert CFBundleName -string TurboFieldfare "$APP_DIR/Contents/Info.plist"
 plutil -insert CFBundleIdentifier -string com.turbofieldfare.app "$APP_DIR/Contents/Info.plist"
 plutil -insert CFBundleExecutable -string TurboFieldfareMac "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundleIconFile -string TurboFieldfare.icns "$APP_DIR/Contents/Info.plist"
 plutil -insert CFBundlePackageType -string APPL "$APP_DIR/Contents/Info.plist"
 plutil -insert CFBundleSignature -string '????' "$APP_DIR/Contents/Info.plist"
 plutil -insert CFBundleShortVersionString -string 0.7.2 "$APP_DIR/Contents/Info.plist"

--- a/Scripts/build_app.sh
+++ b/Scripts/build_app.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+BUILD_DIR="$ROOT_DIR/.build/release"
+APP_DIR="$ROOT_DIR/.build/TurboFieldfare.app"
+MACOS_DIR="$APP_DIR/Contents/MacOS"
+RESOURCES_DIR="$APP_DIR/Contents/Resources"
+
+INSTALL=false
+
+if [[ "${1:-}" == "--install" ]]; then
+    INSTALL=true
+elif [[ $# -gt 0 ]]; then
+    printf 'Usage: %s [--install]\n' "$0"
+    exit 1
+fi
+
+cd "$ROOT_DIR"
+
+swift build -c release
+
+rm -rf "$APP_DIR"
+mkdir -p "$MACOS_DIR" "$RESOURCES_DIR"
+
+cp "$BUILD_DIR/TurboFieldfareMac" "$MACOS_DIR/TurboFieldfareMac"
+cp "$BUILD_DIR/TurboFieldfareDecodeService" "$MACOS_DIR/TurboFieldfareDecodeService"
+
+cp -R "$BUILD_DIR"/*.bundle "$RESOURCES_DIR/"
+
+plutil -create xml1 "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundleDisplayName -string TurboFieldfare "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundleName -string TurboFieldfare "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundleIdentifier -string com.turbofieldfare.app "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundleExecutable -string TurboFieldfareMac "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundlePackageType -string APPL "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundleSignature -string '????' "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundleShortVersionString -string 0.7.2 "$APP_DIR/Contents/Info.plist"
+plutil -insert CFBundleVersion -string 0.7.2 "$APP_DIR/Contents/Info.plist"
+plutil -insert LSMinimumSystemVersion -string 26.0 "$APP_DIR/Contents/Info.plist"
+plutil -insert NSHighResolutionCapable -bool true "$APP_DIR/Contents/Info.plist"
+plutil -insert NSPrincipalClass -string NSApplication "$APP_DIR/Contents/Info.plist"
+codesign --force --deep --sign - "$APP_DIR"
+codesign --verify --deep --strict --verbose=2 "$APP_DIR"
+printf 'Packaged %s\n' "$APP_DIR"
+
+if $INSTALL; then
+    INSTALL_DIR="/Applications"
+    INSTALL_APP="$INSTALL_DIR/TurboFieldfare.app"
+    rm -rf "$INSTALL_APP"
+    ditto "$APP_DIR" "$INSTALL_APP"
+    printf 'Installed %s\n' "$INSTALL_APP"
+fi


### PR DESCRIPTION
## Summary

Creation of a build script that builds the app, and bundles it into a valid .app bundle. If passed the `--install` flag, it will install the app into /Applications
Closes #104 

## Validation

```
git clone https://github.com/nmcc1212/turbo-fieldfare.git
git checkout build-script
Scripts/build_app.sh
```
After script completes, in `.build` folder there is a `TurboFieldfare.app` that can be double-clicked to open
If re-running the script with the `--install` flag `Scripts/build_app.sh --install` the app will be installed into /Applications

## Memory and performance

Not applicable

## Remaining limitations

- [ ] No CI/CD pipeline to automatically build and publish the app, this wasn't done as I'm not sure on the maintainers stance on this.
- [ ] The version in the Info.plist file is hardcoded in the script, meaning an extra step is required when publishing a new version. (L56-57)